### PR TITLE
Add info on #138 to docs

### DIFF
--- a/vignettes/Rcpp-attributes.Rnw
+++ b/vignettes/Rcpp-attributes.Rnw
@@ -286,6 +286,9 @@ requirements to be correctly handled:
    Rcpp types may however appear without a namespace qualifier (i.e.
    \texttt{DataFrame} is okay as a type name but \texttt{std::string} must be
    specified fully).
+ \item
+    Do not have inline comments in the argument list. Such comments are not parsed 
+    correctly by \pkg{Rcpp}'s built-in \proglang{C++} parser.
 \end{itemize}
 
 \subsection{Random Number Generation}


### PR DESCRIPTION
See [#138](https://github.com/RcppCore/Rcpp/issues/138): inline comments in argument list do not get parsed correctly by `compileAttributes()`.
