### PR TITLE
move more headers into major/minor protection

### DIFF
--- a/inst/include/Rcpp/r/headers.h
+++ b/inst/include/Rcpp/r/headers.h
@@ -45,6 +45,10 @@
 # pragma push_macro("makedev")
 #endif
 
+#include <Rcpp/platform/compiler.h>
+#include <Rcpp/config.h>
+#include <Rcpp/macros/macros.h>
+
 #include <R.h>
 #include <Rinternals.h>
 #include <R_ext/Complex.h>

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -26,11 +26,6 @@
 // #define RCPP_DEBUG_LEVEL 1
 // #define RCPP_DEBUG_MODULE_LEVEL 1
 
-#include <Rcpp/platform/compiler.h>
-#include <Rcpp/config.h>
-#include <Rcpp/macros/macros.h>
-
-
 #include <Rcpp/r/headers.h>
 
 /**


### PR DESCRIPTION
This PR moves three of our headers into the `major/minor` 'protection' block. When `-std=c++11` is specified, those headers pull in the `major/macro` defines (not sure what chain gets them). This PR fixes that.