### PR TITLE
alternate LogicalVector construction from bool

### DIFF
--- a/inst/include/Rcpp/traits/is_bool.h
+++ b/inst/include/Rcpp/traits/is_bool.h
@@ -1,0 +1,24 @@
+#ifndef Rcpp__traits__is_bool__h
+#define Rcpp__traits__is_bool__h
+
+namespace Rcpp{ namespace traits {
+
+template<typename>
+struct is_bool
+    : public false_type { };
+
+template<>
+struct is_bool<bool>
+    : public true_type { };
+
+template<>
+struct is_bool<const bool>
+    : public true_type { };
+
+template<>
+struct is_bool<volatile bool>
+    : public true_type { };
+
+}}
+
+#endif

--- a/inst/include/Rcpp/traits/traits.h
+++ b/inst/include/Rcpp/traits/traits.h
@@ -60,6 +60,7 @@ struct int2type { enum { value = I }; };
 #include <Rcpp/traits/is_finite.h>
 #include <Rcpp/traits/is_infinite.h>
 #include <Rcpp/traits/is_nan.h>
+#include <Rcpp/traits/is_bool.h>
 #include <Rcpp/traits/if_.h>
 #include <Rcpp/traits/get_na.h>
 #include <Rcpp/traits/is_trivial.h>

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -120,8 +120,11 @@ public:
     }
 
     // Enable construction from bool for LogicalVectors
-    template <int T = RTYPE>
-    Vector(bool value, typename Rcpp::traits::enable_if<T == LGLSXP, void>::type* = 0) {
+    // SFINAE only work for template. Add template class T and then restict T to
+    // bool.
+    template <typename T>
+    Vector(T value,
+           typename Rcpp::traits::enable_if<traits::is_bool<T>::value && RTYPE == LGLSXP, void>::type* = 0) {
         Storage::set__(Rf_allocVector(RTYPE, 1));
         fill(value);
     }


### PR DESCRIPTION
without using default template arguments, which is a C++11 feature.

The handcrafted traits::is_bool may not cover all cases, but it works well for
the constructor.
