### PR TITLE
Alternative syntax for creating vectors and matrices without initializin...

### DIFF
--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -2,7 +2,7 @@
 //
 // Matrix.h: Rcpp R/C++ interface class library -- matrices
 //
-// Copyright (C) 2010 - 2014 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2015 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -55,6 +55,15 @@ public:
     Matrix( const int& nrows_, const int& ncols) : VECTOR( Dimension( nrows_, ncols ) ),
         nrows(nrows_)
     {}
+    
+    /**
+     * bare constructor that does not initialize values
+     * 
+     * @param nrows number of rows
+     * @param ncols number of columns
+     * @return uninitialized matrix of the given dimensions
+     */
+    Matrix( int nrows, int ncols, internal::NamedPlaceHolder ) : VECTOR( Rf_allocMatrix( RTYPE, nrows, ncols ) ){}
 
     template <typename Iterator>
     Matrix( const int& nrows_, const int& ncols, Iterator start ) :

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -2,7 +2,7 @@
 //
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2015 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -87,6 +87,16 @@ public:
         RCPP_DEBUG_2( "Vector<%d>( const int& size = %d, const stored_type& u )", RTYPE, size)
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill( u ) ;
+    }
+    
+    /**
+     * Constructor that does not initialize values
+     *
+     * @param size size of the vector
+     * @return A vector of the given size, with uninitialized values
+     */
+    Vector( int size, internal::NamedPlaceHolder ){
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
     }
 
     // constructor for CharacterVector()

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -2,7 +2,7 @@
 //
 // Vector.cpp: Rcpp R/C++ interface class library -- Vector unit tests
 //
-// Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2015    Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -766,3 +766,14 @@ LogicalVector logical_vector_from_bool_assign() {
 void no_op(int major) {
     int minor = 1;
 }
+
+// [[Rcpp::export]]
+IntegerVector test_bare_vector_ctor(){
+    return IntegerVector(5,_) ;    
+}
+
+// [[Rcpp::export]]
+NumericMatrix test_bare_matrix_ctor(){
+    return NumericMatrix(4,7,_) ;    
+}
+

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -1,7 +1,7 @@
 #!/usr/bin/r -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
-# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -672,6 +672,13 @@ if (.runThisTest) {
 
     test.logical.vector.from.bool.assign <- function() {
         checkIdentical(logical_vector_from_bool_assign(), TRUE)
+    }
+
+    test.bare.ctors <- function(){
+        v <- test_bare_vector_ctor()
+        checkEquals( length(v), 5L )
+        m <- test_bare_matrix_ctor()
+        checkEquals( dim(m), c(4L,7L) )
     }
     
 }


### PR DESCRIPTION
Alternative syntax for creating vectors and matrices without initializin..., e.g.

```
// create a numeric vector of size 5 without initializing the values
// similar to NumericVector x = no_init(5) ;
NumericVector x(5, _) ;

// not initializd matrix
// no equivalent with no_init
// similar to IntegerMatrix m = Rf_allocMatrix( INTSXP, 6, 9 ) ;
IntegerMatrix m(6,9,_) ;
```