### PR TITLE
more on Timer.

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,14 @@
       \item The deprecation of \code{RCPP_FUNCTION_*} which was announced with
       release 0.10.5 last year is proceeding as planned, and the file
       \code{macros/preprocessor_generated.h} has been removed.
+      \item \code{Timer} no longer records time between steps, but times from 
+      the origin. It also gains a \code{get_timers(int)} methods that 
+      creates a vector of \code{Timer} that have the same origin. This is modelled
+      on the \code{Rcpp11} implementation and is more useful for situations where
+      we use timers in several threads. \code{Timer} also gains a constructor 
+      taking a \code{nanotime_t} to use as its origin, and a \code{origin} method. 
+      This can be useful for situations where the number of threads is not known
+      in advance but we still want to track what goes on in each thread. 
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -103,11 +103,10 @@ namespace Rcpp{
     class Timer {
     public:
         Timer() : data(), start_time( get_nanotime() ){}
+        Timer(nanotime_t start_time_) : data(), start_time(start_time_){}
 
         void step( const std::string& name){
-            nanotime_t now = get_nanotime();
-            data.push_back(std::make_pair(name, now - start_time));
-            start_time = get_nanotime();
+            data.push_back(std::make_pair(name, now()));
         }
 
         operator SEXP() const {
@@ -116,7 +115,7 @@ namespace Rcpp{
             CharacterVector names(n);
             for (size_t i=0; i<n; i++) {
                 names[i] = data[i].first;
-                out[i] = data[i].second;
+                out[i] = data[i].second - start_time ;
             }
             out.attr("names") = names;
             return out;
@@ -125,13 +124,21 @@ namespace Rcpp{
         static std::vector<Timer> get_timers(int n){
             return std::vector<Timer>( n, Timer() ) ;
         }
+        
+        inline nanotime_t now() const {
+            return get_nanotime() ;
+        }
+        
+        inline nanotime_t origin() const {
+            return start_time ;    
+        }
 
     private:
         typedef std::pair<std::string,nanotime_t> Step;
         typedef std::vector<Step> Steps;
 
         Steps data;
-        nanotime_t start_time;
+        const nanotime_t start_time;
     };
 
 }


### PR DESCRIPTION
Having looked at it, I don't think yesterday's change are useful enough as is. These changes make it so the data collected by a Timer are absolute time points, and the `operator SEXP()` transform these steps into time since the origin.

In conjunction with `Timer::get_timers` which makes several `Timer` with the same origin, the new ctor `Timer(nanotime_t)` and the method `Timer::origin()` it makes something that is much more useful for tracking what goes on with multiple threads. 

Note that if we want the data as before, we can use `diff` on the R side results. This will be more accurate anyway because Timer does less so is less of an influence. 
