### PR TITLE
Fix output strings

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -128,11 +128,11 @@ sourceCpp <- function(file = "",
             # examine status
             status <- attr(result, "status")
             if (!is.null(status)) {
-                cat(result, "\n")
+                cat(result, sep = "\n")
                 succeeded <- FALSE
                 stop("Error ", status, " occurred building shared library.")
             } else if (!file.exists(context$dynlibFilename)) {
-                cat(result, "\n")
+                cat(result, sep = "\n")
                 succeeded <- FALSE
                 stop("Error occurred building shared library.")
             } else {


### PR DESCRIPTION
On Windows, the output of `sourceCpp()` will be squeezed into one line which looks a bit messy. This is because in line 131 and line 135 of R/Attributes.R, `result` is a character vector but `cat(result, "\n")` will concatenate each string with the default space separator. We should use `cat(result, sep = "\n")` instead.
