### PR TITLE
enhance the output of sourceCpp()

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -134,11 +134,11 @@ sourceCpp <- function(file = "",
         if(!showOutput) {
             # examine status
             if (!is.null(status)) {
-                cat(output, "\n", sep = "\n")
+                cat(output, sep = "\n")
                 succeeded <- FALSE
                 stop("Error ", status, " occurred building shared library.")
             } else if (!file.exists(context$dynlibFilename)) {
-                cat(output, "\n", sep = "\n")
+                cat(output, sep = "\n")
                 succeeded <- FALSE
                 stop("Error occurred building shared library.")
             } else {
@@ -146,7 +146,7 @@ sourceCpp <- function(file = "",
             }
         } else {
             # always print output if showOutput = TRUE
-            cat(output, "\n", sep = "\n")
+            cat(output, sep = "\n")
             succeeded <- TRUE
 
             # check for failure in building


### PR DESCRIPTION
There are some drawbacks of the current version of `sourceCpp()`:
1. On windows, the output will be squeezed into one line which looks a bit messy. This is because in line 131 and line 135 of R/Attributes.R, `result` is a character **vector** but `cat(result, "\n")` will concatenate each string with the default space separator. We should use `cat(result, sep = "\n")` instead.
2. Some of the output by `sourceCpp()` is not captured by R, but instead written to `stderr`. This means that if we are calling `sourceCpp()`(or `cppFunction()`) inside a `knitr` document, we will lose part of the error messages.

This patch uses `system2()` instead of `system` to capture the output of `R CMD SHLIB`, which will record all the warning and error messages.
