### PR TITLE
Default ctor for Matrix return 0x0 matrix

### DIFF
--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -44,7 +44,7 @@ public:
     typedef typename VECTOR::Proxy Proxy ;
     typedef typename VECTOR::const_Proxy const_Proxy ;
 
-    Matrix() : VECTOR() {}
+    Matrix() : VECTOR(Dimension(0, 0)), nrows(0) {}
 
     Matrix(SEXP x) : VECTOR( r_cast<RTYPE>( x ) ), nrows( VECTOR::dims()[0] ) {}
 
@@ -53,7 +53,7 @@ public:
         VECTOR::init() ;
     }
     Matrix( const int& nrows_, const int& ncols) : VECTOR( Dimension( nrows_, ncols ) ),
-        nrows(nrows_)
+      nrows(nrows_)
     {}
 
     template <typename Iterator>


### PR DESCRIPTION
Commit to fix the issue - "Matrix default ctor does not make a matrix #129"