### PR TITLE
work around macro leakage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-01-15  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/RcppCommon.h: remove leaked macros
+        'major', 'minor' and 'makedev' from sys/sysmacros.h
+
 2015-01-08  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/OpenMP/GNUmakefile: Renamed from Makefile because it

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,14 +1,16 @@
 2015-01-15  Kevin Ushey  <kevinushey@gmail.com>
 
-        * inst/include/RcppCommon.h: remove leaked macros
-        'major', 'minor' and 'makedev' from sys/sysmacros.h
+        * inst/include/Rcpp/platform/sysmacros.h: remove leaked macros
+        'major', 'minor', 'makedev' from <sys/sysmacros.h>
+        * inst/include/RcppCommon.h: ditto
+        * inst/unitTests/cpp/Vector.cpp: simple test
 
 2015-01-08  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/OpenMP/GNUmakefile: Renamed from Makefile because it
         contains GNU make extentions (which we happen to like)
         * inst/examples/ConvolveBenchmarks: Ditto
-        
+
 2015-01-02  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/sugar/functions/setdiff.h: fix for setequals

--- a/inst/include/Rcpp/platform/sysmacros.h
+++ b/inst/include/Rcpp/platform/sysmacros.h
@@ -1,0 +1,64 @@
+// sysmacros.h: Rcpp R/C++ interface class library -- avoid sysmacros pollution
+//
+// Copyright (C) 2015  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/Licenses/>.
+
+#ifndef RCPP__PLATFORM__SYSMACROS_H
+#define RCPP__PLATFORM__SYSMACROS_H
+
+// include <sys/sysmacros.h>, and then remove stupid
+// 'major', 'minor' and 'makedev' defines. this works
+// around Rinternals.h eventually including this header
+// and letting the macros leak through
+#if defined(__GNUC__) && !defined(__APPLE__)
+
+# ifdef major
+#  define RCPP_HAS_MAJOR_MACRO
+#  pragma push_macro("major")
+# endif
+
+# ifdef minor
+#  define RCPP_HAS_MINOR_MACRO
+#  pragma push_macro("minor")
+# endif
+
+# ifdef makedev
+#  define RCPP_HAS_MAKEDEV_MACRO
+#  pragma push_macro("makedev")
+# endif
+
+# include <sys/sysmacros.h>
+
+# undef major
+# undef minor
+# undef makedev
+
+# ifdef RCPP_HAS_MAJOR_MACRO
+#  pragma pop_macro("major")
+# endif
+
+# ifdef RCPP_HAS_MINOR_MACRO
+#  pragma pop_macro("minor")
+# endif
+
+# ifdef RCPP_HAS_MAKEDEV_MACRO
+#  pragma pop_macro("makedev")
+# endif
+
+#endif
+
+#endif /* RCPP__PLATFORM__SYSMACROS_H */

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -32,32 +32,6 @@
 
 #include <Rcpp/platform/sysmacros.h>
 
-// include <sys/sysmacros.h>, and then remove stupid
-// 'major', 'minor' and 'makedev' defines. this works
-// around Rinternals.h eventually including this header
-// and letting the macros leak through
-#if defined(__GNUC__) && !defined(__clang__)
-
-# ifdef major
-#  warning Macro 'major' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
-# endif
-
-# ifdef minor
-#  warning Macro 'minor' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
-# endif
-
-# ifdef makedev
-#  warning Macro 'makedev' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
-# endif
-
-# include <sys/sysmacros.h>
-
-# undef major
-# undef minor
-# undef makedev
-
-#endif
-
 // include R headers, but set R_NO_REMAP and access everything via Rf_ prefixes
 #define MAXELTSIZE 8192
 #define R_NO_REMAP

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -30,6 +30,8 @@
 #include <Rcpp/config.h>
 #include <Rcpp/macros/macros.h>
 
+#include <Rcpp/platform/sysmacros.h>
+
 // include <sys/sysmacros.h>, and then remove stupid
 // 'major', 'minor' and 'makedev' defines. this works
 // around Rinternals.h eventually including this header

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -30,6 +30,32 @@
 #include <Rcpp/config.h>
 #include <Rcpp/macros/macros.h>
 
+// include <sys/sysmacros.h>, and then remove stupid
+// 'major', 'minor' and 'makedev' defines. this works
+// around Rinternals.h eventually including this header
+// and letting the macros leak through
+#if defined(__GNUC__) && !defined(__clang__)
+
+# ifdef major
+#  warning Macro 'major' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
+# endif
+
+# ifdef minor
+#  warning Macro 'minor' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
+# endif
+
+# ifdef makedev
+#  warning Macro 'makedev' will be undefined! See https://bugzilla.redhat.com/show_bug.cgi?id=130601.
+# endif
+
+# include <sys/sysmacros.h>
+
+# undef major
+# undef minor
+# undef makedev
+
+#endif
+
 // include R headers, but set R_NO_REMAP and access everything via Rf_ prefixes
 #define MAXELTSIZE 8192
 #define R_NO_REMAP

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -761,3 +761,8 @@ LogicalVector logical_vector_from_bool_assign() {
     LogicalVector result = true;
     return result;
 }
+
+// [[Rcpp::export]]
+void no_op(int major) {
+    int minor = 1;
+}


### PR DESCRIPTION
This PR works around the (really ridiculous) macro leaking of `<sys/sysmacros.h>` from GCC. See https://github.com/RcppCore/Rcpp/issues/227 for motivation, and see https://bugzilla.redhat.com/show_bug.cgi?id=130601 for how it's probably not going to be fixed on GCC's side.