### PR TITLE
Minor improvements to Timer to make slightly more useful with multi threads

### DIFF
--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -121,6 +121,10 @@ namespace Rcpp{
             out.attr("names") = names;
             return out;
         }
+        
+        static std::vector<Timer> get_timers(int n){
+            return std::vector<Timer>( n, Timer() ) ;
+        }
 
     private:
         typedef std::pair<std::string,nanotime_t> Step;


### PR DESCRIPTION
Send back the absolute time to R is difficult because it is a 64 bit integer type, so instead of what I hinted in #156, I used the same thing as in Rcpp11, which is make available a static method that creates a set of Timer that all start at the same origin. 

So this is just an addition, it does not change anything to the rest of the code. 

Also removed useless get_start and get_second functions that are not used by anything.
