### PR TITLE
adds empty() to [const_]string_proxy for more efficient checks for empty strings

### DIFF
--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -93,6 +93,7 @@ namespace internal{
 		inline iterator begin() const { return CHAR( STRING_ELT( *parent, index ) ) ; }
 		inline iterator end() const { return begin() + size() ; }
 		inline int size() const { return strlen( begin() ) ; }
+		inline bool empty() const { return *begin() == '\0' ; }
 		inline reference operator[]( int n ){ return *( begin() + n ) ; }
 
 		bool operator==( const char* other){

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -158,6 +158,7 @@ namespace internal{
 		inline iterator begin() const { return CHAR( STRING_ELT( *parent, index ) ) ; }
 		inline iterator end() const { return begin() + size() ; }
 		inline int size() const { return strlen( begin() ) ; }
+		inline bool empty() const { return *begin() == '\0' ; }
 		inline reference operator[]( int n ){ return *( begin() + n ) ; }
 
 		template <typename UnaryOperator>


### PR DESCRIPTION
Timings from R:
```{r}
f1 <- cppFunction("LogicalVector is_empty(CharacterVector v) {
                     const int n = v.size();
                     LogicalVector e(n);
                     for (int i = 0; i < n; i++)
                       e[i] = v[i].size() == 0;
                     return e;
                  }")

f2 <- cppFunction("LogicalVector is_empty(CharacterVector v) {
                     const int n = v.size();
                     LogicalVector e(n);
                     for (int i = 0; i < n; i++)
                       e[i] = v[i].empty();
                     return e;
                  }")

chars <- rep(paste(rep("x", 100), collapse=""), 10000000)
chars[sample(10000000, 100000)] <- ""

> system.time(f1(chars))
   user  system elapsed 
  0.176   0.000   0.177 
> system.time(f2(chars))
   user  system elapsed 
  0.079   0.001   0.080 
```
Times improve rapidly as the string length gets longer, saving going via a string.