### PR TITLE
Add Rcpp::warning function as wrapper for Rf_warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-02  JJ Allaire  <jj@rstudio.org>
+
+        * inst/include/Rcpp/exceptions.h: Add Rcpp::warning function as
+        wrapper for Rf_warning
+
 2015-01-25  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/utils/tinyformat.h: define an error handler for

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,7 @@
     \itemize{
       \item Defining an error handler for tinyformat prevents \code{assert()}
       from spilling.
+      \item Add Rcpp::warning function as wrapper for Rf_warning.
     }
   }
 }

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -192,6 +192,61 @@ std::string demangle( const std::string& name) ;
 #define DEMANGLE(__TYPE__) demangle( typeid(__TYPE__).name() ).c_str()
 
 namespace Rcpp{
+
+    inline void warning(const std::string& message) {
+        Rf_warning(message.c_str());
+    }
+
+    template <typename T1>
+    inline void warning(const char* fmt, const T1& arg1) {
+        Rf_warning( tfm::format(fmt, arg1 ).c_str() );
+    }
+
+    template <typename T1, typename T2>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2) {
+        Rf_warning( tfm::format(fmt, arg1, arg2 ).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
+    }
+
+    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
+    }
+
     inline void stop(const std::string& message) {
         throw Rcpp::exception(message.c_str());
     }


### PR DESCRIPTION
This compliments the existing Rcpp::stop function and will encourage the use of the C-level warning API rather than calling base::warning via R. Also added support for tinyfmt which works the same way as it does for Rcpp::stop.

@eddelbuettel It's possible that given how simple a name "warning" is that there is a chance of symbol clashes leading to compilation errors in some packages. C++ namespaces should take care of this but it's not beyond the pale of imagination that there's a subtle corner case we run afowl of. Probably worth a revdep check to be more certain, we can back this out if it presents intractable problems.
