### PR TITLE
Enable preview of vignettes in RStudio

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-02-14  JJ Allaire  <jj@rstudio.org>
+
+        * Rcpp.Rproj: Specify Sweave as Rnw handler for RStudio
+        * vignettes/*.Rnw: Add driver magic comment and turn off 
+        Sweave concordance.
+        * vignettes/.gitignore: Ignore artifacts of PDF preview
+
 2015-02-13  Dirk Eddelbuettel  <edd@debian.org>
 
         * .travis.yml (install): Switch to using ppa:edd/misc to install all the

--- a/Rcpp.Rproj
+++ b/Rcpp.Rproj
@@ -9,7 +9,7 @@ UseSpacesForTab: Yes
 NumSpacesForTab: 4
 Encoding: UTF-8
 
-RnwWeave: knitr
+RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes

--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,0 +1,5 @@
+Rcpp-*.bbl
+Rcpp-*.log
+Rcpp-*.tex
+Rcpp-*.pdf
+unitTests-results/

--- a/vignettes/Rcpp-FAQ.Rnw
+++ b/vignettes/Rcpp-FAQ.Rnw
@@ -1,8 +1,11 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-FAQ}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, FAQ}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
+
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}
 

--- a/vignettes/Rcpp-FAQ.Rnw
+++ b/vignettes/Rcpp-FAQ.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-FAQ}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, FAQ}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-FAQ.Rnw
+++ b/vignettes/Rcpp-FAQ.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-FAQ}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, FAQ}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-attributes.Rnw
+++ b/vignettes/Rcpp-attributes.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[11pt]{article}
 %\VignetteIndexEntry{Rcpp-attributes}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, attributes}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{1.25in}{1.25in}{1.25in}{1.25in}

--- a/vignettes/Rcpp-attributes.Rnw
+++ b/vignettes/Rcpp-attributes.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[11pt]{article}
 %\VignetteIndexEntry{Rcpp-attributes}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, attributes}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{1.25in}{1.25in}{1.25in}{1.25in}

--- a/vignettes/Rcpp-attributes.Rnw
+++ b/vignettes/Rcpp-attributes.Rnw
@@ -1,8 +1,11 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[11pt]{article}
 %\VignetteIndexEntry{Rcpp-attributes}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, attributes}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
+
 \usepackage[USletter]{vmargin}
 \setmargrb{1.25in}{1.25in}{1.25in}{1.25in}
 

--- a/vignettes/Rcpp-extending.Rnw
+++ b/vignettes/Rcpp-extending.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-extending}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-extending.Rnw
+++ b/vignettes/Rcpp-extending.Rnw
@@ -1,8 +1,11 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-extending}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
+
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}
 

--- a/vignettes/Rcpp-extending.Rnw
+++ b/vignettes/Rcpp-extending.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-extending}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-introduction.Rnw
+++ b/vignettes/Rcpp-introduction.Rnw
@@ -1,9 +1,11 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 %% use JSS class -- use 'nojss' to turn off header
 \documentclass[shortnames,nojss,article]{jss}
 \usepackage{booktabs,flafter,thumbpdf}
 %\VignetteIndexEntry{Rcpp-introduction}
 %\VignetteKeywords{Rcpp, foreign function interface, .Call, C++, R}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \author{Dirk Eddelbuettel\\Debian Project \And Romain Fran\c{c}ois\\\proglang{R} Enthusiasts}
 \Plainauthor{Dirk Eddelbuettel, Romain Fran\c{c}ois}

--- a/vignettes/Rcpp-introduction.Rnw
+++ b/vignettes/Rcpp-introduction.Rnw
@@ -1,4 +1,3 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 %% use JSS class -- use 'nojss' to turn off header
 \documentclass[shortnames,nojss,article]{jss}
 \usepackage{booktabs,flafter,thumbpdf}

--- a/vignettes/Rcpp-modules.Rnw
+++ b/vignettes/Rcpp-modules.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-modules}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, module}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-modules.Rnw
+++ b/vignettes/Rcpp-modules.Rnw
@@ -1,8 +1,10 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-modules}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, module}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-modules.Rnw
+++ b/vignettes/Rcpp-modules.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-modules}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, module}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-package.Rnw
+++ b/vignettes/Rcpp-package.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-package}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-package.Rnw
+++ b/vignettes/Rcpp-package.Rnw
@@ -1,8 +1,10 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-package}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-package.Rnw
+++ b/vignettes/Rcpp-package.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-package}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, package}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-quickref.Rnw
+++ b/vignettes/Rcpp-quickref.Rnw
@@ -1,8 +1,10 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[8pt,twocolumn,a4paper]{article}
 %\VignetteIndexEntry{Rcpp-quickref}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, reference}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \setlength{\hoffset}{-0.8in}
 \setlength{\voffset}{-0.8in}

--- a/vignettes/Rcpp-quickref.Rnw
+++ b/vignettes/Rcpp-quickref.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[8pt,twocolumn,a4paper]{article}
 %\VignetteIndexEntry{Rcpp-quickref}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, reference}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \setlength{\hoffset}{-0.8in}
 \setlength{\voffset}{-0.8in}

--- a/vignettes/Rcpp-quickref.Rnw
+++ b/vignettes/Rcpp-quickref.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[8pt,twocolumn,a4paper]{article}
 %\VignetteIndexEntry{Rcpp-quickref}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, reference}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \setlength{\hoffset}{-0.8in}
 \setlength{\voffset}{-0.8in}

--- a/vignettes/Rcpp-sugar.Rnw
+++ b/vignettes/Rcpp-sugar.Rnw
@@ -1,10 +1,9 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-sugar}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, syntactic sugar}
 %\VignetteDepends{Rcpp}
-\SweaveOpts{concordance=FALSE}
+% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-sugar.Rnw
+++ b/vignettes/Rcpp-sugar.Rnw
@@ -1,8 +1,10 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-sugar}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, syntactic sugar}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-sugar.Rnw
+++ b/vignettes/Rcpp-sugar.Rnw
@@ -1,9 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-sugar}
 %\VignetteEngine{highlight::highlight}
 %\VignetteKeywords{Rcpp, syntactic sugar}
 %\VignetteDepends{Rcpp}
-% !Rnw driver = highlight::HighlightWeaveLatex()
 
 \usepackage[USletter]{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}

--- a/vignettes/Rcpp-unitTests.Rnw
+++ b/vignettes/Rcpp-unitTests.Rnw
@@ -1,4 +1,3 @@
-% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-unitTests}
 %\VignetteKeywords{R,Rcpp,unit tests}

--- a/vignettes/Rcpp-unitTests.Rnw
+++ b/vignettes/Rcpp-unitTests.Rnw
@@ -1,7 +1,9 @@
+% !Rnw driver = highlight::HighlightWeaveLatex()
 \documentclass[10pt]{article}
 %\VignetteIndexEntry{Rcpp-unitTests}
 %\VignetteKeywords{R,Rcpp,unit tests}
 %\VignetteDepends{Rcpp}
+\SweaveOpts{concordance=FALSE}
 
 \usepackage{vmargin}
 \setmargrb{0.75in}{0.75in}{0.75in}{0.75in}


### PR DESCRIPTION
A few changes to make the 'Compile PDF' button work for Rcpp vignettes in RStudio:

- Set Sweave as the default Rnw processor in RStudio project file
- Magic comment to specify highlight package as the Sweave driver (note this is only recognized by development versions of RStudio >= v0.99.259)
- Turn off Sweave concordance (enabling it produced errors, not sure why)
- Add artifacts of PDF preview to .gitignore for vignettes directory