### PR TITLE
Improvements to XPtr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2014-02-02  JJ Allaire  <jj@rstudio.org>
+
+        * inst/include/Rcpp/XPtr.h: Improvements to XPtr including new
+        checked_get and release functions and improved behavior (throw
+        an exception rather than crash) when a NULL external pointer is
+        dereferenced.
+        * inst/unitTests/runit.XPTr.R: tests for XPtr improvements.
+        * inst/unitTests/cpp/XPtr.cpp: tests for XPtr improvements.
+
 2015-01-25  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/utils/tinyformat.h: define an error handler for

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,10 @@
     \itemize{
       \item Defining an error handler for tinyformat prevents \code{assert()}
       from spilling.
+      \item Improvements to XPtr including new \code{checked_get} and
+      \code{release} functions as well as improved behavior (throw an
+      exception rather than crash) when a NULL external pointer is
+      dereferenced.
     }
   }
 }

--- a/inst/unitTests/cpp/XPtr.cpp
+++ b/inst/unitTests/cpp/XPtr.cpp
@@ -46,3 +46,24 @@ int xptr_2( XPtr< std::vector<int> > p){
     		return p->front() ;
 }
 
+// [[Rcpp::export]]
+bool xptr_release( XPtr< std::vector<int> > p) {
+    p.release();
+    return !p;
+}
+
+// [[Rcpp::export]]
+bool xptr_access_released( XPtr< std::vector<int> > p) {
+
+    // double-release should be a no-op
+    p.release();
+
+    // get should return NULL
+    return p.get() == NULL;
+}
+
+// [[Rcpp::export]]
+int xptr_use_released( XPtr< std::vector<int> > p ) {
+    return p->front();
+}
+

--- a/inst/unitTests/runit.XPTr.R
+++ b/inst/unitTests/runit.XPTr.R
@@ -30,6 +30,14 @@ if (.runThisTest) {
         
         front <- xptr_2(xp)
         checkEquals( front, 1L, msg = "check usage of external pointer" )
+
+        checkTrue(xptr_release(xp), msg = "check release of external pointer")
+
+        checkTrue(xptr_access_released(xp), msg = "check access of released external pointer")
+
+        checkException(xptr_use_released(xp),
+                       msg = "check exception on use of released external pointer",
+                       silent = TRUE)
     }
 
 }


### PR DESCRIPTION
- New checked_get and release functions
- Improved behavior (throw an exception rather than crash) when a NULL external pointer is dereferenced