### PR TITLE
sourceCpp: build c++ files corresponding to local shared header files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,8 @@
 
         * src/attributes.cpp: Guard against includes referencing themselves
         (and thus creating an endless loop of include processing); Process
-        attributes in included files.
+        attributes in included files; Automatically build implementation files
+        (*.cc; *.cpp) corresponding to local header files if they exist.
         
 2015-02-20  Lionel Henry  <lionel.hry@gmail.com>
 

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -114,7 +114,10 @@ sourceCpp <- function(file = "",
                      "-o ", shQuote(context$dynlibFilename), " ",
                      ifelse(rebuild, "--preclean ", ""),
                      ifelse(dryRun, "--dry-run ", ""),
-                     shQuote(context$cppSourceFilename), sep="")
+                     paste(shQuote(context$cppDependencySourcePaths), 
+                           collapse = " "), " ",
+                     shQuote(context$cppSourceFilename), " ", 
+                     sep="")
         if (showOutput)
             cat(cmd, "\n")
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -20,7 +20,8 @@
       \item The \code{pkg_types.h} file is now included in \code{RcppExports.cpp}
       if it is present in either the \code{inst/include} or \code{src}. 
       \item \code{sourceCpp} was modified to allow includes of local files 
-      (e.g. #include "foo.hpp").
+      (e.g. #include "foo.hpp"). Implementation files (*.cc; *.cpp) corresponding
+      to local includes are also automatically built if they exist.
       \item The generated attributes code was simplified with respect to
       \code{RNGScope} and now uses \code{RObject} and its destructor rather than \code{SEXP}
       protect/unprotect.

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -54,6 +54,14 @@ namespace attributes {
         bool exists() const { return exists_; }
         time_t lastModified() const { return lastModified_; }
         
+        std::string extension() const {
+            std::string::size_type pos = path_.find_last_of('.');
+            if (pos != std::string::npos)
+                return path_.substr(pos);
+            else
+                return "";
+        }
+        
         bool operator<(const FileInfo& other) const {
             return path_ < other.path_;
         };
@@ -143,7 +151,17 @@ namespace attributes {
         {
         }
         bool empty() const { return name().empty(); }
-
+        
+        bool operator==(const Type& other) const {
+            return name_ == other.name_ &&
+                   isConst_ == other.isConst_ &&
+                   isReference_ == other.isReference_;
+        };
+        
+        bool operator!=(const Type& other) const {
+            return !(*this == other);
+        };
+        
         const std::string& name() const { return name_; }
         std::string full_name() const {
             std::string res ;
@@ -175,6 +193,17 @@ namespace attributes {
         }
 
         bool empty() const { return type().empty(); }
+        
+        bool operator==(const Argument& other) const {
+            return name_ == other.name_ &&
+                   type_ == other.type_ &&
+                   defaultValue_ == other.defaultValue_;
+        };
+        
+        bool operator!=(const Argument& other) const {
+            return !(*this == other);
+        };
+        
 
         const std::string& name() const { return name_; }
         const Type& type() const { return type_; }
@@ -192,14 +221,13 @@ namespace attributes {
         Function() {}
         Function(const Type& type,
                  const std::string& name,
-                 const std::vector<Argument>& arguments,
-                 const std::string& source)
-            : type_(type), name_(name), arguments_(arguments), source_(source)
+                 const std::vector<Argument>& arguments)
+            : type_(type), name_(name), arguments_(arguments)
         {
         }
 
         Function renamedTo(const std::string& name) const {
-            return Function(type(), name, arguments(), source());
+            return Function(type(), name, arguments());
         }
 
         std::string signature() const { return signature(name()); }
@@ -210,17 +238,25 @@ namespace attributes {
         }
 
         bool empty() const { return name().empty(); }
+        
+        bool operator==(const Function& other) const {
+            return type_ == other.type_ &&
+                   name_ == other.name_ &&
+                   arguments_ == other.arguments_;
+        };
+        
+        bool operator!=(const Function& other) const {
+            return !(*this == other);
+        };
 
         const Type& type() const { return type_; }
         const std::string& name() const { return name_; }
         const std::vector<Argument>& arguments() const { return arguments_; }
-        const std::string& source() const { return source_; }
-
+      
     private:
         Type type_;
         std::string name_;
         std::vector<Argument> arguments_;
-        std::string source_;
     };
 
     // Attribute parameter (with optional value)
@@ -229,6 +265,16 @@ namespace attributes {
         Param() {}
         explicit Param(const std::string& paramText);
         bool empty() const { return name().empty(); }
+        
+        bool operator==(const Param& other) const {
+            return name_ == other.name_ &&
+                   value_ == other.value_;
+        };
+        
+        bool operator!=(const Param& other) const {
+            return !(*this == other);
+        };
+        
 
         const std::string& name() const { return name_; }
         const std::string& value() const { return value_; }
@@ -251,6 +297,18 @@ namespace attributes {
         }
 
         bool empty() const { return name().empty(); }
+        
+        bool operator==(const Attribute& other) const {
+            return name_ == other.name_ &&
+                   params_ == other.params_ &&
+                   function_ == other.function_ &&
+                   roxygen_ == other.roxygen_;
+        };
+        
+        bool operator!=(const Attribute& other) const {
+            return !(*this == other);
+        };
+        
 
         const std::string& name() const { return name_; }
 
@@ -749,6 +807,9 @@ namespace attributes {
             Rcpp::Function filepath = baseEnv["file.path"];
             Rcpp::Function normalizePath = baseEnv["normalizePath"];
             Rcpp::Function fileExists = baseEnv["file.exists"];
+            Rcpp::Environment toolsEnv = Rcpp::Environment::namespace_env(
+                                                                    "tools");
+            Rcpp::Function filePathSansExt = toolsEnv["file_path_sans_ext"];
             
             // get the path to the source file's directory
             Rcpp::CharacterVector sourceDir = dirname(sourceFile);
@@ -789,6 +850,25 @@ namespace attributes {
                                 newDependencies.push_back(
                                     FileInfo(Rcpp::as<std::string>(include)));
                             }
+                            
+                            std::vector<std::string> exts;
+                            exts.push_back(".cc");
+                            exts.push_back(".cpp");
+                            for (size_t i = 0; i<exts.size(); ++i) {
+                                
+                                // look for corresponding cpp file and add it
+                                std::string file = Rcpp::as<std::string>(
+                                    filePathSansExt(include)) + exts[i];
+                                
+                                exists = fileExists(file);
+                                if (exists[0]) {
+                                    if (addUniqueDependency(file, 
+                                                            pDependencies)) {
+                                        FileInfo fileInfo(file);
+                                        newDependencies.push_back(fileInfo);
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -804,8 +884,17 @@ namespace attributes {
         // parse the source dependencies from the passed lines
         std::vector<FileInfo> parseSourceDependencies(
                                         const std::string& sourceFile) {
+            
+            // parse dependencies
             std::vector<FileInfo> dependencies;
             parseSourceDependencies(sourceFile, &dependencies);
+            
+            // remove main source file
+            dependencies.erase(std::remove(dependencies.begin(), 
+                                           dependencies.end(), 
+                                           FileInfo(sourceFile)), 
+                               dependencies.end()); 
+            
             return dependencies;
         }
 
@@ -1075,21 +1164,26 @@ namespace attributes {
             // Recursively parse dependencies if requested
             if (parseDependencies) {
                 
-                // get local includes
+                // get source dependencies
                 sourceDependencies_ = parseSourceDependencies(sourceFile);
                 
-                // parse attributes and modules from each local include
+                // parse attributes and modules from each dependent file
                 for (size_t i = 0; i<sourceDependencies_.size(); i++) {
                     
                     // perform parse
                     std::string dependency = sourceDependencies_[i].path();
                     SourceFileAttributesParser parser(dependency, false);
                     
-                    // copy to base attributes
-                    std::copy(parser.begin(), 
-                              parser.end(),
-                              std::back_inserter(attributes_));
-                    
+                    // copy to base attributes (if it's a new attribute)
+                    for (SourceFileAttributesParser::const_iterator 
+                            it = parser.begin(); it != parser.end(); ++it) {
+                        if (std::find(attributes_.begin(),
+                                      attributes_.end(),
+                                      *it) == attributes_.end()) {
+                            attributes_.push_back(*it);
+                        }
+                    }
+                   
                     // copy to base modules
                     std::copy(parser.modules().begin(),
                               parser.modules().end(),
@@ -1339,7 +1433,7 @@ namespace attributes {
             arguments.push_back(Argument(name, type, defaultValue));
         }
 
-        return Function(type, name, arguments, signature);
+        return Function(type, name, arguments);
     }
 
 
@@ -2746,7 +2840,7 @@ namespace {
             // always include Rcpp.h in case the user didn't
             ostr << std::endl << std::endl;
             ostr << "#include <Rcpp.h>" << std::endl;
-            generateCpp(ostr, sourceAttributes, false, false, contextId_);
+            generateCpp(ostr, sourceAttributes, true, false, contextId_);
             generatedCpp_ = ostr.str();
             std::ofstream cppOfs(generatedCppSourcePath().c_str(),
                                  std::ofstream::out | std::ofstream::app);
@@ -2812,6 +2906,17 @@ namespace {
 
         const std::string& cppSourcePath() const {
             return cppSourcePath_;
+        }
+        
+        const std::vector<std::string> cppDependencySourcePaths() {
+            std::vector<std::string> dependencies;
+            for (size_t i = 0; i<sourceDependencies_.size(); ++i) {
+                FileInfo dep = sourceDependencies_[i];
+                if (dep.extension() == ".cc" || dep.extension() == ".cpp") {
+                    dependencies.push_back(dep.path());
+                }
+            }
+            return dependencies;
         }
 
         std::string buildDirectory() const {
@@ -3044,6 +3149,7 @@ BEGIN_RCPP
     return List::create(
         _["contextId"] = pDynlib->contextId(),
         _["cppSourcePath"] = pDynlib->cppSourcePath(),
+        _["cppDependencySourcePaths"] = pDynlib->cppDependencySourcePaths(),
         _["buildRequired"] = buildRequired,
         _["buildDirectory"] = pDynlib->buildDirectory(),
         _["generatedCpp"] = pDynlib->generatedCpp(),

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1001,22 +1001,32 @@ namespace attributes {
         return os;
     }
 
-    // Argument operator <<
-    std::ostream& operator<<(std::ostream& os, const Argument& argument) {
+    // Print argument
+    void printArgument(std::ostream& os, 
+                       const Argument& argument, 
+                       bool printDefault = true) {
         if (!argument.empty()) {
             os << argument.type();
             if (!argument.name().empty()) {
                 os << " ";
                 os << argument.name();
-                if (!argument.defaultValue().empty())
+                if (printDefault && !argument.defaultValue().empty())
                     os << " = " << argument.defaultValue();
             }
         }
+    }
+
+    // Argument operator <<
+    std::ostream& operator<<(std::ostream& os, const Argument& argument) {
+        printArgument(os, argument);
         return os;
     }
 
-    // Function operator <<
-    std::ostream& operator<<(std::ostream& os, const Function& function) {
+    // Print function
+    void printFunction(std::ostream& os, 
+                       const Function& function, 
+                       bool printArgDefaults = true) {    
+        
         if (!function.empty()) {
             if (!function.type().empty()) {
                 os << function.type();
@@ -1026,12 +1036,17 @@ namespace attributes {
             os << "(";
             const std::vector<Argument>& arguments = function.arguments();
             for (std::size_t i = 0; i<arguments.size(); i++) {
-                os << arguments[i];
+                printArgument(os, arguments[i], printArgDefaults);
                 if (i != (arguments.size()-1))
                     os << ", ";
             }
             os << ")";
         }
+    }
+
+    // Function operator <<
+    std::ostream& operator<<(std::ostream& os, const Function& function) {
+        printFunction(os, function);
         return os;
     }
 
@@ -2484,7 +2499,8 @@ namespace attributes {
             // include prototype if requested
             if (includePrototype) {
                 ostr << "// " << function.name() << std::endl;
-                ostr << function << ";";
+                printFunction(ostr, function, false);
+                ostr << ";";
             }
 
             // write the C++ callable SEXP-based function (this version

--- a/vignettes/Rcpp-attributes.Rnw
+++ b/vignettes/Rcpp-attributes.Rnw
@@ -418,6 +418,8 @@ code. This has many benefits not the least of which is easy distribution of
 shared code. More information on creating packages that contain C++ code
 is included in the Package Development section below.
 
+\subsubsection{Shared Code in Header Files}
+
 If you need to share a small amount of C++ code between source files 
 compiled with \texttt{sourceCpp} and the option of creating a package
 isn't practical, then you can also share code using local includes of C++
@@ -441,8 +443,7 @@ use an include guard and be sure to pick a unique name for the corresponding
 \texttt{\#define}. 
 
 Also note the use of the \code{inline} keyword preceding the function. This
-isn't necessary for \code{sourceCpp} however if you are working on an R package
-then it's important to ensure that there are not multiple definitions of
+is important to ensure that there are not multiple definitions of
 functions included from header files. Classes fully defined in header files
 automatically have inline semantics so don't require this treatment.
 
@@ -459,10 +460,49 @@ double transformValue(double x) {
 }
 @ 
 
-Note that the processing of Rcpp attributes (e.g. \texttt{export}, 
-\texttt{depends}, etc.) is limited to the main source file so all exported
-functions and dependencies should be defined there rather than in 
-shared header files.
+\subsubsection{Shared Code in C++ Files}
+
+When scanning for locally included header files \code{sourceCpp} also checks
+for a corresponding implementation file and automatically includes it in the
+compilation if it exists.
+
+This enables you to break the shared code entirely into it's own source file.
+In terms of the above example, this would mean having only a function 
+declaration in the header:
+
+<<lang=cpp>>=
+#ifndef __UTILITIES__
+#define __UTILITIES__
+
+double timesTwo(double x);
+
+#endif // __UTILITIES__
+@ 
+
+Then actually defining the function in a separate source file with the 
+same base name as the header file but with a .cpp extension (in the above
+example this would be \code{utilities.cpp}):
+
+<<lang=cpp>>=
+#include "utilities.hpp"
+
+double timesTwo(double x) {
+    return x * 2;
+}
+@ 
+
+It's also possible to use attributes to declare dependencies and exported 
+functions within shared header and source files. This enables you to take
+a source file that is typically used standalone and include it when compiling
+another source file. 
+
+Note that since additional source files are processed as separate translation
+units the total compilation time will increase proportional to the number of
+files processed. From this standpoint it's often preferable to use shared 
+header files with definitions fully inlined as demonstrated above.
+
+Note also that embedded R code is only executed for the main source file not
+those referenced by local includes.
 
 \subsection{Including C++ Inline}
 


### PR DESCRIPTION
This brings sourceCpp closer into line with source("foo.R") in that multiple translation units can be strung together from within the "main" C++ translation unit that is sourced. While packages are still preferred for binary redistribution, unit testing, etc. this extension to sourceCpp will make working with Rcpp at the REPL a bit more scalable. This also matches better with user intuition about what *should* work as users could never fathom why compiling in sourceCpp didn't allow for simple local code sharing.

A bit more detail on the mechanism: local includes (e.g. "#include foo.hpp" with quotes rather than <>) are considered an implicit specification that you want e.g. foo.cpp included in the compilation if it exists. We still track the file modification times for all dependent hpp and cpp files so rebuilds will always occur when necessary.

This should only affect sourceCpp so the revdep check against CRAN will not likely catch any regressions. I rebuilt the entire Rcpp Gallery with the change (and discovered one subtle defect that is now fixed by doing so).