### PR TITLE
Allow new_env() to create an environment with a specified parent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-19  Lionel Henry  <lionel.hry@gmail.com>
+
+        * inst/include/Rcpp/Environment.h Allow new_env() to create an
+        environment with a specified parent
+
 2015-02-19  JJ Allaire  <jj@rstudio.org>
 
         * vignettes/Rcpp-attributes.Rnw: Add note on using inline
@@ -13,7 +18,7 @@
         * src/attributes.cpp: Allow includes of local files
         (e.g. #include "foo.hpp") in sourceCpp
         * Rcpp.Rproj: Specify Sweave as Rnw handler for RStudio
-        * vignettes/*.Rnw: Add driver magic comment and turn off 
+        * vignettes/*.Rnw: Add driver magic comment and turn off
         Sweave concordance.
         * vignettes/.gitignore: Ignore artifacts of PDF preview
 

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -361,6 +361,15 @@ inline Environment new_env(int size = 29) {
     return R_NewHashedEnv(R_EmptyEnv, sizeSEXP);
 }
 
+inline Environment new_env(SEXP parent, int size = 29) {
+    Shield<SEXP> sizeSEXP(Rf_ScalarInteger(size));
+    Shield<SEXP> parentSEXP(parent);
+    if (!Rf_isEnvironment(parentSEXP)) {
+        stop("parent is not an environment");
+    }
+    return R_NewHashedEnv(parentSEXP, sizeSEXP);
+}
+
 
 } // namespace Rcpp
 

--- a/inst/unitTests/cpp/Environment.cpp
+++ b/inst/unitTests/cpp/Environment.cpp
@@ -150,4 +150,12 @@ Environment runit_child(){
     return global_env.new_child(false) ;
 }
 
+// [[Rcpp::export]]
+Environment runit_new_env_default() {
+    return Rcpp::new_env();
+}
 
+// [[Rcpp::export]]
+Environment runit_new_env_parent(SEXP env) {
+    return Rcpp::new_env(env);
+}

--- a/inst/unitTests/runit.environments.R
+++ b/inst/unitTests/runit.environments.R
@@ -270,8 +270,8 @@ if (.runThisTest) {
 
     test.environment.new_env <- function() {
         env <- new.env()
-        checkEquals(parent.env(runit_new_env_default()), emptyenv(), msg = "new environment with default parent")
-        checkEquals(parent.env(runit_new_env_parent(env)), parent.env(env), msg = "new environment with specified parent")
+        checkIdentical(parent.env(runit_new_env_default()), emptyenv(), msg = "new environment with default parent")
+        checkIdentical(parent.env(runit_new_env_parent(env)), env, msg = "new environment with specified parent")
     }
 
 }

--- a/inst/unitTests/runit.environments.R
+++ b/inst/unitTests/runit.environments.R
@@ -268,5 +268,10 @@ if (.runThisTest) {
         checkEquals( parent.env(runit_child()), globalenv(), msg = "child environment" )
     }
 
+    test.environment.new_env <- function() {
+        env <- new.env()
+        checkEquals(parent.env(runit_new_env_default()), emptyenv(), msg = "new environment with default parent")
+        checkEquals(parent.env(runit_new_env_parent(env)), parent.env(env), msg = "new environment with specified parent")
+    }
 
 }


### PR DESCRIPTION
Hello,

This is a small change to have a more useful way of creating environments with Rcpp.