### PR TITLE
ifelse was broken

### DIFF
--- a/inst/include/Rcpp/sugar/functions/ifelse.h
+++ b/inst/include/Rcpp/sugar/functions/ifelse.h
@@ -2,7 +2,7 @@
 //
 // ifelse.h: Rcpp R/C++ interface class library -- ifelse
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2014 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -54,7 +54,7 @@ public:
 
 	inline STORAGE operator[]( int i ) const {
 		int x = cond[i] ;
-		if( Rcpp::traits::is_na<LGLSXP>(x) ) return x ;
+		if( Rcpp::traits::is_na<LGLSXP>(x) ) return Rcpp::traits::get_na<RTYPE>() ;
 		if( x ) return lhs[i] ;
 		return rhs[i] ;
 	}


### PR DESCRIPTION
`ifelse` was returning an `int`(`NA_LOGICAL`)  instead of the appropriate value for `NA` for the target type. For example it was failing to compile: 

```
CharacterVector ifelse_( LogicalVector test, CharacterVector yes, CharacterVector no){
  return ifelse( test, yes, no ) ;
}
```

But more dangerously, it was not failing to compile for NumericVector but quite likely did not do what you would expect, i.e. if the test was `NA` you'd get the value of `NA_INTEGER` instead. 
