### PR TITLE
Using UTF-8 in String ctor

### DIFF
--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -63,7 +63,8 @@ namespace Rcpp {
         }
 
         /** construct a string from a single CHARSXP SEXP */
-        String(SEXP charsxp) : data(charsxp), valid(true), buffer_ready(false) {
+        String(SEXP charsxp) : valid(true), buffer_ready(false) {
+            data = Rf_mkCharCE(Rf_translateCharUTF8(charsxp), CE_UTF8) ;
             RCPP_STRING_DEBUG( "String(SEXP)" ) ;
         }
 

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -43,23 +43,22 @@ namespace internal{
 	inline SEXP make_charsexp__impl__wstring( const wchar_t* data ){
 		char* buffer = get_string_buffer() ;
 		wcstombs( buffer, data, MAXELTSIZE ) ;
-		return Rf_mkChar(buffer) ;
+		return Rf_mkCharCE( Rf_translateCharUTF8(Rf_mkChar(buffer)), CE_UTF8) ;
 	}
 	inline SEXP make_charsexp__impl__wstring( wchar_t data ){
 		wchar_t x[2] ; x[0] = data ; x[1] = '\0' ;
 		char* buffer = get_string_buffer() ;
 		wcstombs( buffer, x, MAXELTSIZE ) ;
-		return Rf_mkChar(buffer) ;
+		return Rf_mkCharCE( Rf_translateCharUTF8(Rf_mkChar(buffer)), CE_UTF8) ;
 	}
 	inline SEXP make_charsexp__impl__wstring( const std::wstring& st ){
 		return make_charsexp__impl__wstring( st.data()) ;
 	}
 	inline SEXP make_charsexp__impl__cstring( const char* data ){
-		return Rf_mkChar( data ) ;
+		return Rf_mkCharCE( data, CE_UTF8 ) ;
 	}
 	inline SEXP make_charsexp__impl__cstring( char data ){
-		char x[2]; x[0] = data ; x[1] = '\0' ;
-		return Rf_mkChar( x ) ;
+		return Rf_mkCharLen( &data, 1 ) ;
 	}
 
 	inline SEXP make_charsexp__impl__cstring( const std::string& st ){

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -58,7 +58,8 @@ namespace internal{
 		return Rf_mkCharCE( data, CE_UTF8 ) ;
 	}
 	inline SEXP make_charsexp__impl__cstring( char data ){
-		return Rf_mkCharLen( &data, 1 ) ;
+		char x[2]; x[0] = data ; x[1] = '\0' ;
+		return Rf_mkCharCE( x, CE_UTF8 ) ;
 	}
 
 	inline SEXP make_charsexp__impl__cstring( const std::string& st ){

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -61,3 +61,8 @@ String test_push_front(String x) {
     x.push_front("abc");
     return x;
 }
+
+// [[Rcpp::export]]
+bool test_String_encoding_equality(String a, String b){
+    return a == b ;    
+}

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -54,4 +54,12 @@ if (.runThisTest) {
         res <- test_push_front("def")
         checkIdentical(res, "abcdef")
     }
+    
+    test.string.encoding.equal <- function() {
+        a <- b <- "å"
+        Encoding(a) <- "unknown"
+        Encoding(b) <- "UTF-8"
+        checkTrue(test_String_encoding_equality(a,b))
+    }
+
 }


### PR DESCRIPTION
This is for https://github.com/RcppCore/Rcpp/issues/189 . String ctor now uses UTF-8.

There seems much more work if we want to support different encoding in String.

Feel free to close this PR.