### PR TITLE
Better support for Vector with alternative storage policy. closes #291

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2014-04-25  Romain Francois  <romain@r-enthusiasts.com>
+
+        * inst/include/Rcpp/vector/Vector.h: update the parameterization of Vector cache
+        * inst/include/Rcpp/vector/traits.h: ...
+        * inst/include/Rcpp/vector/00_forward_proxy.h: ...
+        * inst/unitTests/runit.Vector.R: test for above changes
+        * inst/unitTests/cpp/Vector.cpp: ...
+        
 2015-04-22  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/utils/tinyformat.h: don't use C++11 features

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.11.5.3
-Date: 2015-04-11
+Version: 0.11.5.4
+Date: 2015-04-25
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
  Douglas Bates, and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,6 +12,8 @@
       \item Matrices now have a default constructor for zero-by-zero dimension
       matrices (via pull request by Dmitrii Meleshko).
       \item A new \code{empty()} string constructor was added.
+      \item Better support for vector with storage policy different from the 
+      default, i.e. \code{NoProtectStorage}.
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION Rcpp_Version(0,11,5)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,11,5,3)
+#define RCPP_DEV_VERSION RcppDevVersion(0,11,5,4)
 
 #endif
 

--- a/inst/include/Rcpp/vector/00_forward_proxy.h
+++ b/inst/include/Rcpp/vector/00_forward_proxy.h
@@ -35,8 +35,8 @@ namespace internal{
 }
 
 namespace traits {
-    template <int RTYPE> struct r_vector_cache_type ;
-	template <int RTYPE> class r_vector_cache ;
+    template <int RTYPE, template <class> class StoragePolicy> struct r_vector_cache_type ;
+	template <int RTYPE, template <class> class StoragePolicy> class r_vector_cache ;
 
 	template <int RTYPE> struct r_vector_name_proxy ;
 	template <int RTYPE> struct r_vector_proxy ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -39,7 +39,7 @@ public:
 
     typedef StoragePolicy<Vector> Storage ;
 
-    typename traits::r_vector_cache_type<RTYPE>::type cache ;
+    typename traits::r_vector_cache_type<RTYPE, StoragePolicy>::type cache ;
     typedef typename traits::r_vector_proxy<RTYPE>::type Proxy ;
     typedef typename traits::r_vector_const_proxy<RTYPE>::type const_Proxy ;
     typedef typename traits::r_vector_name_proxy<RTYPE>::type NameProxy ;

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -2,7 +2,7 @@
 //
 // traits.h: Rcpp R/C++ interface class library -- support traits for vector
 //
-// Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2015 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,10 +25,10 @@
 namespace Rcpp{
 namespace traits{
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage >
 	class r_vector_cache{
 	public:
-		typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef typename r_vector_iterator<RTYPE>::type iterator ;
 		typedef typename r_vector_const_iterator<RTYPE>::type const_iterator ;
 		typedef typename r_vector_proxy<RTYPE>::type proxy ;
@@ -51,9 +51,10 @@ namespace traits{
 		private:
 			iterator start ;
 	} ;
-	template <int RTYPE> class proxy_cache{
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> 
+	class proxy_cache{
 	public:
-		typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef typename r_vector_iterator<RTYPE>::type iterator ;
 		typedef typename r_vector_const_iterator<RTYPE>::type const_iterator ;
 		typedef typename r_vector_proxy<RTYPE>::type proxy ;
@@ -79,12 +80,24 @@ namespace traits{
 	} ;
 
 	// regular types for INTSXP, REALSXP, ...
-	template <int RTYPE> struct r_vector_cache_type { typedef r_vector_cache<RTYPE> type ;  } ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> 
+	struct r_vector_cache_type { 
+	    typedef r_vector_cache<RTYPE, StoragePolicy> type ;  
+	} ;
 
 	// proxy types for VECSXP, STRSXP and EXPRSXP
-	template <> struct r_vector_cache_type<VECSXP>  { typedef proxy_cache<VECSXP> type ;  } ;
-	template <> struct r_vector_cache_type<EXPRSXP> { typedef proxy_cache<EXPRSXP> type ; } ;
-	template <> struct r_vector_cache_type<STRSXP>  { typedef proxy_cache<STRSXP> type ;  } ;
+	template <template <class> class StoragePolicy> 
+	struct r_vector_cache_type<VECSXP, StoragePolicy>  { 
+	    typedef proxy_cache<VECSXP, StoragePolicy> type ;  
+	} ;
+	template <template <class> class StoragePolicy> 
+	struct r_vector_cache_type<EXPRSXP, StoragePolicy> { 
+	    typedef proxy_cache<EXPRSXP, StoragePolicy> type ; 
+	} ;
+	template <template <class> class StoragePolicy> 
+	struct r_vector_cache_type<STRSXP, StoragePolicy>  { 
+	    typedef proxy_cache<STRSXP, StoragePolicy> type ;  
+	} ;
 
 } // traits
 }

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -772,3 +772,7 @@ int noprotect_vector( Vector<REALSXP, NoProtectStorage> x){
   return x.size() ;
 }
 
+// [[Rcpp::export]]
+int noprotect_matrix( Matrix<REALSXP, NoProtectStorage> x){
+  return x.nrow() ;
+}

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -2,7 +2,7 @@
 //
 // Vector.cpp: Rcpp R/C++ interface class library -- Vector unit tests
 //
-// Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2015    Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -766,3 +766,9 @@ LogicalVector logical_vector_from_bool_assign() {
 void no_op(int major) {
     int minor = 1;
 }
+
+// [[Rcpp::export]]
+int noprotect_vector( Vector<REALSXP, NoProtectStorage> x){
+  return x.size() ;
+}
+

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -1,7 +1,7 @@
 #!/usr/bin/r -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
-# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -672,6 +672,11 @@ if (.runThisTest) {
 
     test.logical.vector.from.bool.assign <- function() {
         checkIdentical(logical_vector_from_bool_assign(), TRUE)
+    }
+    
+    test.noprotect_vector <- function(){
+        x <- rnorm(10)
+        checkIdentical( noprotect_vector(x), 10L )
     }
     
 }

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -679,5 +679,10 @@ if (.runThisTest) {
         checkIdentical( noprotect_vector(x), 10L )
     }
     
+    test.noprotect_matrix <- function(){
+        x <- matrix(rnorm(10), nrow=2)
+        checkIdentical( noprotect_matrix(x), 2L )
+    }
+    
 }
 


### PR DESCRIPTION
This makes this code compile: 

```
#include <Rcpp.h>
using namespace Rcpp ;

// [[Rcpp::export]]
int foo( Vector<REALSXP, NoProtectStorage> x){
  return x.size() ;
}

/*** R
  x <- rnorm(10)
  foo(x)
*/
```

The issue was that the `cache` did not depend on the storage policy so vectors with alternative policies gt confused. 