### PR TITLE
Simplify generated attributes code for RNGScope

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2015-02-03  JJ Allaire  <jj@rstudio.org>
 
+        * src/attributes.cpp: Simplify generated attributes code for
+        RNGScope (use RObject and it's destructor rather than SEXP
+        protect/unprotect).
+        * vignettes/Rcpp-package.Rnw: Update docs on generated code.
+
+2015-02-03  JJ Allaire  <jj@rstudio.org>
+
         * inst/include/Rcpp/exceptions.h: Add Rcpp::warning function as
         wrapper for Rf_warning
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -20,6 +20,9 @@
     \itemize{
       \item Include pkg_types.h file in RcppExports.cpp if it's present in
       inst/include or src.
+      \item Simplify generated attributes code for \code{RNGScope} (use
+      \code{RObject} and it's destructor rather than \code{SEXP}
+      protect/unprotect).
     }
   }
 }

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2225,21 +2225,20 @@ namespace attributes {
             ostr << args << ") {" << std::endl;
             ostr << "BEGIN_RCPP" << std::endl;
             if (!function.type().isVoid())
-                ostr << "    SEXP __sexp_result;" << std::endl;
-            ostr << "    {" << std::endl;
+                ostr << "    Rcpp::RObject __result;" << std::endl;
             if (!cppInterface)
-                ostr << "        Rcpp::RNGScope __rngScope;" << std::endl;
+                ostr << "    Rcpp::RNGScope __rngScope;" << std::endl;
             for (size_t i = 0; i<arguments.size(); i++) {
                 const Argument& argument = arguments[i];
 
-                ostr << "        Rcpp::traits::input_parameter< "
+                ostr << "    Rcpp::traits::input_parameter< "
                      << argument.type().full_name() << " >::type " << argument.name()
-                     << "(" << argument.name() << "SEXP );" << std::endl;
+                     << "(" << argument.name() << "SEXP);" << std::endl;
             }
 
-            ostr << "        ";
+            ostr << "    ";
             if (!function.type().isVoid())
-                ostr << function.type() << " __result = ";
+                ostr << "__result = Rcpp::wrap(";
             ostr << function.name() << "(";
             for (size_t i = 0; i<arguments.size(); i++) {
                 const Argument& argument = arguments[i];
@@ -2247,18 +2246,13 @@ namespace attributes {
                 if (i != (arguments.size()-1))
                     ostr << ", ";
             }
+            if (!function.type().isVoid())
+                ostr << ")";
             ostr << ");" << std::endl;
 
             if (!function.type().isVoid())
             {
-                ostr << "        PROTECT(__sexp_result = Rcpp::wrap(__result));"
-                     << std::endl;
-            }
-            ostr << "    }" << std::endl;
-            if (!function.type().isVoid())
-            {
-                ostr << "    UNPROTECT(1);" << std::endl;
-                ostr << "    return __sexp_result;" << std::endl;
+                ostr << "    return __result;" << std::endl;
             }
             else
             {

--- a/vignettes/Rcpp-package.Rnw
+++ b/vignettes/Rcpp-package.Rnw
@@ -183,14 +183,10 @@ using namespace Rcpp;
 List rcpp_hello_world();
 RcppExport SEXP mypackage_rcpp_hello_world() {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        List __result = rcpp_hello_world();
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    __result = Rcpp::wrap(rcpp_hello_world());
+    return __result;
 END_RCPP
 }
 @


### PR DESCRIPTION
Use RObject and it's destructor rather than SEXP protect/unprotect. The code we were generating was correct however hard to read and reason about for users not familiar with R/Rcpp internals. Previously we held the result in a raw SEXP which we unprotected after leaving a special block created for the RNGScope:

```cpp
RcppExport SEXP rcpp_hello_world() {
BEGIN_RCPP
    SEXP __sexp_result;
    {
        Rcpp::RNGScope __rngScope;
        List __result = rcpp_hello_world();
        PROTECT(__sexp_result = Rcpp::wrap(__result));
    }
    UNPROTECT(1);
    return __sexp_result;
END_RCPP
}
```

Now, we simply construct an RObject *prior to* the RNGScope on the stack and then return that object (this ensures that any GC triggered by PutRNGState won't collect the result SEXP before it can be returned):

```cpp
RcppExport SEXP rcpp_hello_world() {
BEGIN_RCPP
    Rcpp::RObject __result;
    Rcpp::RNGScope __rngScope;
    __result = Rcpp::wrap(rcpp_hello_world());
    return __result;
END_RCPP
}
```
