### PR TITLE
add NAComparator for Rcomplex type

### DIFF
--- a/inst/include/Rcpp/internal/NAComparator.h
+++ b/inst/include/Rcpp/internal/NAComparator.h
@@ -73,6 +73,31 @@ struct NAComparator<double> {
 };
 
 template <>
+struct NAComparator<Rcomplex> {
+    inline bool operator()(Rcomplex left, Rcomplex right) const {
+        // sort() in R says that complex numbers are first sorted by
+        // the real parts, and then the imaginary parts.
+
+        // When only one of the two numbers contains NA or NaN, move
+        // it to the right hand side.
+
+        // When both left and right contain NA or NaN, return true.
+
+        bool leftNaN = (left.r != left.r) || (left.i != left.i);
+        bool rightNaN = (right.r != right.r) || (right.i != right.i);
+
+        if (!(leftNaN || rightNaN))  // if both are nice numbers
+        {
+            if (left.r == right.r)   // if real parts are the same
+                return left.i < right.i;
+            else
+                return left.r < right.r;
+        } else
+            return leftNaN <= rightNaN;
+    }
+};
+
+template <>
 struct NAComparator<SEXP> {
     inline bool operator()(SEXP left, SEXP right) const {
         return StrCmp(left, right) < 0;


### PR DESCRIPTION
Hi All,
It seems that in the current version of Rcpp, member function `Vector::sort()` of `Vector` does not support complex vectors. This patch adds a comparator for the `Rcomplex` type, and it should work now. An example is given below:

```
> library(Rcpp)
> cppFunction('
+ 
+ RObject sort_complex(ComplexVector x)
+ {
+     ComplexVector xx = clone(x);
+     xx.sort();
+     return xx;
+ }
+ 
+ ')
> 
> r = i = c(-1, 0, 1, NA, NaN)
> comb = expand.grid(r = r, i = i)
> s = complex(real = comb$r, imaginary = comb$i)
> sort(s, na.last = TRUE)
 [1]  -1-  1i  -1+  0i  -1+  1i   0-  1i   0+  0i   0+  1i   1-  1i   1+  0i
 [9]   1+  1i       NA NaN-  1i       NA NaN+  0i       NA NaN+  1i       NA
[17]       NA       NA       NA       NA  -1+NaNi   0+NaNi   1+NaNi       NA
[25] NaN+NaNi
> sort_complex(s)
 [1]  -1-  1i  -1+  0i  -1+  1i   0-  1i   0+  0i   0+  1i   1-  1i   1+  0i
 [9]   1+  1i NaN+NaNi       NA   1+NaNi   0+NaNi  -1+NaNi       NA       NA
[17]       NA       NA       NA NaN+  1i       NA       NA NaN-  1i       NA
[25] NaN+  0i
```

There are a few inconsistencies between the two versions of sorting, possibly due to different treatment of ties (involving missing values and NaN) in R and `std::sort()`.
