### PR TITLE
enable includes of local files in sourceCpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-14  JJ Allaire  <jj@rstudio.org>
+
+        * src/attributes.cpp: Allow includes of local files
+        (e.g. #include "foo.hpp") in sourceCpp
+
 2015-02-13  JJ Allaire  <jj@rstudio.org>
 
         * src/attributes.cpp: Allow 'R' to come immediately after '***'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.11.4.5
+Version: 0.11.4.6
 Date: 2015-02-03
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
  Douglas Bates, and John Chambers

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -624,17 +624,23 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
     # set CLINK_CPPFLAGS based on the LinkingTo dependencies
     buildEnv$CLINK_CPPFLAGS <- .buildClinkCppFlags(linkingToPackages)
 
-    # if the source file is in a package then add src and inst/include
+    # add the source file's directory to the compliation
+    srcDir <- dirname(sourceFile)
+    srcDir <- asBuildPath(srcDir)
+    buildDirs <- srcDir
+    
+    # if the source file is in a package then add inst/include
     if (.isPackageSourceFile(sourceFile)) {
-        srcDir <- dirname(sourceFile)
-        srcDir <- asBuildPath(srcDir)
         incDir <- file.path(dirname(sourceFile), "..", "inst", "include")
         incDir <- asBuildPath(incDir)
-        dirFlags <- paste0('-I"', c(srcDir, incDir), '"', collapse=" ")
-        buildEnv$CLINK_CPPFLAGS <- paste(buildEnv$CLINK_CPPFLAGS,
-                                         dirFlags,
-                                         collapse=" ")
+        buildDirs <- c(buildDirs, incDir)
     }
+    
+    # set CLINK_CPPFLAGS with directory flags
+    dirFlags <- paste0('-I"', buildDirs, '"', collapse=" ")
+    buildEnv$CLINK_CPPFLAGS <- paste(buildEnv$CLINK_CPPFLAGS,
+                                     dirFlags,
+                                     collapse=" ")
 
     # merge existing environment variables
     for (name in names(buildEnv))

--- a/TODO
+++ b/TODO
@@ -80,11 +80,6 @@ Syntactic sugar
     	
     	rnt : idem
 
-Attributes
-
-    o   Consider allowing local includes in sourceCpp (but compilation cache
-        must pay mind to any local includes)
-
 Testing
 
     o	all r* functions : rnorm, etc ...

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -19,6 +19,8 @@
     \itemize{
       \item The \code{pkg_types.h} file is now included in \code{RcppExports.cpp}
       if it is present in either the \code{inst/include} or \code{src}. 
+      \item \code{sourceCpp} was modified to allow includes of local files 
+      (e.g. #include "foo.hpp").
       \item The generated attributes code was simplified with respect to
       \code{RNGScope} and now uses \code{RObject} and its destructor rather than \code{SEXP}
       protect/unprotect.

--- a/inst/unitTests/cpp/attributes.cpp
+++ b/inst/unitTests/cpp/attributes.cpp
@@ -1,6 +1,9 @@
 #include <Rcpp.h>
 using namespace Rcpp;
 
+// include a dummy header file to test support for local includes
+#include "attributes.hpp"
+
 //' @param foo // don't do anything to this
 //'     // or this
 //' @param bar " // or this guy "

--- a/inst/unitTests/cpp/attributes.hpp
+++ b/inst/unitTests/cpp/attributes.hpp
@@ -1,0 +1,9 @@
+
+#ifndef __RCPP_UNITTESTS_ATTRIBUTES__
+#define __RCPP_UNITTESTS_ATTRIBUTES__
+
+/*
+ *  dummy header used to test that local includes for sourceCpp are working
+ */
+
+#endif // __RCPP_UNITTESTS_ATTRIBUTES__

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -718,7 +718,7 @@ namespace attributes {
 
         template <typename Stream>
         void readFile(const std::string& file, Stream& os) {
-            std::ifstream ifs(file);
+            std::ifstream ifs(file.c_str());
             if (ifs.fail())
                 throw Rcpp::file_io_error(file);
             os << ifs.rdbuf();
@@ -804,7 +804,7 @@ namespace attributes {
             
             // remove duplicates
             std::sort(localIncludes.begin(), localIncludes.end());
-            std::vector<FileInfo>::const_iterator end = 
+            std::vector<FileInfo>::iterator end = 
                 std::unique(localIncludes.begin(), localIncludes.end());
             localIncludes.erase(end, localIncludes.end());
             


### PR DESCRIPTION
This PR makes it possible to do local includes (e.g. `#include "foo.hpp"`) within a sourceCpp translation unit. This was formerly not enabled because sourceCpp caches the results of builds and only performed a rebuild when the main C++ file was modified. This meant that changes in files referenced via a local include wouldn't force a rebuild and therefore would give surprising (and incorrect) results.

We now scan recursively for all local includes within the translation unit and make their file modification times part of the cache key (so changes in these files will always result in a rebuild).