### PR TITLE
Changes required to build for visual studio

### DIFF
--- a/inst/include/Rcpp/api/meat/proxy.h
+++ b/inst/include/Rcpp/api/meat/proxy.h
@@ -175,7 +175,7 @@ DottedPairProxyPolicy<CLASS>::const_DottedPairProxy::operator T() const {
 // FieldProxy
 template <typename CLASS>
 typename FieldProxyPolicy<CLASS>::FieldProxy&
-FieldProxyPolicy<CLASS>::FieldProxy::operator=(const FieldProxyPolicy<CLASS>::FieldProxy& rhs) {
+FieldProxyPolicy<CLASS>::FieldProxy::operator=(const typename FieldProxyPolicy<CLASS>::FieldProxy& rhs) {
     if (this != &rhs) set(rhs.get());
     return *this;
 }

--- a/inst/include/Rcpp/internal/NAComparator.h
+++ b/inst/include/Rcpp/internal/NAComparator.h
@@ -59,7 +59,7 @@ struct NAComparator<double> {
 
         // this branch inspired by data.table: see
         // https://github.com/arunsrinivasan/datatable/commit/1a3e476d3f746e18261662f484d2afa84ac7a146#commitcomment-4885242
-        if (Rcpp_IsNaN(right) and Rcpp_IsNA(left))
+        if (Rcpp_IsNaN(right) && Rcpp_IsNA(left))
             return true;
 
         if (leftNaN != rightNaN) {

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -38,6 +38,9 @@
 #ifdef __INTEL_COMPILER
 #define GOOD_COMPILER_FOR_RCPP
 #endif
+#ifdef _MSC_VER
+#define GOOD_COMPILER_FOR_RCPP
+#endif
 
 #ifndef GOOD_COMPILER_FOR_RCPP
 # error "This compiler is not supported"
@@ -69,6 +72,9 @@
             #define HAS_STATIC_ASSERT
         #endif
     #endif
+#elif defined(_MSC_VER)
+	#define HAS_CXX0X_FLAG
+	#define HAS_STATIC_ASSERT
 #elif defined(__clang__)
     #if __cplusplus >= 201103L
         #define RCPP_USING_CXX11
@@ -101,6 +107,9 @@
             #define HAS_CXX0X_INITIALIZER_LIST
         #endif
     #endif
+#elif defined(_MSC_VER)
+	#define HAS_CXX0X_UNORDERED_MAP
+    #define HAS_CXX0X_UNORDERED_SET
 #elif defined(__clang__)
     #if __cplusplus >= 201103L
         #if __has_include(<unordered_map>)

--- a/inst/include/Rcpp/sugar/block/Vectorized_Math.h
+++ b/inst/include/Rcpp/sugar/block/Vectorized_Math.h
@@ -80,21 +80,36 @@ private:
 } // sugar
 } // Rcpp
 
+#ifdef _MSC_VER
 #define VECTORIZED_MATH_1(__NAME__,__SYMBOL__)                               \
-namespace Rcpp{                                                              \
-        template <bool NA, typename T>                                           \
-        inline sugar::Vectorized<__SYMBOL__,NA,T>                                \
-        __NAME__( const VectorBase<REALSXP,NA,T>& t ){                           \
-                return sugar::Vectorized<__SYMBOL__,NA,T>( t ) ;                     \
-        }                                                                        \
-        inline sugar::Vectorized<__SYMBOL__,true,NumericVector>                  \
-        __NAME__( SEXP x){ return __NAME__( NumericVector( x ) ) ; }             \
-        template <bool NA, typename T>                                           \
-        inline sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>                         \
-        __NAME__( const VectorBase<INTSXP,NA,T>& t      ){                           \
-                return sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>( t ) ;              \
-        }                                                                        \
-}
-
+	namespace Rcpp{                                                              \
+			template <bool NA, typename T>                                           \
+			inline sugar::Vectorized<__SYMBOL__,NA,T>                                \
+			__NAME__( const VectorBase<REALSXP,NA,T>& t ){                           \
+					return sugar::Vectorized<__SYMBOL__,NA,T>( t ) ;                     \
+			}                                                                        \
+			template <bool NA, typename T>                                           \
+			inline sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>                         \
+			__NAME__( const VectorBase<INTSXP,NA,T>& t      ){                           \
+					return sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>( t ) ;              \
+			}                                                                        \
+	}
+#else
+#define VECTORIZED_MATH_1(__NAME__,__SYMBOL__)                               \
+	namespace Rcpp{                                                              \
+			template <bool NA, typename T>                                           \
+			inline sugar::Vectorized<__SYMBOL__,NA,T>                                \
+			__NAME__( const VectorBase<REALSXP,NA,T>& t ){                           \
+					return sugar::Vectorized<__SYMBOL__,NA,T>( t ) ;                     \
+			}                                                                        \
+			inline sugar::Vectorized<__SYMBOL__,true,NumericVector>                  \
+			__NAME__( SEXP x){ return __NAME__( NumericVector( x ) ) ; }             \
+			template <bool NA, typename T>                                           \
+			inline sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>                         \
+			__NAME__( const VectorBase<INTSXP,NA,T>& t      ){                           \
+					return sugar::Vectorized_INTSXP<__SYMBOL__,NA,T>( t ) ;              \
+			}                                                                        \
+	}
+#endif
 
 #endif

--- a/inst/include/Rcpp/sugar/functions/math.h
+++ b/inst/include/Rcpp/sugar/functions/math.h
@@ -21,6 +21,9 @@
 
 #ifndef RCPP_SUGAR_MATH_H
 #define RCPP_SUGAR_MATH_H
+#ifdef _MSC_VER
+#include "extra_math_functions.h"
+#endif
 
 VECTORIZED_MATH_1(exp,::exp)
 VECTORIZED_MATH_1(acos,::acos)

--- a/inst/include/extra_math_functions.h
+++ b/inst/include/extra_math_functions.h
@@ -1,0 +1,10 @@
+#ifndef EXTRA_MATH_FUNCTIONS_HEADER_GUARD
+#define EXTRA_MATH_FUNCTIONS_HEADER_GUARD
+#ifdef _MSC_VER
+	float expm1(float arg);
+	double expm1(double arg);
+
+	float log1p(float arg);
+	double log1p(double arg);
+#endif
+#endif

--- a/inst/include/inttypes.h
+++ b/inst/include/inttypes.h
@@ -1,0 +1,303 @@
+// ISO C9x  compliant inttypes.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124 
+// 
+//  Copyright (c) 2006 Alexander Chemeris
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+// 
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+// 
+//   3. The name of the author may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef _MSC_VER // [
+#ifndef _MSC_INTTYPES_H_ // [
+#define _MSC_INTTYPES_H_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#include "stdint.h"
+
+// 7.8 Format conversion of integer types
+
+typedef struct {
+   intmax_t quot;
+   intmax_t rem;
+} imaxdiv_t;
+
+// 7.8.1 Macros for format specifiers
+
+#if !defined(__cplusplus) || defined(__STDC_FORMAT_MACROS) // [   See footnote 185 at page 198
+
+// The fprintf macros for signed integers are:
+#define PRId8       "d"
+#define PRIi8       "i"
+#define PRIdLEAST8  "d"
+#define PRIiLEAST8  "i"
+#define PRIdFAST8   "d"
+#define PRIiFAST8   "i"
+
+#define PRId16       "hd"
+#define PRIi16       "hi"
+#define PRIdLEAST16  "hd"
+#define PRIiLEAST16  "hi"
+#define PRIdFAST16   "hd"
+#define PRIiFAST16   "hi"
+
+#define PRId32       "I32d"
+#define PRIi32       "I32i"
+#define PRIdLEAST32  "I32d"
+#define PRIiLEAST32  "I32i"
+#define PRIdFAST32   "I32d"
+#define PRIiFAST32   "I32i"
+
+#define PRId64       "I64d"
+#define PRIi64       "I64i"
+#define PRIdLEAST64  "I64d"
+#define PRIiLEAST64  "I64i"
+#define PRIdFAST64   "I64d"
+#define PRIiFAST64   "I64i"
+
+#define PRIdMAX     "I64d"
+#define PRIiMAX     "I64i"
+
+#define PRIdPTR     "Id"
+#define PRIiPTR     "Ii"
+
+// The fprintf macros for unsigned integers are:
+#define PRIo8       "o"
+#define PRIu8       "u"
+#define PRIx8       "x"
+#define PRIX8       "X"
+#define PRIoLEAST8  "o"
+#define PRIuLEAST8  "u"
+#define PRIxLEAST8  "x"
+#define PRIXLEAST8  "X"
+#define PRIoFAST8   "o"
+#define PRIuFAST8   "u"
+#define PRIxFAST8   "x"
+#define PRIXFAST8   "X"
+
+#define PRIo16       "ho"
+#define PRIu16       "hu"
+#define PRIx16       "hx"
+#define PRIX16       "hX"
+#define PRIoLEAST16  "ho"
+#define PRIuLEAST16  "hu"
+#define PRIxLEAST16  "hx"
+#define PRIXLEAST16  "hX"
+#define PRIoFAST16   "ho"
+#define PRIuFAST16   "hu"
+#define PRIxFAST16   "hx"
+#define PRIXFAST16   "hX"
+
+#define PRIo32       "I32o"
+#define PRIu32       "I32u"
+#define PRIx32       "I32x"
+#define PRIX32       "I32X"
+#define PRIoLEAST32  "I32o"
+#define PRIuLEAST32  "I32u"
+#define PRIxLEAST32  "I32x"
+#define PRIXLEAST32  "I32X"
+#define PRIoFAST32   "I32o"
+#define PRIuFAST32   "I32u"
+#define PRIxFAST32   "I32x"
+#define PRIXFAST32   "I32X"
+
+#define PRIo64       "I64o"
+#define PRIu64       "I64u"
+#define PRIx64       "I64x"
+#define PRIX64       "I64X"
+#define PRIoLEAST64  "I64o"
+#define PRIuLEAST64  "I64u"
+#define PRIxLEAST64  "I64x"
+#define PRIXLEAST64  "I64X"
+#define PRIoFAST64   "I64o"
+#define PRIuFAST64   "I64u"
+#define PRIxFAST64   "I64x"
+#define PRIXFAST64   "I64X"
+
+#define PRIoMAX     "I64o"
+#define PRIuMAX     "I64u"
+#define PRIxMAX     "I64x"
+#define PRIXMAX     "I64X"
+
+#define PRIoPTR     "Io"
+#define PRIuPTR     "Iu"
+#define PRIxPTR     "Ix"
+#define PRIXPTR     "IX"
+
+// The fscanf macros for signed integers are:
+#define SCNd8       "d"
+#define SCNi8       "i"
+#define SCNdLEAST8  "d"
+#define SCNiLEAST8  "i"
+#define SCNdFAST8   "d"
+#define SCNiFAST8   "i"
+
+#define SCNd16       "hd"
+#define SCNi16       "hi"
+#define SCNdLEAST16  "hd"
+#define SCNiLEAST16  "hi"
+#define SCNdFAST16   "hd"
+#define SCNiFAST16   "hi"
+
+#define SCNd32       "ld"
+#define SCNi32       "li"
+#define SCNdLEAST32  "ld"
+#define SCNiLEAST32  "li"
+#define SCNdFAST32   "ld"
+#define SCNiFAST32   "li"
+
+#define SCNd64       "I64d"
+#define SCNi64       "I64i"
+#define SCNdLEAST64  "I64d"
+#define SCNiLEAST64  "I64i"
+#define SCNdFAST64   "I64d"
+#define SCNiFAST64   "I64i"
+
+#define SCNdMAX     "I64d"
+#define SCNiMAX     "I64i"
+
+#ifdef _WIN64 // [
+#  define SCNdPTR     "I64d"
+#  define SCNiPTR     "I64i"
+#else  // _WIN64 ][
+#  define SCNdPTR     "ld"
+#  define SCNiPTR     "li"
+#endif  // _WIN64 ]
+
+// The fscanf macros for unsigned integers are:
+#define SCNo8       "o"
+#define SCNu8       "u"
+#define SCNx8       "x"
+#define SCNX8       "X"
+#define SCNoLEAST8  "o"
+#define SCNuLEAST8  "u"
+#define SCNxLEAST8  "x"
+#define SCNXLEAST8  "X"
+#define SCNoFAST8   "o"
+#define SCNuFAST8   "u"
+#define SCNxFAST8   "x"
+#define SCNXFAST8   "X"
+
+#define SCNo16       "ho"
+#define SCNu16       "hu"
+#define SCNx16       "hx"
+#define SCNX16       "hX"
+#define SCNoLEAST16  "ho"
+#define SCNuLEAST16  "hu"
+#define SCNxLEAST16  "hx"
+#define SCNXLEAST16  "hX"
+#define SCNoFAST16   "ho"
+#define SCNuFAST16   "hu"
+#define SCNxFAST16   "hx"
+#define SCNXFAST16   "hX"
+
+#define SCNo32       "lo"
+#define SCNu32       "lu"
+#define SCNx32       "lx"
+#define SCNX32       "lX"
+#define SCNoLEAST32  "lo"
+#define SCNuLEAST32  "lu"
+#define SCNxLEAST32  "lx"
+#define SCNXLEAST32  "lX"
+#define SCNoFAST32   "lo"
+#define SCNuFAST32   "lu"
+#define SCNxFAST32   "lx"
+#define SCNXFAST32   "lX"
+
+#define SCNo64       "I64o"
+#define SCNu64       "I64u"
+#define SCNx64       "I64x"
+#define SCNX64       "I64X"
+#define SCNoLEAST64  "I64o"
+#define SCNuLEAST64  "I64u"
+#define SCNxLEAST64  "I64x"
+#define SCNXLEAST64  "I64X"
+#define SCNoFAST64   "I64o"
+#define SCNuFAST64   "I64u"
+#define SCNxFAST64   "I64x"
+#define SCNXFAST64   "I64X"
+
+#define SCNoMAX     "I64o"
+#define SCNuMAX     "I64u"
+#define SCNxMAX     "I64x"
+#define SCNXMAX     "I64X"
+
+#ifdef _WIN64 // [
+#  define SCNoPTR     "I64o"
+#  define SCNuPTR     "I64u"
+#  define SCNxPTR     "I64x"
+#  define SCNXPTR     "I64X"
+#else  // _WIN64 ][
+#  define SCNoPTR     "lo"
+#  define SCNuPTR     "lu"
+#  define SCNxPTR     "lx"
+#  define SCNXPTR     "lX"
+#endif  // _WIN64 ]
+
+#endif // __STDC_FORMAT_MACROS ]
+
+// 7.8.2 Functions for greatest-width integer types
+
+// 7.8.2.1 The imaxabs function
+#define imaxabs _abs64
+
+// 7.8.2.2 The imaxdiv function
+
+// This is modified version of div() function from Microsoft's div.c found
+// in %MSVC.NET%\crt\src\div.c
+#ifdef STATIC_IMAXDIV // [
+static
+#else // STATIC_IMAXDIV ][
+_inline
+#endif // STATIC_IMAXDIV ]
+imaxdiv_t __cdecl imaxdiv(intmax_t numer, intmax_t denom)
+{
+   imaxdiv_t result;
+
+   result.quot = numer / denom;
+   result.rem = numer % denom;
+
+   if (numer < 0 && result.rem > 0) {
+      // did division wrong; must fix up
+      ++result.quot;
+      result.rem -= denom;
+   }
+
+   return result;
+}
+
+// 7.8.2.3 The strtoimax and strtoumax functions
+#define strtoimax _strtoi64
+#define strtoumax _strtoui64
+
+// 7.8.2.4 The wcstoimax and wcstoumax functions
+#define wcstoimax _wcstoi64
+#define wcstoumax _wcstoui64
+
+
+#endif // _MSC_INTTYPES_H_ ]
+#endif

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -101,7 +101,12 @@ namespace Rcpp {
 #include "fcntl.h"
 #include "float.h"	/* for FLT_MAX and DBL_MAX */
 
+#ifdef _MSC_VER
+#include <stdint.h>
+#include <io.h>
+#else
 #include <unistd.h>		// solaris needs this for read() and close()
+#endif
 
 
 /* merged from private.h */

--- a/src/extra_math_functions.cpp
+++ b/src/extra_math_functions.cpp
@@ -1,0 +1,20 @@
+#ifdef _MSC_VER
+#include <math.h>
+	float expm1(float arg)
+	{
+		return ::exp(arg)-1;
+	}
+	double expm1(double arg)
+	{
+		return ::exp(arg)-1;
+	}
+
+	float log1p(float arg)
+	{
+		return ::log(arg+1);
+	}
+	double log1p(double arg)
+	{
+		return ::log(arg+1);
+	}
+#endif


### PR DESCRIPTION
For some reason every reference I can find to building Rcpp with Visual Studio says it is impossible. This is completely wrong. I've attached a relatively minor patch that successfully builds Rcpp under Visual Studio Express 2012 for Desktop (the free version, compiler version 11). 
-Missing typename in proxy.h
-Replaced one use of "and" by "&&".
-Obvious edits to compiler.h
-Changes to math.h to include a new file, which defines missing functions expm1, log1p
-Inclusion of a suitable inttypes.h. Probably only a few lines of this are actually relevant. 
-Change to Date.cpp to include io.h and stdint.h instead of unistd.h

The only change I am unhappy with is the one to, inst/include/Rcpp/sugar/block/Vectorized_Math.h, it is too heavily templated for me to to really understand - Although it seems that the relevant two lines might be removed rather than changed using conditional compilation. Required compilation options are compiler define snprintf=_snprintf and /sdl-. 

Again, I have been using this set-up for over a year without any problems, and would like to have it integrated into the main branch. This is a good idea because R is widely used on windows, but the MinGW port of g++/gcc to windows is terrible, especially its debugger and especially for heavily templated code such as Rcpp. A compiler like Visual Studio makes the whole thing much more useable. 
