### PR TITLE
don't enable C++11 features in tinyformat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-22  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/Rcpp/utils/tinyformat.h: don't use C++11 features
+
 2015-04-14  Dirk Eddelbuettel  <edd@debian.org>
 
         * .travis.yml (sudo): Adding 'sudo: required' to force older Travis backend

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -128,10 +128,8 @@ namespace Rcpp {
 }
 #define TINYFORMAT_ERROR(REASON) ::Rcpp::stop(REASON)
 
-// Define for C++11 variadic templates which make the code shorter & more
-// general.  If you don't define this, C++11 support is autodetected below.
-// #define TINYFORMAT_USE_VARIADIC_TEMPLATES
-
+// don't use C++11 features (support older compilers)
+#define TINYFORMAT_NO_VARIADIC_TEMPLATES
 
 //------------------------------------------------------------------------------
 // Implementation details.


### PR DESCRIPTION
This should fix compiler errors as seen [here](https://github.com/hadley/readxl/issues/78) -- we force C++98 compliance for `tinyformat`.