### PR TITLE
faster strsxp subsetting (cc @romainfrancois, #250)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-06  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/Rcpp/vector/Subsetter.h: compare CHARSXP pointers
+        rather than string contents in subsetter
+
 2015-02-03  JJ Allaire  <jj@rstudio.org>
 
         * src/attributes.cpp: Simplify generated attributes code for

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -141,18 +141,15 @@ private:
         indices.reserve(rhs_n);
         SEXP names = Rf_getAttrib(lhs, R_NamesSymbol);
         if (Rf_isNull(names)) stop("names is null");
-        for (int i=0; i < rhs_n; ++i) {
-            indices.push_back( find(names, CHAR( STRING_ELT(rhs, i) )) );
+        SEXP* namesPtr = STRING_PTR(names);
+        SEXP* rhsPtr = STRING_PTR(rhs);
+        for (int i = 0; i < rhs_n; ++i) {
+            SEXP* match = std::find(namesPtr, namesPtr + lhs_n, *(rhsPtr + i));
+            if (match == namesPtr + lhs_n)
+                stop("not found");
+            indices.push_back(match - namesPtr);
         }
         indices_n = indices.size();
-    }
-
-    int find(const RHS_t& names, const char* str) {
-        for (int i=0; i < lhs_n; ++i) {
-            if (strcmp( CHAR( STRING_ELT( names, i) ), str) == 0) return i;
-        }
-        stop("no name found");
-        return -1;
     }
 
     void get_indices( traits::identity< traits::int2type<LGLSXP> > t ) {


### PR DESCRIPTION
This compares string elements by pointers rather than contents, providing improved sugar subsetting.

@romainfrancois, if you're willing can you confirm I haven't bundled anything here? (Testing on the examples of #250 shows it's much faster, but still not on par with base R's `[`)