### PR TITLE
Function constructors that look up functions in an environment or in a namespace

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-02-20  Lionel Henry  <lionel.hry@gmail.com>
+
+        * inst/include/Rcpp/Function.h New Function constructors that will
+        perform function-lookup in an environment or in a namespace.
+
 2015-02-19  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION: Bump Version: and Date:

--- a/inst/unitTests/cpp/Function.cpp
+++ b/inst/unitTests/cpp/Function.cpp
@@ -26,6 +26,16 @@ using namespace Rcpp ;
 Function function_(SEXP x){ return Function(x) ; }
 
 // [[Rcpp::export]]
+Function function_cons_env(std::string x, SEXP env) {
+    return Function(x, env);
+}
+
+// [[Rcpp::export]]
+Function function_cons_ns(std::string x, std::string ns) {
+    return Function(x, ns);
+}
+
+// [[Rcpp::export]]
 NumericVector function_variadic(Function sort, NumericVector y){
     return sort( y, Named("decreasing", true) ) ;
 }
@@ -66,4 +76,3 @@ Function function_namespace_env(){
     Function fun = ns[".asSparse"] ;  // accesses a non-exported function
     return fun;
 }
-

--- a/inst/unitTests/runit.Function.R
+++ b/inst/unitTests/runit.Function.R
@@ -27,7 +27,7 @@ if (.runThisTest) {
     test.Function <- function(){
         checkEquals( function_( rnorm ), rnorm, msg = "Function( CLOSXP )" )
         checkEquals( function_( is.function ), is.function, msg = "Pairlist( BUILTINSXP )" )
-        
+
         checkException( function_(1:10), msg = "Function( INTSXP) " )
         checkException( function_(TRUE), msg = "Function( LGLSXP )" )
         checkException( function_(1.3), msg = "Function( REALSXP) " )
@@ -67,5 +67,24 @@ if (.runThisTest) {
         exportedfunc <- function_namespace_env()
         checkEquals( stats:::.asSparse, exportedfunc, msg = "namespace_env(Function)" )
     }
+
+    test.Function.cons.env <- function() {
+        parent_env <- new.env()
+        parent_env$fun_parent <- rbinom
+        child_env <- new.env(parent = parent_env)
+        child_env$fun_child <- rnorm
+
+        checkEquals(rnorm, function_cons_env("fun_child", child_env), msg = "env-lookup constructor")
+        checkEquals(rbinom, function_cons_env("fun_parent", child_env), msg = "env-lookup constructor: search function in parent environments")
+        checkException(function_cons_env("fun_child", parent_env), msg = "env-lookup constructor: fail when function not found")
+    }
+
+    test.Function.cons.ns <- function() {
+        checkEquals(Rcpp::sourceCpp, function_cons_ns("sourceCpp", "Rcpp"), msg = "namespace-lookup constructor")
+        checkException(function_cons_ns("sourceCpp", "Rcppp"), msg = "namespace-lookup constructor: fail when ns does not exist")
+        checkException(function_cons_ns("sourceCppp", "Rcpp"), msg = "namespace-lookup constructor: fail when function not found")
+    }
+
+    # also check function is found in parent env
 
 }


### PR DESCRIPTION
Before we needed to have
```{cpp}
    Environment ns = Environment::namespace_env("Rcpp") ;
    Function fun = ns["sourceRcpp"];
```

With this we can just do
```{cpp}
    Function fun("sourceRcpp", "Rcpp");
```