### PR TITLE
Allow use of attributes without Rcpp:: prefix when preceded by 'using namespace Rcpp'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,11 @@
 
         * DESCRIPTION: bump version
         * src/attributes.cpp: Add rng parameter to Rcpp::export to 
-        prevent inclusion of RNGScope in generated code.
+        prevent inclusion of RNGScope in generated code; Allow use
+        of attributes without Rcpp:: prefix when preceded by 
+        'using namespace Rcpp'
+        * inst/unitTests/cpp/na.cpp Use un-namespaced version of
+        export attribute for the NA unit tests
 
 2015-02-06  Kevin Ushey  <kevinushey@gmail.com>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.11.4.5
+Version: 0.11.4.6
 Date: 2015-02-03
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
  Douglas Bates, and John Chambers

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -25,6 +25,8 @@
       protect/unprotect).
       \item Add rng parameter to Rcpp::export to prevent inclusion of
       RNGScope in generated code.
+      \item Allow use of attributes without Rcpp:: prefix when 
+      preceded by 'using namespace Rcpp'
     }
   }
 }

--- a/inst/unitTests/cpp/na.cpp
+++ b/inst/unitTests/cpp/na.cpp
@@ -22,22 +22,22 @@
 #include <Rcpp.h>
 using namespace Rcpp ;
 
-// [[Rcpp::export]]
+// [[export]]
 bool Rcpp_IsNA(double x) {
     return internal::Rcpp_IsNA(x);
 }
 
-// [[Rcpp::export]]
+// [[export]]
 bool Rcpp_IsNaN(double x) {
     return internal::Rcpp_IsNaN(x);
 }
 
-// [[Rcpp::export]]
+// [[export]]
 bool R_IsNA_(double x) {
     return ::R_IsNA(x);
 }
 
-// [[Rcpp::export]]
+// [[export]]
 bool R_IsNaN_(double x) {
     return ::R_IsNaN(x);
 }


### PR DESCRIPTION
Note that this PR is branched off the previous rng = false one so should only be taken after that one is.