### PR TITLE
add dryRun parameter to sourceCpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-09-23  JJ Allaire <jj@rstudio.org>
+
+        * R/Attributes.R: Add dryRun parameter to sourceCpp.
+
 2014-09-21  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/unitTests/runit.environments.R: Use 'checkIdentical' as it's a

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -23,7 +23,8 @@ sourceCpp <- function(file = "",
                       embeddedR = TRUE,
                       rebuild = FALSE,
                       showOutput = verbose,
-                      verbose = getOption("verbose")) {
+                      verbose = getOption("verbose"),
+                      dryRun = FALSE) {
 
     # resolve code into a file if necessary. also track the working
     # directory to source the R embedded code chunk within
@@ -112,6 +113,7 @@ sourceCpp <- function(file = "",
                      "CMD SHLIB ",
                      "-o ", shQuote(context$dynlibFilename), " ",
                      ifelse(rebuild, "--preclean ", ""),
+                     ifelse(dryRun, "--dry-run ", ""),
                      shQuote(context$cppSourceFilename), sep="")
         if (showOutput)
             cat(cmd, "\n")
@@ -151,6 +153,10 @@ sourceCpp <- function(file = "",
             cat("\nNo rebuild required (use rebuild = TRUE to ",
                 "force a rebuild)\n\n", sep="")
     }
+
+    # return immediately if this was a dry run
+    if (dryRun)
+        return(invisible(NULL))
 
     # load the module if we have exported symbols
     if (length(context$exportedFunctions) > 0 || length(context$modules) > 0) {

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -32,6 +32,7 @@
     \itemize{
       \item Include LinkingTo in DESCRIPTION fields scanned to confirm that
       C++ dependencies are referenced by package.
+      \item Add \code{dryRun} parameter to \code{sourceCpp}.
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/man/sourceCpp.Rd
+++ b/man/sourceCpp.Rd
@@ -8,9 +8,10 @@ Source C++ Code from a File or String
 and RCPP_MODULE declarations. A shared library is then built and its exported functions and Rcpp modules are made available in the specified environment.
 }
 \usage{
-sourceCpp(file = "", code = NULL, env = globalenv(), 
-          embeddedR = TRUE, rebuild = FALSE, 
-          showOutput = verbose, verbose = getOption("verbose"))
+sourceCpp(file = "", code = NULL, env = globalenv(),
+          embeddedR = TRUE, rebuild = FALSE,
+          showOutput = verbose, verbose = getOption("verbose"),
+          dryRun = FALSE)
 }
 \arguments{
   \item{file}{
@@ -33,6 +34,10 @@ sourceCpp(file = "", code = NULL, env = globalenv(),
 }
   \item{verbose}{
     \code{TRUE} to print detailed information about generated code to the console.
+}
+  \item{dryRun}{
+    \code{TRUE} to do a dry run (showing commands that would be used rather than
+actually executing the commands).
 }
 }
 \details{


### PR DESCRIPTION
The output of the dry run can be fed to libclang for accurate parsing of translation unit (reflecting includes, preprocessor directives, etc.)
