### PR TITLE
correct RcppDevVersion macro

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2014-04-14  Romain Francois  <romain@r-enthusiasts.com>
 
         * inst/include/Rcpp/api/meat/is.h: added is__simple<Rcomplex>
+        * inst/include/Rcpp/config.h: not using floating point arithmetic in preprocessor
 
 2015-04-12  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -24,7 +24,7 @@
 
 #define Rcpp_Version(v,p,s) (((v) * 65536) + ((p) * 256) + (s))
 
-#define RcppDevVersion(maj, min, rev, dev)  (((maj)*1e6) + ((min)*1e4) + ((rev)*1e2) + (dev))
+#define RcppDevVersion(maj, min, rev, dev)  (((maj)*1000000) + ((min)*10000) + ((rev)*100) + (dev))
 
 // the currently released version
 #define RCPP_VERSION Rcpp_Version(0,11,5)


### PR DESCRIPTION
Because 1e6, etc ... is floating point stuff, it cannot be used in the preprocessor.  
See https://travis-ci.org/hadley/dplyr/jobs/58447752 for an example failure.