### PR TITLE
added omitted is__simple<Rcomplex>. 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2014-04-14  Romain Francois  <romain@r-enthusiasts.com>
+
+        * inst/include/Rcpp/api/meat/is.h: added is__simple<Rcomplex>
+
 2015-04-12  Dirk Eddelbuettel  <edd@debian.org>
 
         * vignettes/Rcpp-FAQ.Rnw: Also load Rcpp to make cppFunction visible

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.11.5.2
+Version: 0.11.5.3
 Date: 2015-04-11
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
  Douglas Bates, and John Chambers

--- a/inst/include/Rcpp/api/meat/is.h
+++ b/inst/include/Rcpp/api/meat/is.h
@@ -45,6 +45,9 @@ namespace Rcpp {
     template <> inline bool is__simple<String>(SEXP x) {
         return is_atomic(x) && TYPEOF(x) == STRSXP;
     }
+    template <> inline bool is__simple<Rcomplex>(SEXP x) {
+        return is_atomic(x) && TYPEOF(x) == CPLXSXP;
+    }
     template <> inline bool is__simple<CharacterVector>(SEXP x) {
         return TYPEOF(x) == STRSXP;
     }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION Rcpp_Version(0,11,5)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,11,5,0)
+#define RCPP_DEV_VERSION RcppDevVersion(0,11,5,3)
 
 #endif
 


### PR DESCRIPTION
So that we can do: 

```
bool x = is<Rcomplex>(y) ;
```
