### PR TITLE
Fix memory leaks. closes #286

### DIFF
--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -3,6 +3,7 @@
 // InternalFunction_with_std_function.h: Rcpp R/C++ interface class library -- exposing C++ std::function's
 //
 // Copyright (C) 2014 Christian Authmann
+// Copyright (C) 2015 Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -37,10 +38,8 @@ namespace Rcpp{
 				virtual ~CppFunctionBaseFromStdFunction() {}
 
 				SEXP operator()(SEXP* args) {
-					BEGIN_RCPP
 					auto result = call<RESULT_TYPE, Args...>(fun, args);
 					return Rcpp::module_wrap<RESULT_TYPE>(result);
-					END_RCPP
 				}
 
 			private:
@@ -54,9 +53,7 @@ namespace Rcpp{
 				virtual ~CppFunctionBaseFromStdFunction() {}
 
 				SEXP operator()(SEXP* args) {
-					BEGIN_RCPP
 					call<void, Args...>(fun, args);
-					END_RCPP
 				}
 
 			private:

--- a/inst/include/Rcpp/api/meat/module/Module.h
+++ b/inst/include/Rcpp/api/meat/module/Module.h
@@ -1,6 +1,6 @@
 // Module.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2013 Romain Francois
+// Copyright (C) 2013 - 2015 Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -37,12 +37,10 @@ namespace Rcpp {
 	}
 
     inline CppClass Module::get_class( const std::string& cl ){
-        BEGIN_RCPP
             CLASS_MAP::iterator it = classes.find(cl) ;
             if( it == classes.end() ) throw std::range_error( "no such class" ) ;
             std::string buffer ;
             return CppClass( this, it->second, buffer ) ;
-        END_RCPP
     }
 
 }

--- a/inst/include/Rcpp/macros/xp.h
+++ b/inst/include/Rcpp/macros/xp.h
@@ -2,7 +2,7 @@
 //
 // xp.h: Rcpp R/C++ interface class library -- pre processor help
 //
-// Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2015 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -33,11 +33,11 @@ extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)(){         \
     return info   ;                                            \
 }                                                              \
 extern "C" SEXP __NAME__( SEXP xp ){                           \
-	SEXP res = R_NilValue ;                                    \
 	BEGIN_RCPP                                                 \
+	    SEXP res = R_NilValue ;                                \
 		::Rcpp::XPtr< __CLASS__ > ptr(xp) ;                    \
 		res = ::Rcpp::wrap( ptr->__FIELD__ ) ;                 \
-	return res ;                                               \
+		return res ;                                           \
 	END_RCPP                                                   \
 }
 

--- a/inst/include/Rcpp/module/Module_generated_CppFunction.h
+++ b/inst/include/Rcpp/module/Module_generated_CppFunction.h
@@ -49,6 +49,7 @@ class CppFunction0<void> : public CppFunction {
 
         SEXP operator()(SEXP*) {
             ptr_fun();
+            return R_NilValue ;
         }
 
         inline int nargs() { return 0; }
@@ -85,6 +86,7 @@ class CppFunction_WithFormals0<void> : public CppFunction {
 
         SEXP operator()(SEXP*) {
             ptr_fun() ;
+            return R_NilValue ;
         }
 
         inline int nargs() { return 0; }
@@ -123,6 +125,7 @@ class CppFunction1<void,U0> : public CppFunction {
         SEXP operator()(SEXP* args) {
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 1; }
@@ -167,6 +170,7 @@ class CppFunction_WithFormals1<void,U0> : public CppFunction {
         SEXP operator()(SEXP* args) {
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 1; }
@@ -209,6 +213,7 @@ class CppFunction2<void,U0,U1> : public CppFunction {
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 2; }
@@ -255,6 +260,7 @@ class CppFunction_WithFormals2<void,U0,U1> : public CppFunction {
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 2; }
@@ -299,6 +305,7 @@ class CppFunction3<void,U0,U1,U2> : public CppFunction {
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 3; }
@@ -347,6 +354,7 @@ class CppFunction_WithFormals3<void,U0,U1,U2> : public CppFunction {
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 3; }
@@ -393,6 +401,7 @@ class CppFunction4<void,U0,U1,U2,U3> : public CppFunction {
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 4; }
@@ -443,6 +452,7 @@ class CppFunction_WithFormals4<void,U0,U1,U2,U3> : public CppFunction {
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 4; }
@@ -491,6 +501,7 @@ class CppFunction5<void,U0,U1,U2,U3,U4> : public CppFunction {
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 5; }
@@ -543,6 +554,7 @@ class CppFunction_WithFormals5<void,U0,U1,U2,U3,U4> : public CppFunction {
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 5; }
@@ -647,6 +659,7 @@ class CppFunction_WithFormals6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             ptr_fun(x0,x1,x2,x3,x4,x5);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 6; }
@@ -699,6 +712,7 @@ class CppFunction7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 7; }
@@ -755,6 +769,7 @@ class CppFunction_WithFormals7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 7; }
@@ -809,6 +824,7 @@ class CppFunction8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunction {
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 8; }
@@ -867,6 +883,7 @@ class CppFunction_WithFormals8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunctio
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 8; }
@@ -923,6 +940,7 @@ class CppFunction9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunction {
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 9; }
@@ -983,6 +1001,7 @@ class CppFunction_WithFormals9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunc
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 9; }
@@ -1041,6 +1060,7 @@ class CppFunction10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public CppFunction {
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 10; }
@@ -1103,6 +1123,7 @@ class CppFunction_WithFormals10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public Cpp
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 10; }
@@ -1163,6 +1184,7 @@ class CppFunction11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public CppFunction
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 11; }
@@ -1227,6 +1249,7 @@ class CppFunction_WithFormals11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 11; }
@@ -1289,6 +1312,7 @@ class CppFunction12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : public CppFunc
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 12; }
@@ -1355,6 +1379,7 @@ class CppFunction_WithFormals12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : pu
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 12; }
@@ -1419,6 +1444,7 @@ class CppFunction13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> : public Cpp
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 13; }
@@ -1487,6 +1513,7 @@ class CppFunction_WithFormals13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> 
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 13; }
@@ -1553,6 +1580,7 @@ class CppFunction14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13> : public
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 14; }
@@ -1623,6 +1651,7 @@ class CppFunction_WithFormals14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 14; }
@@ -1691,6 +1720,7 @@ class CppFunction15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14> : pu
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 15; }
@@ -1763,6 +1793,7 @@ class CppFunction_WithFormals15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 15; }
@@ -1833,6 +1864,7 @@ class CppFunction16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15> 
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 16; }
@@ -1907,6 +1939,7 @@ class CppFunction_WithFormals16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 16; }
@@ -1979,6 +2012,7 @@ class CppFunction17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 17; }
@@ -2055,6 +2089,7 @@ class CppFunction_WithFormals17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 17; }
@@ -2129,6 +2164,7 @@ class CppFunction18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 18; }
@@ -2207,6 +2243,7 @@ class CppFunction_WithFormals18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 18; }
@@ -2283,6 +2320,7 @@ class CppFunction19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 19; }
@@ -2363,6 +2401,7 @@ class CppFunction_WithFormals19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 19; }
@@ -2441,6 +2480,7 @@ class CppFunction20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 20; }
@@ -2523,6 +2563,7 @@ class CppFunction_WithFormals20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 20; }
@@ -2603,6 +2644,7 @@ class CppFunction21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 21; }
@@ -2687,6 +2729,7 @@ class CppFunction_WithFormals21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 21; }
@@ -2769,6 +2812,7 @@ class CppFunction22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 22; }
@@ -2855,6 +2899,7 @@ class CppFunction_WithFormals22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 22; }
@@ -2939,6 +2984,7 @@ class CppFunction23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 23; }
@@ -3027,6 +3073,7 @@ class CppFunction_WithFormals23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 23; }
@@ -3113,6 +3160,7 @@ class CppFunction24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 24; }
@@ -3203,6 +3251,7 @@ class CppFunction_WithFormals24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 24; }
@@ -3291,6 +3340,7 @@ class CppFunction25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 25; }
@@ -3383,6 +3433,7 @@ class CppFunction_WithFormals25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 25; }
@@ -3473,6 +3524,7 @@ class CppFunction26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 26; }
@@ -3567,6 +3619,7 @@ class CppFunction_WithFormals26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 26; }
@@ -3659,6 +3712,7 @@ class CppFunction27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 27; }
@@ -3755,6 +3809,7 @@ class CppFunction_WithFormals27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 27; }
@@ -3849,6 +3904,7 @@ class CppFunction28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 28; }
@@ -3947,6 +4003,7 @@ class CppFunction_WithFormals28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 28; }
@@ -4043,6 +4100,7 @@ class CppFunction29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 29; }
@@ -4143,6 +4201,7 @@ class CppFunction_WithFormals29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 29; }
@@ -4241,6 +4300,7 @@ class CppFunction30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 30; }
@@ -4343,6 +4403,7 @@ class CppFunction_WithFormals30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 30; }
@@ -4443,6 +4504,7 @@ class CppFunction31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 31; }
@@ -4547,6 +4609,7 @@ class CppFunction_WithFormals31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 31; }
@@ -4649,6 +4712,7 @@ class CppFunction32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 32; }
@@ -4755,6 +4819,7 @@ class CppFunction_WithFormals32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 32; }
@@ -4859,6 +4924,7 @@ class CppFunction33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 33; }
@@ -4967,6 +5033,7 @@ class CppFunction_WithFormals33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 33; }
@@ -5073,6 +5140,7 @@ class CppFunction34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 34; }
@@ -5183,6 +5251,7 @@ class CppFunction_WithFormals34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 34; }
@@ -5291,6 +5360,7 @@ class CppFunction35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 35; }
@@ -5403,6 +5473,7 @@ class CppFunction_WithFormals35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 35; }
@@ -5513,6 +5584,7 @@ class CppFunction36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 36; }
@@ -5627,6 +5699,7 @@ class CppFunction_WithFormals36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 36; }
@@ -5739,6 +5812,7 @@ class CppFunction37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 37; }
@@ -5855,6 +5929,7 @@ class CppFunction_WithFormals37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 37; }
@@ -5969,6 +6044,7 @@ class CppFunction38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 38; }
@@ -6087,6 +6163,7 @@ class CppFunction_WithFormals38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 38; }
@@ -6203,6 +6280,7 @@ class CppFunction39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 39; }
@@ -6323,6 +6401,7 @@ class CppFunction_WithFormals39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 39; }
@@ -6441,6 +6520,7 @@ class CppFunction40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 40; }
@@ -6563,6 +6643,7 @@ class CppFunction_WithFormals40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 40; }
@@ -6683,6 +6764,7 @@ class CppFunction41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 41; }
@@ -6807,6 +6889,7 @@ class CppFunction_WithFormals41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 41; }
@@ -6929,6 +7012,7 @@ class CppFunction42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 42; }
@@ -7055,6 +7139,7 @@ class CppFunction_WithFormals42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 42; }
@@ -7179,6 +7264,7 @@ class CppFunction43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 43; }
@@ -7307,6 +7393,7 @@ class CppFunction_WithFormals43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 43; }
@@ -7433,6 +7520,7 @@ class CppFunction44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 44; }
@@ -7563,6 +7651,7 @@ class CppFunction_WithFormals44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 44; }
@@ -7691,6 +7780,7 @@ class CppFunction45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 45; }
@@ -7823,6 +7913,7 @@ class CppFunction_WithFormals45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 45; }
@@ -7953,6 +8044,7 @@ class CppFunction46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 46; }
@@ -8087,6 +8179,7 @@ class CppFunction_WithFormals46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 46; }
@@ -8219,6 +8312,7 @@ class CppFunction47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 47; }
@@ -8355,6 +8449,7 @@ class CppFunction_WithFormals47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 47; }
@@ -8489,6 +8584,7 @@ class CppFunction48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 48; }
@@ -8627,6 +8723,7 @@ class CppFunction_WithFormals48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 48; }
@@ -8763,6 +8860,7 @@ class CppFunction49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 49; }
@@ -8903,6 +9001,7 @@ class CppFunction_WithFormals49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 49; }
@@ -9041,6 +9140,7 @@ class CppFunction50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 50; }
@@ -9183,6 +9283,7 @@ class CppFunction_WithFormals50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 50; }
@@ -9323,6 +9424,7 @@ class CppFunction51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 51; }
@@ -9467,6 +9569,7 @@ class CppFunction_WithFormals51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 51; }
@@ -9609,6 +9712,7 @@ class CppFunction52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 52; }
@@ -9755,6 +9859,7 @@ class CppFunction_WithFormals52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 52; }
@@ -9899,6 +10004,7 @@ class CppFunction53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 53; }
@@ -10047,6 +10153,7 @@ class CppFunction_WithFormals53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 53; }
@@ -10193,6 +10300,7 @@ class CppFunction54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 54; }
@@ -10343,6 +10451,7 @@ class CppFunction_WithFormals54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 54; }
@@ -10491,6 +10600,7 @@ class CppFunction55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 55; }
@@ -10643,6 +10753,7 @@ class CppFunction_WithFormals55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 55; }
@@ -10793,6 +10904,7 @@ class CppFunction56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 56; }
@@ -10947,6 +11059,7 @@ class CppFunction_WithFormals56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 56; }
@@ -11099,6 +11212,7 @@ class CppFunction57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 57; }
@@ -11255,6 +11369,7 @@ class CppFunction_WithFormals57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 57; }
@@ -11409,6 +11524,7 @@ class CppFunction58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 58; }
@@ -11567,6 +11683,7 @@ class CppFunction_WithFormals58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 58; }
@@ -11723,6 +11840,7 @@ class CppFunction59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 59; }
@@ -11883,6 +12001,7 @@ class CppFunction_WithFormals59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 59; }
@@ -12041,6 +12160,7 @@ class CppFunction60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 60; }
@@ -12203,6 +12323,7 @@ class CppFunction_WithFormals60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 60; }
@@ -12363,6 +12484,7 @@ class CppFunction61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 61; }
@@ -12527,6 +12649,7 @@ class CppFunction_WithFormals61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 61; }
@@ -12689,6 +12812,7 @@ class CppFunction62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 62; }
@@ -12855,6 +12979,7 @@ class CppFunction_WithFormals62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 62; }
@@ -13019,6 +13144,7 @@ class CppFunction63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 63; }
@@ -13187,6 +13313,7 @@ class CppFunction_WithFormals63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 63; }
@@ -13353,6 +13480,7 @@ class CppFunction64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 64; }
@@ -13523,6 +13651,7 @@ class CppFunction_WithFormals64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 64; }
@@ -13691,6 +13820,7 @@ class CppFunction65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 65; }
@@ -13863,6 +13993,7 @@ class CppFunction_WithFormals65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
+            return R_NilValue ;
         }
 
         inline int nargs() { return 65; }

--- a/inst/include/Rcpp/module/Module_generated_CppFunction.h
+++ b/inst/include/Rcpp/module/Module_generated_CppFunction.h
@@ -3,7 +3,7 @@
 // Module_generated_CppFunction.h: -- generated helper code for Modules
 //                                    see rcpp-scripts repo for generator script
 //
-// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -30,9 +30,7 @@ class CppFunction0 : public CppFunction {
     public:
         CppFunction0(RESULT_TYPE (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
         SEXP operator()(SEXP*) {
-            BEGIN_RCPP
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
-            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -50,9 +48,7 @@ class CppFunction0<void> : public CppFunction {
         CppFunction0(void (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {};
 
         SEXP operator()(SEXP*) {
-            BEGIN_RCPP
             ptr_fun();
-            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -70,9 +66,7 @@ class CppFunction_WithFormals0 : public CppFunction {
     public:
         CppFunction_WithFormals0(RESULT_TYPE (*fun)(void), Rcpp::List,  const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
         SEXP operator()(SEXP*) {
-            BEGIN_RCPP
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
-            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -90,9 +84,7 @@ class CppFunction_WithFormals0<void> : public CppFunction {
         CppFunction_WithFormals0(void (*fun)(void), Rcpp::List, const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {} ;
 
         SEXP operator()(SEXP*) {
-            BEGIN_RCPP
             ptr_fun() ;
-            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -111,10 +103,8 @@ template <typename RESULT_TYPE, typename U0> class CppFunction1 : public CppFunc
         CppFunction1(RESULT_TYPE (*fun)(U0) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0));
-            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -131,10 +121,8 @@ class CppFunction1<void,U0> : public CppFunction {
         CppFunction1(void (*fun)(U0) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
-            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -156,10 +144,8 @@ class CppFunction_WithFormals1 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0));
-            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -179,10 +165,8 @@ class CppFunction_WithFormals1<void,U0> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
-            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -203,11 +187,9 @@ template <typename RESULT_TYPE, typename U0,typename U1> class CppFunction2 : pu
         CppFunction2(RESULT_TYPE (*fun)(U0,U1) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1));
-            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -224,11 +206,9 @@ class CppFunction2<void,U0,U1> : public CppFunction {
         CppFunction2(void (*fun)(U0,U1) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
-            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -250,11 +230,9 @@ class CppFunction_WithFormals2 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1));
-            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -274,11 +252,9 @@ class CppFunction_WithFormals2<void,U0,U1> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
-            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -299,12 +275,10 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2> class CppFu
         CppFunction3(RESULT_TYPE (*fun)(U0,U1,U2) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2));
-            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -321,12 +295,10 @@ class CppFunction3<void,U0,U1,U2> : public CppFunction {
         CppFunction3(void (*fun)(U0,U1,U2) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
-            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -348,12 +320,10 @@ class CppFunction_WithFormals3 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2));
-            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -373,12 +343,10 @@ class CppFunction_WithFormals3<void,U0,U1,U2> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
-            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -399,13 +367,11 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3>
         CppFunction4(RESULT_TYPE (*fun)(U0,U1,U2,U3) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3));
-            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -422,13 +388,11 @@ class CppFunction4<void,U0,U1,U2,U3> : public CppFunction {
         CppFunction4(void (*fun)(U0,U1,U2,U3) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
-            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -450,13 +414,11 @@ class CppFunction_WithFormals4 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3));
-            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -476,13 +438,11 @@ class CppFunction_WithFormals4<void,U0,U1,U2,U3> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
-            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -503,14 +463,12 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction5(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4));
-            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -527,14 +485,12 @@ class CppFunction5<void,U0,U1,U2,U3,U4> : public CppFunction {
         CppFunction5(void (*fun)(U0,U1,U2,U3,U4) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
-            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -556,14 +512,12 @@ class CppFunction_WithFormals5 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4));
-            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -583,14 +537,12 @@ class CppFunction_WithFormals5<void,U0,U1,U2,U3,U4> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
-            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -611,7 +563,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction6(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -619,7 +570,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5));
-            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -636,7 +586,6 @@ class CppFunction6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
         CppFunction6(void (*fun)(U0,U1,U2,U3,U4,U5) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -644,7 +593,6 @@ class CppFunction6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             ptr_fun(x0,x1,x2,x3,x4,x5);
-            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -666,7 +614,6 @@ class CppFunction_WithFormals6 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -674,7 +621,6 @@ class CppFunction_WithFormals6 : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5));
-            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -694,7 +640,6 @@ class CppFunction_WithFormals6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -702,7 +647,6 @@ class CppFunction_WithFormals6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             ptr_fun(x0,x1,x2,x3,x4,x5);
-            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -723,7 +667,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction7(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -732,7 +675,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6));
-            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -749,7 +691,6 @@ class CppFunction7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
         CppFunction7(void (*fun)(U0,U1,U2,U3,U4,U5,U6) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -758,7 +699,6 @@ class CppFunction7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
-            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -780,7 +720,6 @@ class CppFunction_WithFormals7 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -789,7 +728,6 @@ class CppFunction_WithFormals7 : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6));
-            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -809,7 +747,6 @@ class CppFunction_WithFormals7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -818,7 +755,6 @@ class CppFunction_WithFormals7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
-            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -839,7 +775,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction8(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -849,7 +784,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7));
-            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -866,7 +800,6 @@ class CppFunction8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunction {
         CppFunction8(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -876,7 +809,6 @@ class CppFunction8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunction {
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
-            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -898,7 +830,6 @@ class CppFunction_WithFormals8 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -908,7 +839,6 @@ class CppFunction_WithFormals8 : public CppFunction {
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7));
-            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -928,7 +858,6 @@ class CppFunction_WithFormals8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunctio
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -938,7 +867,6 @@ class CppFunction_WithFormals8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunctio
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
-            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -959,7 +887,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction9(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -970,7 +897,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8));
-            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -987,7 +913,6 @@ class CppFunction9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunction {
         CppFunction9(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -998,7 +923,6 @@ class CppFunction9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunction {
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
-            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -1020,7 +944,6 @@ class CppFunction_WithFormals9 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1031,7 +954,6 @@ class CppFunction_WithFormals9 : public CppFunction {
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8));
-            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -1051,7 +973,6 @@ class CppFunction_WithFormals9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunc
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1062,7 +983,6 @@ class CppFunction_WithFormals9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunc
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
-            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -1083,7 +1003,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction10(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1095,7 +1014,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9));
-            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1112,7 +1030,6 @@ class CppFunction10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public CppFunction {
         CppFunction10(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1124,7 +1041,6 @@ class CppFunction10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public CppFunction {
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
-            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1146,7 +1062,6 @@ class CppFunction_WithFormals10 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1158,7 +1073,6 @@ class CppFunction_WithFormals10 : public CppFunction {
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9));
-            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1178,7 +1092,6 @@ class CppFunction_WithFormals10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public Cpp
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1190,7 +1103,6 @@ class CppFunction_WithFormals10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public Cpp
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
-            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1211,7 +1123,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction11(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1224,7 +1135,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10));
-            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1241,7 +1151,6 @@ class CppFunction11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public CppFunction
         CppFunction11(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1254,7 +1163,6 @@ class CppFunction11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public CppFunction
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
-            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1276,7 +1184,6 @@ class CppFunction_WithFormals11 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1289,7 +1196,6 @@ class CppFunction_WithFormals11 : public CppFunction {
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10));
-            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1309,7 +1215,6 @@ class CppFunction_WithFormals11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1322,7 +1227,6 @@ class CppFunction_WithFormals11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
-            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1343,7 +1247,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction12(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1357,7 +1260,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11));
-            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1374,7 +1276,6 @@ class CppFunction12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : public CppFunc
         CppFunction12(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1388,7 +1289,6 @@ class CppFunction12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : public CppFunc
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
-            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1410,7 +1310,6 @@ class CppFunction_WithFormals12 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1424,7 +1323,6 @@ class CppFunction_WithFormals12 : public CppFunction {
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11));
-            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1444,7 +1342,6 @@ class CppFunction_WithFormals12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : pu
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1458,7 +1355,6 @@ class CppFunction_WithFormals12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : pu
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
-            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1479,7 +1375,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction13(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1494,7 +1389,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12));
-            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1511,7 +1405,6 @@ class CppFunction13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> : public Cpp
         CppFunction13(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1526,7 +1419,6 @@ class CppFunction13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> : public Cpp
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
-            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1548,7 +1440,6 @@ class CppFunction_WithFormals13 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1563,7 +1454,6 @@ class CppFunction_WithFormals13 : public CppFunction {
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12));
-            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1583,7 +1473,6 @@ class CppFunction_WithFormals13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> 
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1598,7 +1487,6 @@ class CppFunction_WithFormals13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> 
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
-            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1619,7 +1507,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction14(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1635,7 +1522,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13));
-            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1652,7 +1538,6 @@ class CppFunction14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13> : public
         CppFunction14(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1668,7 +1553,6 @@ class CppFunction14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13> : public
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
-            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1690,7 +1574,6 @@ class CppFunction_WithFormals14 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1706,7 +1589,6 @@ class CppFunction_WithFormals14 : public CppFunction {
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13));
-            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1726,7 +1608,6 @@ class CppFunction_WithFormals14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1742,7 +1623,6 @@ class CppFunction_WithFormals14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
-            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1763,7 +1643,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction15(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1780,7 +1659,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14));
-            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1797,7 +1675,6 @@ class CppFunction15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14> : pu
         CppFunction15(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1814,7 +1691,6 @@ class CppFunction15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14> : pu
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
-            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1836,7 +1712,6 @@ class CppFunction_WithFormals15 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1853,7 +1728,6 @@ class CppFunction_WithFormals15 : public CppFunction {
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14));
-            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1873,7 +1747,6 @@ class CppFunction_WithFormals15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1890,7 +1763,6 @@ class CppFunction_WithFormals15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
-            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1911,7 +1783,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction16(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1929,7 +1800,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15));
-            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1946,7 +1816,6 @@ class CppFunction16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15> 
         CppFunction16(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1964,7 +1833,6 @@ class CppFunction16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15> 
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
-            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1986,7 +1854,6 @@ class CppFunction_WithFormals16 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2004,7 +1871,6 @@ class CppFunction_WithFormals16 : public CppFunction {
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15));
-            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -2024,7 +1890,6 @@ class CppFunction_WithFormals16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2042,7 +1907,6 @@ class CppFunction_WithFormals16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
-            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -2063,7 +1927,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction17(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2082,7 +1945,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16));
-            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2099,7 +1961,6 @@ class CppFunction17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction17(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2118,7 +1979,6 @@ class CppFunction17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
-            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2140,7 +2000,6 @@ class CppFunction_WithFormals17 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2159,7 +2018,6 @@ class CppFunction_WithFormals17 : public CppFunction {
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16));
-            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2179,7 +2037,6 @@ class CppFunction_WithFormals17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2198,7 +2055,6 @@ class CppFunction_WithFormals17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
-            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2219,7 +2075,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction18(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2239,7 +2094,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17));
-            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2256,7 +2110,6 @@ class CppFunction18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction18(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2276,7 +2129,6 @@ class CppFunction18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
-            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2298,7 +2150,6 @@ class CppFunction_WithFormals18 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2318,7 +2169,6 @@ class CppFunction_WithFormals18 : public CppFunction {
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17));
-            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2338,7 +2188,6 @@ class CppFunction_WithFormals18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2358,7 +2207,6 @@ class CppFunction_WithFormals18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
-            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2379,7 +2227,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction19(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2400,7 +2247,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18));
-            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2417,7 +2263,6 @@ class CppFunction19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction19(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2438,7 +2283,6 @@ class CppFunction19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
-            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2460,7 +2304,6 @@ class CppFunction_WithFormals19 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2481,7 +2324,6 @@ class CppFunction_WithFormals19 : public CppFunction {
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18));
-            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2501,7 +2343,6 @@ class CppFunction_WithFormals19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2522,7 +2363,6 @@ class CppFunction_WithFormals19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
-            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2543,7 +2383,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction20(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2565,7 +2404,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19));
-            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2582,7 +2420,6 @@ class CppFunction20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction20(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2604,7 +2441,6 @@ class CppFunction20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
-            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2626,7 +2462,6 @@ class CppFunction_WithFormals20 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2648,7 +2483,6 @@ class CppFunction_WithFormals20 : public CppFunction {
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19));
-            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2668,7 +2502,6 @@ class CppFunction_WithFormals20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2690,7 +2523,6 @@ class CppFunction_WithFormals20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
-            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2711,7 +2543,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction21(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2734,7 +2565,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20));
-            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2751,7 +2581,6 @@ class CppFunction21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction21(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2774,7 +2603,6 @@ class CppFunction21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
-            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2796,7 +2624,6 @@ class CppFunction_WithFormals21 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2819,7 +2646,6 @@ class CppFunction_WithFormals21 : public CppFunction {
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20));
-            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2839,7 +2665,6 @@ class CppFunction_WithFormals21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2862,7 +2687,6 @@ class CppFunction_WithFormals21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
-            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2883,7 +2707,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction22(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2907,7 +2730,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21));
-            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2924,7 +2746,6 @@ class CppFunction22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction22(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2948,7 +2769,6 @@ class CppFunction22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
-            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2970,7 +2790,6 @@ class CppFunction_WithFormals22 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2994,7 +2813,6 @@ class CppFunction_WithFormals22 : public CppFunction {
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21));
-            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -3014,7 +2832,6 @@ class CppFunction_WithFormals22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3038,7 +2855,6 @@ class CppFunction_WithFormals22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
-            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -3059,7 +2875,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction23(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3084,7 +2899,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22));
-            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3101,7 +2915,6 @@ class CppFunction23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction23(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3126,7 +2939,6 @@ class CppFunction23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
-            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3148,7 +2960,6 @@ class CppFunction_WithFormals23 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3173,7 +2984,6 @@ class CppFunction_WithFormals23 : public CppFunction {
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22));
-            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3193,7 +3003,6 @@ class CppFunction_WithFormals23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3218,7 +3027,6 @@ class CppFunction_WithFormals23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
-            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3239,7 +3047,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction24(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3265,7 +3072,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23));
-            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3282,7 +3088,6 @@ class CppFunction24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction24(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3308,7 +3113,6 @@ class CppFunction24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
-            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3330,7 +3134,6 @@ class CppFunction_WithFormals24 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3356,7 +3159,6 @@ class CppFunction_WithFormals24 : public CppFunction {
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23));
-            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3376,7 +3178,6 @@ class CppFunction_WithFormals24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3402,7 +3203,6 @@ class CppFunction_WithFormals24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
-            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3423,7 +3223,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction25(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3450,7 +3249,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24));
-            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3467,7 +3265,6 @@ class CppFunction25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction25(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3494,7 +3291,6 @@ class CppFunction25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
-            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3516,7 +3312,6 @@ class CppFunction_WithFormals25 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3543,7 +3338,6 @@ class CppFunction_WithFormals25 : public CppFunction {
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24));
-            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3563,7 +3357,6 @@ class CppFunction_WithFormals25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3590,7 +3383,6 @@ class CppFunction_WithFormals25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
-            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3611,7 +3403,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction26(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3639,7 +3430,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25));
-            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3656,7 +3446,6 @@ class CppFunction26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction26(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3684,7 +3473,6 @@ class CppFunction26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
-            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3706,7 +3494,6 @@ class CppFunction_WithFormals26 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3734,7 +3521,6 @@ class CppFunction_WithFormals26 : public CppFunction {
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25));
-            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3754,7 +3540,6 @@ class CppFunction_WithFormals26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3782,7 +3567,6 @@ class CppFunction_WithFormals26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
-            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3803,7 +3587,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction27(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3832,7 +3615,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26));
-            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3849,7 +3631,6 @@ class CppFunction27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction27(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3878,7 +3659,6 @@ class CppFunction27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
-            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3900,7 +3680,6 @@ class CppFunction_WithFormals27 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3929,7 +3708,6 @@ class CppFunction_WithFormals27 : public CppFunction {
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26));
-            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3949,7 +3727,6 @@ class CppFunction_WithFormals27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3978,7 +3755,6 @@ class CppFunction_WithFormals27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
-            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3999,7 +3775,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction28(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4029,7 +3804,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27));
-            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -4046,7 +3820,6 @@ class CppFunction28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction28(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4076,7 +3849,6 @@ class CppFunction28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
-            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -4098,7 +3870,6 @@ class CppFunction_WithFormals28 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4128,7 +3899,6 @@ class CppFunction_WithFormals28 : public CppFunction {
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27));
-            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -4148,7 +3918,6 @@ class CppFunction_WithFormals28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4178,7 +3947,6 @@ class CppFunction_WithFormals28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
-            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -4199,7 +3967,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction29(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4230,7 +3997,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28));
-            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4247,7 +4013,6 @@ class CppFunction29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction29(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4278,7 +4043,6 @@ class CppFunction29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
-            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4300,7 +4064,6 @@ class CppFunction_WithFormals29 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4331,7 +4094,6 @@ class CppFunction_WithFormals29 : public CppFunction {
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28));
-            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4351,7 +4113,6 @@ class CppFunction_WithFormals29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4382,7 +4143,6 @@ class CppFunction_WithFormals29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
-            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4403,7 +4163,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction30(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4435,7 +4194,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29));
-            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4452,7 +4210,6 @@ class CppFunction30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction30(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4484,7 +4241,6 @@ class CppFunction30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
-            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4506,7 +4262,6 @@ class CppFunction_WithFormals30 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4538,7 +4293,6 @@ class CppFunction_WithFormals30 : public CppFunction {
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29));
-            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4558,7 +4312,6 @@ class CppFunction_WithFormals30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4590,7 +4343,6 @@ class CppFunction_WithFormals30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
-            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4611,7 +4363,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction31(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4644,7 +4395,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30));
-            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4661,7 +4411,6 @@ class CppFunction31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction31(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4694,7 +4443,6 @@ class CppFunction31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
-            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4716,7 +4464,6 @@ class CppFunction_WithFormals31 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4749,7 +4496,6 @@ class CppFunction_WithFormals31 : public CppFunction {
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30));
-            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4769,7 +4515,6 @@ class CppFunction_WithFormals31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4802,7 +4547,6 @@ class CppFunction_WithFormals31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
-            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4823,7 +4567,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction32(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4857,7 +4600,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31));
-            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4874,7 +4616,6 @@ class CppFunction32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction32(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4908,7 +4649,6 @@ class CppFunction32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
-            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4930,7 +4670,6 @@ class CppFunction_WithFormals32 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4964,7 +4703,6 @@ class CppFunction_WithFormals32 : public CppFunction {
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31));
-            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4984,7 +4722,6 @@ class CppFunction_WithFormals32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5018,7 +4755,6 @@ class CppFunction_WithFormals32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
-            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -5039,7 +4775,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction33(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5074,7 +4809,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32));
-            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5091,7 +4825,6 @@ class CppFunction33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction33(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5126,7 +4859,6 @@ class CppFunction33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
-            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5148,7 +4880,6 @@ class CppFunction_WithFormals33 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5183,7 +4914,6 @@ class CppFunction_WithFormals33 : public CppFunction {
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32));
-            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5203,7 +4933,6 @@ class CppFunction_WithFormals33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5238,7 +4967,6 @@ class CppFunction_WithFormals33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
-            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5259,7 +4987,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction34(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5295,7 +5022,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33));
-            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5312,7 +5038,6 @@ class CppFunction34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction34(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5348,7 +5073,6 @@ class CppFunction34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
-            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5370,7 +5094,6 @@ class CppFunction_WithFormals34 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5406,7 +5129,6 @@ class CppFunction_WithFormals34 : public CppFunction {
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33));
-            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5426,7 +5148,6 @@ class CppFunction_WithFormals34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5462,7 +5183,6 @@ class CppFunction_WithFormals34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
-            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5483,7 +5203,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction35(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5520,7 +5239,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34));
-            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5537,7 +5255,6 @@ class CppFunction35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction35(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5574,7 +5291,6 @@ class CppFunction35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
-            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5596,7 +5312,6 @@ class CppFunction_WithFormals35 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5633,7 +5348,6 @@ class CppFunction_WithFormals35 : public CppFunction {
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34));
-            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5653,7 +5367,6 @@ class CppFunction_WithFormals35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5690,7 +5403,6 @@ class CppFunction_WithFormals35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
-            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5711,7 +5423,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction36(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5749,7 +5460,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35));
-            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5766,7 +5476,6 @@ class CppFunction36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction36(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5804,7 +5513,6 @@ class CppFunction36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
-            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5826,7 +5534,6 @@ class CppFunction_WithFormals36 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5864,7 +5571,6 @@ class CppFunction_WithFormals36 : public CppFunction {
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35));
-            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5884,7 +5590,6 @@ class CppFunction_WithFormals36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5922,7 +5627,6 @@ class CppFunction_WithFormals36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
-            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5943,7 +5647,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction37(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5982,7 +5685,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36));
-            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -5999,7 +5701,6 @@ class CppFunction37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction37(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6038,7 +5739,6 @@ class CppFunction37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
-            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -6060,7 +5760,6 @@ class CppFunction_WithFormals37 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6099,7 +5798,6 @@ class CppFunction_WithFormals37 : public CppFunction {
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36));
-            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -6119,7 +5817,6 @@ class CppFunction_WithFormals37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6158,7 +5855,6 @@ class CppFunction_WithFormals37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
-            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -6179,7 +5875,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction38(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6219,7 +5914,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37));
-            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6236,7 +5930,6 @@ class CppFunction38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction38(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6276,7 +5969,6 @@ class CppFunction38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
-            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6298,7 +5990,6 @@ class CppFunction_WithFormals38 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6338,7 +6029,6 @@ class CppFunction_WithFormals38 : public CppFunction {
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37));
-            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6358,7 +6048,6 @@ class CppFunction_WithFormals38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6398,7 +6087,6 @@ class CppFunction_WithFormals38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
-            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6419,7 +6107,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction39(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6460,7 +6147,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38));
-            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6477,7 +6163,6 @@ class CppFunction39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction39(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6518,7 +6203,6 @@ class CppFunction39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
-            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6540,7 +6224,6 @@ class CppFunction_WithFormals39 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6581,7 +6264,6 @@ class CppFunction_WithFormals39 : public CppFunction {
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38));
-            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6601,7 +6283,6 @@ class CppFunction_WithFormals39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6642,7 +6323,6 @@ class CppFunction_WithFormals39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
-            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6663,7 +6343,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction40(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6705,7 +6384,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39));
-            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6722,7 +6400,6 @@ class CppFunction40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction40(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6764,7 +6441,6 @@ class CppFunction40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
-            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6786,7 +6462,6 @@ class CppFunction_WithFormals40 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6828,7 +6503,6 @@ class CppFunction_WithFormals40 : public CppFunction {
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39));
-            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6848,7 +6522,6 @@ class CppFunction_WithFormals40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6890,7 +6563,6 @@ class CppFunction_WithFormals40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
-            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6911,7 +6583,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction41(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6954,7 +6625,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40));
-            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -6971,7 +6641,6 @@ class CppFunction41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction41(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7014,7 +6683,6 @@ class CppFunction41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
-            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -7036,7 +6704,6 @@ class CppFunction_WithFormals41 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7079,7 +6746,6 @@ class CppFunction_WithFormals41 : public CppFunction {
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40));
-            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -7099,7 +6765,6 @@ class CppFunction_WithFormals41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7142,7 +6807,6 @@ class CppFunction_WithFormals41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
-            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -7163,7 +6827,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction42(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7207,7 +6870,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41));
-            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7224,7 +6886,6 @@ class CppFunction42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction42(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7268,7 +6929,6 @@ class CppFunction42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
-            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7290,7 +6950,6 @@ class CppFunction_WithFormals42 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7334,7 +6993,6 @@ class CppFunction_WithFormals42 : public CppFunction {
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41));
-            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7354,7 +7012,6 @@ class CppFunction_WithFormals42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7398,7 +7055,6 @@ class CppFunction_WithFormals42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
-            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7419,7 +7075,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction43(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7464,7 +7119,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42));
-            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7481,7 +7135,6 @@ class CppFunction43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction43(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7526,7 +7179,6 @@ class CppFunction43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
-            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7548,7 +7200,6 @@ class CppFunction_WithFormals43 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7593,7 +7244,6 @@ class CppFunction_WithFormals43 : public CppFunction {
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42));
-            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7613,7 +7263,6 @@ class CppFunction_WithFormals43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7658,7 +7307,6 @@ class CppFunction_WithFormals43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
-            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7679,7 +7327,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction44(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7725,7 +7372,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43));
-            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7742,7 +7388,6 @@ class CppFunction44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction44(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7788,7 +7433,6 @@ class CppFunction44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
-            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7810,7 +7454,6 @@ class CppFunction_WithFormals44 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7856,7 +7499,6 @@ class CppFunction_WithFormals44 : public CppFunction {
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43));
-            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7876,7 +7518,6 @@ class CppFunction_WithFormals44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7922,7 +7563,6 @@ class CppFunction_WithFormals44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
-            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7943,7 +7583,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction45(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7990,7 +7629,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44));
-            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -8007,7 +7645,6 @@ class CppFunction45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction45(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8054,7 +7691,6 @@ class CppFunction45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
-            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -8076,7 +7712,6 @@ class CppFunction_WithFormals45 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8123,7 +7758,6 @@ class CppFunction_WithFormals45 : public CppFunction {
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44));
-            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -8143,7 +7777,6 @@ class CppFunction_WithFormals45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8190,7 +7823,6 @@ class CppFunction_WithFormals45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
-            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -8211,7 +7843,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction46(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8259,7 +7890,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45));
-            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8276,7 +7906,6 @@ class CppFunction46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction46(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8324,7 +7953,6 @@ class CppFunction46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
-            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8346,7 +7974,6 @@ class CppFunction_WithFormals46 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8394,7 +8021,6 @@ class CppFunction_WithFormals46 : public CppFunction {
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45));
-            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8414,7 +8040,6 @@ class CppFunction_WithFormals46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8462,7 +8087,6 @@ class CppFunction_WithFormals46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
-            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8483,7 +8107,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction47(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8532,7 +8155,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46));
-            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8549,7 +8171,6 @@ class CppFunction47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction47(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8598,7 +8219,6 @@ class CppFunction47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
-            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8620,7 +8240,6 @@ class CppFunction_WithFormals47 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8669,7 +8288,6 @@ class CppFunction_WithFormals47 : public CppFunction {
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46));
-            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8689,7 +8307,6 @@ class CppFunction_WithFormals47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8738,7 +8355,6 @@ class CppFunction_WithFormals47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
-            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8759,7 +8375,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction48(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8809,7 +8424,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47));
-            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8826,7 +8440,6 @@ class CppFunction48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction48(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8876,7 +8489,6 @@ class CppFunction48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
-            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8898,7 +8510,6 @@ class CppFunction_WithFormals48 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8948,7 +8559,6 @@ class CppFunction_WithFormals48 : public CppFunction {
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47));
-            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8968,7 +8578,6 @@ class CppFunction_WithFormals48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9018,7 +8627,6 @@ class CppFunction_WithFormals48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
-            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -9039,7 +8647,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction49(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9090,7 +8697,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48));
-            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -9107,7 +8713,6 @@ class CppFunction49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction49(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9158,7 +8763,6 @@ class CppFunction49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
-            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -9180,7 +8784,6 @@ class CppFunction_WithFormals49 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9231,7 +8834,6 @@ class CppFunction_WithFormals49 : public CppFunction {
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48));
-            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -9251,7 +8853,6 @@ class CppFunction_WithFormals49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9302,7 +8903,6 @@ class CppFunction_WithFormals49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
-            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -9323,7 +8923,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction50(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9375,7 +8974,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49));
-            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9392,7 +8990,6 @@ class CppFunction50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction50(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9444,7 +9041,6 @@ class CppFunction50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
-            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9466,7 +9062,6 @@ class CppFunction_WithFormals50 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9518,7 +9113,6 @@ class CppFunction_WithFormals50 : public CppFunction {
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49));
-            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9538,7 +9132,6 @@ class CppFunction_WithFormals50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9590,7 +9183,6 @@ class CppFunction_WithFormals50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
-            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9611,7 +9203,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction51(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9664,7 +9255,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50));
-            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9681,7 +9271,6 @@ class CppFunction51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction51(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9734,7 +9323,6 @@ class CppFunction51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
-            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9756,7 +9344,6 @@ class CppFunction_WithFormals51 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9809,7 +9396,6 @@ class CppFunction_WithFormals51 : public CppFunction {
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50));
-            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9829,7 +9415,6 @@ class CppFunction_WithFormals51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9882,7 +9467,6 @@ class CppFunction_WithFormals51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
-            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9903,7 +9487,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction52(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9957,7 +9540,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51));
-            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -9974,7 +9556,6 @@ class CppFunction52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction52(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10028,7 +9609,6 @@ class CppFunction52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
-            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -10050,7 +9630,6 @@ class CppFunction_WithFormals52 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10104,7 +9683,6 @@ class CppFunction_WithFormals52 : public CppFunction {
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51));
-            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -10124,7 +9702,6 @@ class CppFunction_WithFormals52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10178,7 +9755,6 @@ class CppFunction_WithFormals52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
-            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -10199,7 +9775,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction53(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10254,7 +9829,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52));
-            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10271,7 +9845,6 @@ class CppFunction53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction53(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10326,7 +9899,6 @@ class CppFunction53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
-            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10348,7 +9920,6 @@ class CppFunction_WithFormals53 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10403,7 +9974,6 @@ class CppFunction_WithFormals53 : public CppFunction {
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52));
-            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10423,7 +9993,6 @@ class CppFunction_WithFormals53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10478,7 +10047,6 @@ class CppFunction_WithFormals53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
-            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10499,7 +10067,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction54(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10555,7 +10122,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53));
-            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10572,7 +10138,6 @@ class CppFunction54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction54(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10628,7 +10193,6 @@ class CppFunction54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
-            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10650,7 +10214,6 @@ class CppFunction_WithFormals54 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10706,7 +10269,6 @@ class CppFunction_WithFormals54 : public CppFunction {
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53));
-            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10726,7 +10288,6 @@ class CppFunction_WithFormals54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10782,7 +10343,6 @@ class CppFunction_WithFormals54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
-            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10803,7 +10363,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction55(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10860,7 +10419,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54));
-            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10877,7 +10435,6 @@ class CppFunction55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction55(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10934,7 +10491,6 @@ class CppFunction55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
-            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10956,7 +10512,6 @@ class CppFunction_WithFormals55 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11013,7 +10568,6 @@ class CppFunction_WithFormals55 : public CppFunction {
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54));
-            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -11033,7 +10587,6 @@ class CppFunction_WithFormals55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11090,7 +10643,6 @@ class CppFunction_WithFormals55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
-            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -11111,7 +10663,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction56(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11169,7 +10720,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55));
-            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11186,7 +10736,6 @@ class CppFunction56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction56(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11244,7 +10793,6 @@ class CppFunction56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
-            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11266,7 +10814,6 @@ class CppFunction_WithFormals56 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11324,7 +10871,6 @@ class CppFunction_WithFormals56 : public CppFunction {
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55));
-            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11344,7 +10890,6 @@ class CppFunction_WithFormals56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11402,7 +10947,6 @@ class CppFunction_WithFormals56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
-            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11423,7 +10967,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction57(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11482,7 +11025,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56));
-            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11499,7 +11041,6 @@ class CppFunction57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction57(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11558,7 +11099,6 @@ class CppFunction57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
-            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11580,7 +11120,6 @@ class CppFunction_WithFormals57 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11639,7 +11178,6 @@ class CppFunction_WithFormals57 : public CppFunction {
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56));
-            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11659,7 +11197,6 @@ class CppFunction_WithFormals57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11718,7 +11255,6 @@ class CppFunction_WithFormals57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
-            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11739,7 +11275,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction58(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11799,7 +11334,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57));
-            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11816,7 +11350,6 @@ class CppFunction58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction58(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11876,7 +11409,6 @@ class CppFunction58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
-            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11898,7 +11430,6 @@ class CppFunction_WithFormals58 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11958,7 +11489,6 @@ class CppFunction_WithFormals58 : public CppFunction {
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57));
-            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11978,7 +11508,6 @@ class CppFunction_WithFormals58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12038,7 +11567,6 @@ class CppFunction_WithFormals58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
-            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -12059,7 +11587,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction59(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12120,7 +11647,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58));
-            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -12137,7 +11663,6 @@ class CppFunction59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction59(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12198,7 +11723,6 @@ class CppFunction59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
-            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -12220,7 +11744,6 @@ class CppFunction_WithFormals59 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12281,7 +11804,6 @@ class CppFunction_WithFormals59 : public CppFunction {
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58));
-            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -12301,7 +11823,6 @@ class CppFunction_WithFormals59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12362,7 +11883,6 @@ class CppFunction_WithFormals59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
-            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -12383,7 +11903,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction60(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12445,7 +11964,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59));
-            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12462,7 +11980,6 @@ class CppFunction60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction60(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12524,7 +12041,6 @@ class CppFunction60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
-            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12546,7 +12062,6 @@ class CppFunction_WithFormals60 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12608,7 +12123,6 @@ class CppFunction_WithFormals60 : public CppFunction {
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59));
-            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12628,7 +12142,6 @@ class CppFunction_WithFormals60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12690,7 +12203,6 @@ class CppFunction_WithFormals60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
-            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12711,7 +12223,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction61(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12774,7 +12285,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60));
-            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12791,7 +12301,6 @@ class CppFunction61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction61(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12854,7 +12363,6 @@ class CppFunction61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
-            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12876,7 +12384,6 @@ class CppFunction_WithFormals61 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12939,7 +12446,6 @@ class CppFunction_WithFormals61 : public CppFunction {
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60));
-            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12959,7 +12465,6 @@ class CppFunction_WithFormals61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13022,7 +12527,6 @@ class CppFunction_WithFormals61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
-            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -13043,7 +12547,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction62(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13107,7 +12610,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61));
-            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -13124,7 +12626,6 @@ class CppFunction62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction62(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13188,7 +12689,6 @@ class CppFunction62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
-            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -13210,7 +12710,6 @@ class CppFunction_WithFormals62 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13274,7 +12773,6 @@ class CppFunction_WithFormals62 : public CppFunction {
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61));
-            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -13294,7 +12792,6 @@ class CppFunction_WithFormals62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13358,7 +12855,6 @@ class CppFunction_WithFormals62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
-            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -13379,7 +12875,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction63(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13444,7 +12939,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62));
-            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13461,7 +12955,6 @@ class CppFunction63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction63(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13526,7 +13019,6 @@ class CppFunction63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
-            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13548,7 +13040,6 @@ class CppFunction_WithFormals63 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13613,7 +13104,6 @@ class CppFunction_WithFormals63 : public CppFunction {
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62));
-            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13633,7 +13123,6 @@ class CppFunction_WithFormals63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13698,7 +13187,6 @@ class CppFunction_WithFormals63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
-            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13719,7 +13207,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction64(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13785,7 +13272,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63));
-            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13802,7 +13288,6 @@ class CppFunction64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction64(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13868,7 +13353,6 @@ class CppFunction64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
-            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13890,7 +13374,6 @@ class CppFunction_WithFormals64 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13956,7 +13439,6 @@ class CppFunction_WithFormals64 : public CppFunction {
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63));
-            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13976,7 +13458,6 @@ class CppFunction_WithFormals64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -14042,7 +13523,6 @@ class CppFunction_WithFormals64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
-            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -14063,7 +13543,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction65(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63,U64) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -14130,7 +13609,6 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64));
-            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -14147,7 +13625,6 @@ class CppFunction65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction65(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63,U64) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -14214,7 +13691,6 @@ class CppFunction65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
-            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -14236,7 +13712,6 @@ class CppFunction_WithFormals65 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -14303,7 +13778,6 @@ class CppFunction_WithFormals65 : public CppFunction {
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64));
-            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -14323,7 +13797,6 @@ class CppFunction_WithFormals65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
-            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -14390,7 +13863,6 @@ class CppFunction_WithFormals65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
-            END_RCPP
         }
 
         inline int nargs() { return 65; }

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -121,8 +121,7 @@
         }
 
         SEXP newInstance( SEXP* args, int nargs ){
-            BEGIN_RCPP
-                signed_constructor_class* p ;
+            signed_constructor_class* p ;
             int n = constructors.size() ;
             for( int i=0; i<n; i++ ){
                 p = constructors[i];
@@ -132,7 +131,7 @@
                     return XP( ptr, true ) ;
                 }
             }
-
+            
             signed_factory_class* pfact ;
             n = factories.size() ;
             for( int i=0; i<n; i++){
@@ -143,10 +142,9 @@
                 return XP( ptr, true ) ;
               }
             }
-
+            
             throw std::range_error( "no valid constructor available for the argument list" ) ;
-            END_RCPP
-                }
+        }
 
         bool has_default_constructor(){
             int n = constructors.size() ;
@@ -165,9 +163,7 @@
         }
 
         SEXP invoke( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            BEGIN_RCPP
-
-                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -188,13 +184,10 @@
             } else {
                 return Rcpp::List::create( false, m->operator()( XP(object), args ) ) ;
             }
-            END_RCPP
-                }
+        }
 
         SEXP invoke_void( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            BEGIN_RCPP
-
-                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -210,13 +203,10 @@
                 throw std::range_error( "could not find valid method" ) ;
             }
             m->operator()( XP(object), args );
-            END_RCPP
-                }
+        }
 
         SEXP invoke_notvoid( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            BEGIN_RCPP
-
-                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -232,8 +222,7 @@
                 throw std::range_error( "could not find valid method" ) ;
             }
             return m->operator()( XP(object), args ) ;
-            END_RCPP
-                }
+        }
 
 
         self& AddMethod( const char* name_, method_class* m, ValidMethod valid = &yes, const char* docstring = 0){
@@ -392,18 +381,14 @@
         }
 
         SEXP getProperty( SEXP field_xp , SEXP object) {
-            BEGIN_RCPP
-                prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
+            prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
             return prop->get( XP(object) );
-            END_RCPP
-                }
+        }
 
         void setProperty( SEXP field_xp, SEXP object, SEXP value)  {
-            BEGIN_RCPP
-                prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
+            prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
             return prop->set( XP(object), value );
-            VOID_END_RCPP
-                }
+        }
 
 
         Rcpp::List fields( const XP_Class& class_xp ){

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -203,6 +203,7 @@
                 throw std::range_error( "could not find valid method" ) ;
             }
             m->operator()( XP(object), args );
+            return R_NilValue ;
         }
 
         SEXP invoke_notvoid( SEXP method_xp, SEXP object, SEXP *args, int nargs ){

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -135,18 +135,20 @@ END_RCPP
 }
 
 SEXP class__newInstance(SEXP args) {
+BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	XP_Module module(CAR(p)); p = CDR(p);
 	XP_Class clazz(CAR(p)); p = CDR(p);
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 	return clazz->newInstance(cargs, nargs);
+END_RCPP
 }
 
 // relies on being set in .onLoad()
 SEXP rcpp_dummy_pointer = R_NilValue;
 
-#define CHECK_DUMMY_OBJ(p) if (p == rcpp_dummy_pointer) forward_exception_to_r(Rcpp::not_initialized())
+#define CHECK_DUMMY_OBJ(p) if (p == rcpp_dummy_pointer) throw Rcpp::not_initialized()
 
 
 SEXP class__dummyInstance(SEXP args) {
@@ -164,6 +166,7 @@ SEXP class__dummyInstance(SEXP args) {
 }
 
 SEXP CppMethod__invoke(SEXP args) {
+BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -178,11 +181,13 @@ SEXP CppMethod__invoke(SEXP args) {
 
 	// additional arguments, processed the same way as .Call does
 	UNPACK_EXTERNAL_ARGS(cargs,p)
-
+	
    	return clazz->invoke(met, obj, cargs, nargs);
+END_RCPP
 }
 
 SEXP CppMethod__invoke_void(SEXP args) {
+BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -199,9 +204,11 @@ SEXP CppMethod__invoke_void(SEXP args) {
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 	clazz->invoke_void(met, obj, cargs, nargs);
    	return R_NilValue;
+END_RCPP
 }
 
 SEXP CppMethod__invoke_notvoid(SEXP args) {
+BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -218,6 +225,7 @@ SEXP CppMethod__invoke_notvoid(SEXP args) {
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 
    	return clazz->invoke_notvoid(met, obj, cargs, nargs);
+END_RCPP
 }
 
 namespace Rcpp{


### PR DESCRIPTION
This is mainly a fix to `BEGIN_RCPP` and `END_RCPP` to delay the call to `stop` when there are no longer any C++ objects on the stack, including exceptions which were not properly destroyed before. 

With this, I get: 

```
$ R -d "valgrind --tool=memcheck --leak-check=full" --vanilla < /tmp/test.R
==83673== Memcheck, a memory error detector
==83673== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==83673== Using Valgrind-3.10.0.SVN and LibVEX; rerun with -h for copyright info
==83673== Command: /usr/lib/R/bin/exec/R --vanilla
==83673==

R version 3.1.3 (2015-03-09) -- "Smooth Sidewalk"
Copyright (C) 2015 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> Rcpp::sourceCpp( "/tmp/test.cpp")

> foo()
Error in eval(expr, envir, enclos) : foo bar
Calls: <Anonymous> ... source -> withVisible -> eval -> eval -> foo -> <Anonymous>
Execution halted
==83673==
==83673== HEAP SUMMARY:
==83673==     in use at exit: 33,149,768 bytes in 15,977 blocks
==83673==   total heap usage: 41,777 allocs, 25,800 frees, 67,964,645 bytes allocated
==83673==
==83673== LEAK SUMMARY:
==83673==    definitely lost: 0 bytes in 0 blocks
==83673==    indirectly lost: 0 bytes in 0 blocks
==83673==      possibly lost: 0 bytes in 0 blocks
==83673==    still reachable: 33,149,768 bytes in 15,977 blocks
==83673==         suppressed: 0 bytes in 0 blocks
==83673== Reachable blocks (those to which a pointer was found) are not shown.
==83673== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==83673==
==83673== For counts of detected and suppressed errors, rerun with: -v
==83673== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
romain@ip-10-142-249-216:~/git/dplyr/tests$
```

and none of the previous problems related to Rcpp in hadley/dplyr#1062