### PR TITLE
fix return value of range eraser in Vector

### DIFF
--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -894,13 +894,13 @@ private:
         iterator target_it = target.begin() ;
 
         SEXP names = RCPP_GET_NAMES(Storage::get__()) ;
-        iterator result ;
+        int result = 0;
         if( Rf_isNull(names) ){
             int i=0;
             for( ; it < first; ++it, ++target_it, i++ ){
                 *target_it = *it ;
             }
-            result = begin() + i + 1 ;
+            result = i;
             for( it = last ; it < this_end; ++it, ++target_it ){
                 *target_it = *it ;
             }
@@ -911,7 +911,7 @@ private:
                 *target_it = *it ;
                 SET_STRING_ELT( newnames, i, STRING_ELT(names, i ) );
             }
-            result = begin() + i + 1 ;
+            result = i;
             for( it = last ; it < this_end; ++it, ++target_it, i++ ){
                 *target_it = *it ;
                 SET_STRING_ELT( newnames, i, STRING_ELT(names, i + nremoved ) );
@@ -920,7 +920,7 @@ private:
         }
         Storage::set__( target.get__() ) ;
 
-        return result ;
+        return begin() + result;
 
     }
 


### PR DESCRIPTION
Hi All,
I'm studying Rcpp's source code and again I found something unusual in the Vector class.
In my understanding Vector is intended to mimic the behaviour of `std::vector`, including the member function `erase(first, last)`.
In `std::vector`, `erase(first, last)` will return the pointer that points to the element after the last removed element. For example, if `std::vector<int> x` contains 1, 2, 3, 4, 5, 6, then

```
std::vector<int>::iterator iter = x.begin();
iter = x.erase(iter + 1, iter + 3);
```

will remove 2 and 3 and now `iter` points to 4 in the new vector.
However in `Rcpp::Vector`, the range eraser `iterator erase( iterator first, iterator last)` is inconsistent with this. We can show this by looking at the example below:

```
cppFunction('

SEXP eraser()
{
    NumericVector x = NumericVector::create(1, 2, 3, 4, 5, 6);
    double *iter = x.begin();
    iter = x.erase(iter + 1, iter + 3); // removes 2 and 3
    return wrap(*iter); // should give 4 according to std::vector
}

')
eraser()  # this returns 3
```

The result is 3 instead of 4.
In fact, what `Rcpp::Vector::erase(first, last)` does is creating a new vector and copying the data in original vector to the new one. Also, the return value is actually the pointer to the last removed element **in the original vector**. This can be dangerous since the original vector is no longer protected by Rcpp and can be destroyed by the garbage collector later. Therefore the pointer to the original vector isn't helpful, and behaves inconsistently with `std::vector`.
The problem is due to line 903 and 914 of `<Rcpp/vector/Vector.h>`, in which the call `begin()` refers to the beginning of the original vector (since the new vector has not been set until line 921), not the new one.
I'm not sure whether this would be the correct behaviour of `eraser()`, so this pull request is left for your judgement.
