### PR TITLE
Revert changes to modules related to BEGIN/END macros

### DIFF
--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -38,8 +38,10 @@ namespace Rcpp {
                 virtual ~CppFunctionBaseFromStdFunction() {}
 
                 SEXP operator()(SEXP* args) {
+                    BEGIN_RCPP
                     auto result = call<RESULT_TYPE, Args...>(fun, args);
                     return Rcpp::module_wrap<RESULT_TYPE>(result);
+                    END_RCPP
                 }
 
             private:
@@ -53,8 +55,9 @@ namespace Rcpp {
                  virtual ~CppFunctionBaseFromStdFunction() {}
 
                  SEXP operator()(SEXP* args) {
+                     BEGIN_RCPP
                      call<void, Args...>(fun, args);
-                     return R_NilValue;
+                     END_RCPP
                  }
 
             private:

--- a/inst/include/Rcpp/api/meat/module/Module.h
+++ b/inst/include/Rcpp/api/meat/module/Module.h
@@ -1,6 +1,6 @@
 // Module.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2013 - 2015 Romain Francois
+// Copyright (C) 2013 Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -37,10 +37,12 @@ namespace Rcpp {
 	}
 
     inline CppClass Module::get_class( const std::string& cl ){
+        BEGIN_RCPP
             CLASS_MAP::iterator it = classes.find(cl) ;
             if( it == classes.end() ) throw std::range_error( "no such class" ) ;
             std::string buffer ;
             return CppClass( this, it->second, buffer ) ;
+        END_RCPP
     }
 
 }

--- a/inst/include/Rcpp/module/Module_generated_CppFunction.h
+++ b/inst/include/Rcpp/module/Module_generated_CppFunction.h
@@ -3,7 +3,7 @@
 // Module_generated_CppFunction.h: -- generated helper code for Modules
 //                                    see rcpp-scripts repo for generator script
 //
-// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -30,7 +30,9 @@ class CppFunction0 : public CppFunction {
     public:
         CppFunction0(RESULT_TYPE (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
         SEXP operator()(SEXP*) {
+            BEGIN_RCPP
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
+            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -48,8 +50,9 @@ class CppFunction0<void> : public CppFunction {
         CppFunction0(void (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {};
 
         SEXP operator()(SEXP*) {
+            BEGIN_RCPP
             ptr_fun();
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -67,7 +70,9 @@ class CppFunction_WithFormals0 : public CppFunction {
     public:
         CppFunction_WithFormals0(RESULT_TYPE (*fun)(void), Rcpp::List,  const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
         SEXP operator()(SEXP*) {
+            BEGIN_RCPP
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
+            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -85,8 +90,9 @@ class CppFunction_WithFormals0<void> : public CppFunction {
         CppFunction_WithFormals0(void (*fun)(void), Rcpp::List, const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {} ;
 
         SEXP operator()(SEXP*) {
+            BEGIN_RCPP
             ptr_fun() ;
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 0; }
@@ -105,8 +111,10 @@ template <typename RESULT_TYPE, typename U0> class CppFunction1 : public CppFunc
         CppFunction1(RESULT_TYPE (*fun)(U0) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0));
+            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -123,9 +131,10 @@ class CppFunction1<void,U0> : public CppFunction {
         CppFunction1(void (*fun)(U0) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -147,8 +156,10 @@ class CppFunction_WithFormals1 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0));
+            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -168,9 +179,10 @@ class CppFunction_WithFormals1<void,U0> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             ptr_fun(x0);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 1; }
@@ -191,9 +203,11 @@ template <typename RESULT_TYPE, typename U0,typename U1> class CppFunction2 : pu
         CppFunction2(RESULT_TYPE (*fun)(U0,U1) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1));
+            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -210,10 +224,11 @@ class CppFunction2<void,U0,U1> : public CppFunction {
         CppFunction2(void (*fun)(U0,U1) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -235,9 +250,11 @@ class CppFunction_WithFormals2 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1));
+            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -257,10 +274,11 @@ class CppFunction_WithFormals2<void,U0,U1> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             ptr_fun(x0,x1);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 2; }
@@ -281,10 +299,12 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2> class CppFu
         CppFunction3(RESULT_TYPE (*fun)(U0,U1,U2) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2));
+            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -301,11 +321,12 @@ class CppFunction3<void,U0,U1,U2> : public CppFunction {
         CppFunction3(void (*fun)(U0,U1,U2) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -327,10 +348,12 @@ class CppFunction_WithFormals3 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2));
+            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -350,11 +373,12 @@ class CppFunction_WithFormals3<void,U0,U1,U2> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             ptr_fun(x0,x1,x2);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 3; }
@@ -375,11 +399,13 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3>
         CppFunction4(RESULT_TYPE (*fun)(U0,U1,U2,U3) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3));
+            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -396,12 +422,13 @@ class CppFunction4<void,U0,U1,U2,U3> : public CppFunction {
         CppFunction4(void (*fun)(U0,U1,U2,U3) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -423,11 +450,13 @@ class CppFunction_WithFormals4 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3));
+            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -447,12 +476,13 @@ class CppFunction_WithFormals4<void,U0,U1,U2,U3> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             ptr_fun(x0,x1,x2,x3);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 4; }
@@ -473,12 +503,14 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction5(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4));
+            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -495,13 +527,14 @@ class CppFunction5<void,U0,U1,U2,U3,U4> : public CppFunction {
         CppFunction5(void (*fun)(U0,U1,U2,U3,U4) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -523,12 +556,14 @@ class CppFunction_WithFormals5 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4));
+            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -548,13 +583,14 @@ class CppFunction_WithFormals5<void,U0,U1,U2,U3,U4> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
             typename traits::input_parameter< U3 >::type x3(args[3]);
             typename traits::input_parameter< U4 >::type x4(args[4]);
             ptr_fun(x0,x1,x2,x3,x4);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 5; }
@@ -575,6 +611,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction6(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -582,6 +619,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5));
+            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -598,6 +636,7 @@ class CppFunction6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
         CppFunction6(void (*fun)(U0,U1,U2,U3,U4,U5) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -605,7 +644,7 @@ class CppFunction6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             ptr_fun(x0,x1,x2,x3,x4,x5);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -627,6 +666,7 @@ class CppFunction_WithFormals6 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -634,6 +674,7 @@ class CppFunction_WithFormals6 : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5));
+            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -653,6 +694,7 @@ class CppFunction_WithFormals6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -660,7 +702,7 @@ class CppFunction_WithFormals6<void,U0,U1,U2,U3,U4,U5> : public CppFunction {
             typename traits::input_parameter< U4 >::type x4(args[4]);
             typename traits::input_parameter< U5 >::type x5(args[5]);
             ptr_fun(x0,x1,x2,x3,x4,x5);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 6; }
@@ -681,6 +723,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction7(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -689,6 +732,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6));
+            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -705,6 +749,7 @@ class CppFunction7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
         CppFunction7(void (*fun)(U0,U1,U2,U3,U4,U5,U6) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -713,7 +758,7 @@ class CppFunction7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -735,6 +780,7 @@ class CppFunction_WithFormals7 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -743,6 +789,7 @@ class CppFunction_WithFormals7 : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6));
+            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -762,6 +809,7 @@ class CppFunction_WithFormals7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -770,7 +818,7 @@ class CppFunction_WithFormals7<void,U0,U1,U2,U3,U4,U5,U6> : public CppFunction {
             typename traits::input_parameter< U5 >::type x5(args[5]);
             typename traits::input_parameter< U6 >::type x6(args[6]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 7; }
@@ -791,6 +839,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction8(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -800,6 +849,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7));
+            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -816,6 +866,7 @@ class CppFunction8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunction {
         CppFunction8(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -825,7 +876,7 @@ class CppFunction8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunction {
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -847,6 +898,7 @@ class CppFunction_WithFormals8 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -856,6 +908,7 @@ class CppFunction_WithFormals8 : public CppFunction {
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7));
+            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -875,6 +928,7 @@ class CppFunction_WithFormals8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunctio
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -884,7 +938,7 @@ class CppFunction_WithFormals8<void,U0,U1,U2,U3,U4,U5,U6,U7> : public CppFunctio
             typename traits::input_parameter< U6 >::type x6(args[6]);
             typename traits::input_parameter< U7 >::type x7(args[7]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 8; }
@@ -905,6 +959,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction9(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -915,6 +970,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8));
+            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -931,6 +987,7 @@ class CppFunction9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunction {
         CppFunction9(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -941,7 +998,7 @@ class CppFunction9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunction {
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -963,6 +1020,7 @@ class CppFunction_WithFormals9 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -973,6 +1031,7 @@ class CppFunction_WithFormals9 : public CppFunction {
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8));
+            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -992,6 +1051,7 @@ class CppFunction_WithFormals9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunc
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1002,7 +1062,7 @@ class CppFunction_WithFormals9<void,U0,U1,U2,U3,U4,U5,U6,U7,U8> : public CppFunc
             typename traits::input_parameter< U7 >::type x7(args[7]);
             typename traits::input_parameter< U8 >::type x8(args[8]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 9; }
@@ -1023,6 +1083,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction10(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1034,6 +1095,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9));
+            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1050,6 +1112,7 @@ class CppFunction10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public CppFunction {
         CppFunction10(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1061,7 +1124,7 @@ class CppFunction10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public CppFunction {
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1083,6 +1146,7 @@ class CppFunction_WithFormals10 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1094,6 +1158,7 @@ class CppFunction_WithFormals10 : public CppFunction {
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9));
+            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1113,6 +1178,7 @@ class CppFunction_WithFormals10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public Cpp
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1124,7 +1190,7 @@ class CppFunction_WithFormals10<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9> : public Cpp
             typename traits::input_parameter< U8 >::type x8(args[8]);
             typename traits::input_parameter< U9 >::type x9(args[9]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 10; }
@@ -1145,6 +1211,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction11(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1157,6 +1224,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10));
+            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1173,6 +1241,7 @@ class CppFunction11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public CppFunction
         CppFunction11(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1185,7 +1254,7 @@ class CppFunction11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public CppFunction
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1207,6 +1276,7 @@ class CppFunction_WithFormals11 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1219,6 +1289,7 @@ class CppFunction_WithFormals11 : public CppFunction {
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10));
+            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1238,6 +1309,7 @@ class CppFunction_WithFormals11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1250,7 +1322,7 @@ class CppFunction_WithFormals11<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10> : public
             typename traits::input_parameter< U9 >::type x9(args[9]);
             typename traits::input_parameter< U10 >::type x10(args[10]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 11; }
@@ -1271,6 +1343,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction12(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1284,6 +1357,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11));
+            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1300,6 +1374,7 @@ class CppFunction12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : public CppFunc
         CppFunction12(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1313,7 +1388,7 @@ class CppFunction12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : public CppFunc
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1335,6 +1410,7 @@ class CppFunction_WithFormals12 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1348,6 +1424,7 @@ class CppFunction_WithFormals12 : public CppFunction {
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11));
+            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1367,6 +1444,7 @@ class CppFunction_WithFormals12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : pu
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1380,7 +1458,7 @@ class CppFunction_WithFormals12<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11> : pu
             typename traits::input_parameter< U10 >::type x10(args[10]);
             typename traits::input_parameter< U11 >::type x11(args[11]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 12; }
@@ -1401,6 +1479,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction13(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1415,6 +1494,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12));
+            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1431,6 +1511,7 @@ class CppFunction13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> : public Cpp
         CppFunction13(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1445,7 +1526,7 @@ class CppFunction13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> : public Cpp
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1467,6 +1548,7 @@ class CppFunction_WithFormals13 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1481,6 +1563,7 @@ class CppFunction_WithFormals13 : public CppFunction {
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12));
+            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1500,6 +1583,7 @@ class CppFunction_WithFormals13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> 
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1514,7 +1598,7 @@ class CppFunction_WithFormals13<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12> 
             typename traits::input_parameter< U11 >::type x11(args[11]);
             typename traits::input_parameter< U12 >::type x12(args[12]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 13; }
@@ -1535,6 +1619,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction14(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1550,6 +1635,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13));
+            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1566,6 +1652,7 @@ class CppFunction14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13> : public
         CppFunction14(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1581,7 +1668,7 @@ class CppFunction14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13> : public
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1603,6 +1690,7 @@ class CppFunction_WithFormals14 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1618,6 +1706,7 @@ class CppFunction_WithFormals14 : public CppFunction {
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13));
+            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1637,6 +1726,7 @@ class CppFunction_WithFormals14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1652,7 +1742,7 @@ class CppFunction_WithFormals14<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U12 >::type x12(args[12]);
             typename traits::input_parameter< U13 >::type x13(args[13]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 14; }
@@ -1673,6 +1763,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction15(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1689,6 +1780,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14));
+            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1705,6 +1797,7 @@ class CppFunction15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14> : pu
         CppFunction15(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1721,7 +1814,7 @@ class CppFunction15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14> : pu
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1743,6 +1836,7 @@ class CppFunction_WithFormals15 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1759,6 +1853,7 @@ class CppFunction_WithFormals15 : public CppFunction {
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14));
+            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1778,6 +1873,7 @@ class CppFunction_WithFormals15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1794,7 +1890,7 @@ class CppFunction_WithFormals15<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U13 >::type x13(args[13]);
             typename traits::input_parameter< U14 >::type x14(args[14]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 15; }
@@ -1815,6 +1911,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction16(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1832,6 +1929,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15));
+            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1848,6 +1946,7 @@ class CppFunction16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15> 
         CppFunction16(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1865,7 +1964,7 @@ class CppFunction16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15> 
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1887,6 +1986,7 @@ class CppFunction_WithFormals16 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1904,6 +2004,7 @@ class CppFunction_WithFormals16 : public CppFunction {
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15));
+            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1923,6 +2024,7 @@ class CppFunction_WithFormals16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1940,7 +2042,7 @@ class CppFunction_WithFormals16<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U14 >::type x14(args[14]);
             typename traits::input_parameter< U15 >::type x15(args[15]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 16; }
@@ -1961,6 +2063,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction17(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -1979,6 +2082,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16));
+            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -1995,6 +2099,7 @@ class CppFunction17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction17(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2013,7 +2118,7 @@ class CppFunction17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2035,6 +2140,7 @@ class CppFunction_WithFormals17 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2053,6 +2159,7 @@ class CppFunction_WithFormals17 : public CppFunction {
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16));
+            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2072,6 +2179,7 @@ class CppFunction_WithFormals17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2090,7 +2198,7 @@ class CppFunction_WithFormals17<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U15 >::type x15(args[15]);
             typename traits::input_parameter< U16 >::type x16(args[16]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 17; }
@@ -2111,6 +2219,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction18(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2130,6 +2239,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17));
+            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2146,6 +2256,7 @@ class CppFunction18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction18(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2165,7 +2276,7 @@ class CppFunction18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2187,6 +2298,7 @@ class CppFunction_WithFormals18 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2206,6 +2318,7 @@ class CppFunction_WithFormals18 : public CppFunction {
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17));
+            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2225,6 +2338,7 @@ class CppFunction_WithFormals18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2244,7 +2358,7 @@ class CppFunction_WithFormals18<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U16 >::type x16(args[16]);
             typename traits::input_parameter< U17 >::type x17(args[17]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 18; }
@@ -2265,6 +2379,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction19(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2285,6 +2400,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18));
+            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2301,6 +2417,7 @@ class CppFunction19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction19(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2321,7 +2438,7 @@ class CppFunction19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2343,6 +2460,7 @@ class CppFunction_WithFormals19 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2363,6 +2481,7 @@ class CppFunction_WithFormals19 : public CppFunction {
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18));
+            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2382,6 +2501,7 @@ class CppFunction_WithFormals19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2402,7 +2522,7 @@ class CppFunction_WithFormals19<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U17 >::type x17(args[17]);
             typename traits::input_parameter< U18 >::type x18(args[18]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 19; }
@@ -2423,6 +2543,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction20(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2444,6 +2565,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19));
+            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2460,6 +2582,7 @@ class CppFunction20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction20(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2481,7 +2604,7 @@ class CppFunction20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2503,6 +2626,7 @@ class CppFunction_WithFormals20 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2524,6 +2648,7 @@ class CppFunction_WithFormals20 : public CppFunction {
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19));
+            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2543,6 +2668,7 @@ class CppFunction_WithFormals20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2564,7 +2690,7 @@ class CppFunction_WithFormals20<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U18 >::type x18(args[18]);
             typename traits::input_parameter< U19 >::type x19(args[19]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 20; }
@@ -2585,6 +2711,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction21(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2607,6 +2734,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20));
+            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2623,6 +2751,7 @@ class CppFunction21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction21(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2645,7 +2774,7 @@ class CppFunction21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2667,6 +2796,7 @@ class CppFunction_WithFormals21 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2689,6 +2819,7 @@ class CppFunction_WithFormals21 : public CppFunction {
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20));
+            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2708,6 +2839,7 @@ class CppFunction_WithFormals21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2730,7 +2862,7 @@ class CppFunction_WithFormals21<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U19 >::type x19(args[19]);
             typename traits::input_parameter< U20 >::type x20(args[20]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 21; }
@@ -2751,6 +2883,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction22(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2774,6 +2907,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21));
+            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2790,6 +2924,7 @@ class CppFunction22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction22(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2813,7 +2948,7 @@ class CppFunction22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2835,6 +2970,7 @@ class CppFunction_WithFormals22 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2858,6 +2994,7 @@ class CppFunction_WithFormals22 : public CppFunction {
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21));
+            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2877,6 +3014,7 @@ class CppFunction_WithFormals22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2900,7 +3038,7 @@ class CppFunction_WithFormals22<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U20 >::type x20(args[20]);
             typename traits::input_parameter< U21 >::type x21(args[21]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 22; }
@@ -2921,6 +3059,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction23(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2945,6 +3084,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22));
+            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -2961,6 +3101,7 @@ class CppFunction23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction23(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -2985,7 +3126,7 @@ class CppFunction23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3007,6 +3148,7 @@ class CppFunction_WithFormals23 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3031,6 +3173,7 @@ class CppFunction_WithFormals23 : public CppFunction {
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22));
+            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3050,6 +3193,7 @@ class CppFunction_WithFormals23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3074,7 +3218,7 @@ class CppFunction_WithFormals23<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U21 >::type x21(args[21]);
             typename traits::input_parameter< U22 >::type x22(args[22]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 23; }
@@ -3095,6 +3239,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction24(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3120,6 +3265,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23));
+            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3136,6 +3282,7 @@ class CppFunction24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction24(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3161,7 +3308,7 @@ class CppFunction24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3183,6 +3330,7 @@ class CppFunction_WithFormals24 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3208,6 +3356,7 @@ class CppFunction_WithFormals24 : public CppFunction {
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23));
+            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3227,6 +3376,7 @@ class CppFunction_WithFormals24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3252,7 +3402,7 @@ class CppFunction_WithFormals24<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U22 >::type x22(args[22]);
             typename traits::input_parameter< U23 >::type x23(args[23]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 24; }
@@ -3273,6 +3423,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction25(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3299,6 +3450,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24));
+            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3315,6 +3467,7 @@ class CppFunction25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction25(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3341,7 +3494,7 @@ class CppFunction25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3363,6 +3516,7 @@ class CppFunction_WithFormals25 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3389,6 +3543,7 @@ class CppFunction_WithFormals25 : public CppFunction {
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24));
+            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3408,6 +3563,7 @@ class CppFunction_WithFormals25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3434,7 +3590,7 @@ class CppFunction_WithFormals25<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U23 >::type x23(args[23]);
             typename traits::input_parameter< U24 >::type x24(args[24]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 25; }
@@ -3455,6 +3611,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction26(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3482,6 +3639,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25));
+            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3498,6 +3656,7 @@ class CppFunction26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction26(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3525,7 +3684,7 @@ class CppFunction26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3547,6 +3706,7 @@ class CppFunction_WithFormals26 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3574,6 +3734,7 @@ class CppFunction_WithFormals26 : public CppFunction {
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25));
+            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3593,6 +3754,7 @@ class CppFunction_WithFormals26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3620,7 +3782,7 @@ class CppFunction_WithFormals26<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U24 >::type x24(args[24]);
             typename traits::input_parameter< U25 >::type x25(args[25]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 26; }
@@ -3641,6 +3803,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction27(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3669,6 +3832,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26));
+            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3685,6 +3849,7 @@ class CppFunction27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction27(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3713,7 +3878,7 @@ class CppFunction27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3735,6 +3900,7 @@ class CppFunction_WithFormals27 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3763,6 +3929,7 @@ class CppFunction_WithFormals27 : public CppFunction {
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26));
+            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3782,6 +3949,7 @@ class CppFunction_WithFormals27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3810,7 +3978,7 @@ class CppFunction_WithFormals27<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U25 >::type x25(args[25]);
             typename traits::input_parameter< U26 >::type x26(args[26]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 27; }
@@ -3831,6 +3999,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction28(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3860,6 +4029,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27));
+            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -3876,6 +4046,7 @@ class CppFunction28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction28(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3905,7 +4076,7 @@ class CppFunction28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -3927,6 +4098,7 @@ class CppFunction_WithFormals28 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -3956,6 +4128,7 @@ class CppFunction_WithFormals28 : public CppFunction {
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27));
+            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -3975,6 +4148,7 @@ class CppFunction_WithFormals28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4004,7 +4178,7 @@ class CppFunction_WithFormals28<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U26 >::type x26(args[26]);
             typename traits::input_parameter< U27 >::type x27(args[27]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 28; }
@@ -4025,6 +4199,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction29(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4055,6 +4230,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28));
+            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4071,6 +4247,7 @@ class CppFunction29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction29(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4101,7 +4278,7 @@ class CppFunction29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4123,6 +4300,7 @@ class CppFunction_WithFormals29 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4153,6 +4331,7 @@ class CppFunction_WithFormals29 : public CppFunction {
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28));
+            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4172,6 +4351,7 @@ class CppFunction_WithFormals29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4202,7 +4382,7 @@ class CppFunction_WithFormals29<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U27 >::type x27(args[27]);
             typename traits::input_parameter< U28 >::type x28(args[28]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 29; }
@@ -4223,6 +4403,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction30(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4254,6 +4435,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29));
+            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4270,6 +4452,7 @@ class CppFunction30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction30(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4301,7 +4484,7 @@ class CppFunction30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4323,6 +4506,7 @@ class CppFunction_WithFormals30 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4354,6 +4538,7 @@ class CppFunction_WithFormals30 : public CppFunction {
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29));
+            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4373,6 +4558,7 @@ class CppFunction_WithFormals30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4404,7 +4590,7 @@ class CppFunction_WithFormals30<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U28 >::type x28(args[28]);
             typename traits::input_parameter< U29 >::type x29(args[29]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 30; }
@@ -4425,6 +4611,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction31(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4457,6 +4644,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30));
+            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4473,6 +4661,7 @@ class CppFunction31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction31(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4505,7 +4694,7 @@ class CppFunction31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4527,6 +4716,7 @@ class CppFunction_WithFormals31 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4559,6 +4749,7 @@ class CppFunction_WithFormals31 : public CppFunction {
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30));
+            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4578,6 +4769,7 @@ class CppFunction_WithFormals31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4610,7 +4802,7 @@ class CppFunction_WithFormals31<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U29 >::type x29(args[29]);
             typename traits::input_parameter< U30 >::type x30(args[30]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 31; }
@@ -4631,6 +4823,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction32(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4664,6 +4857,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31));
+            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4680,6 +4874,7 @@ class CppFunction32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction32(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4713,7 +4908,7 @@ class CppFunction32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4735,6 +4930,7 @@ class CppFunction_WithFormals32 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4768,6 +4964,7 @@ class CppFunction_WithFormals32 : public CppFunction {
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31));
+            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4787,6 +4984,7 @@ class CppFunction_WithFormals32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4820,7 +5018,7 @@ class CppFunction_WithFormals32<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U30 >::type x30(args[30]);
             typename traits::input_parameter< U31 >::type x31(args[31]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 32; }
@@ -4841,6 +5039,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction33(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4875,6 +5074,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32));
+            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -4891,6 +5091,7 @@ class CppFunction33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction33(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4925,7 +5126,7 @@ class CppFunction33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -4947,6 +5148,7 @@ class CppFunction_WithFormals33 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -4981,6 +5183,7 @@ class CppFunction_WithFormals33 : public CppFunction {
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32));
+            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5000,6 +5203,7 @@ class CppFunction_WithFormals33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5034,7 +5238,7 @@ class CppFunction_WithFormals33<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U31 >::type x31(args[31]);
             typename traits::input_parameter< U32 >::type x32(args[32]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 33; }
@@ -5055,6 +5259,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction34(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5090,6 +5295,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33));
+            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5106,6 +5312,7 @@ class CppFunction34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction34(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5141,7 +5348,7 @@ class CppFunction34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5163,6 +5370,7 @@ class CppFunction_WithFormals34 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5198,6 +5406,7 @@ class CppFunction_WithFormals34 : public CppFunction {
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33));
+            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5217,6 +5426,7 @@ class CppFunction_WithFormals34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5252,7 +5462,7 @@ class CppFunction_WithFormals34<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U32 >::type x32(args[32]);
             typename traits::input_parameter< U33 >::type x33(args[33]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 34; }
@@ -5273,6 +5483,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction35(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5309,6 +5520,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34));
+            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5325,6 +5537,7 @@ class CppFunction35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction35(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5361,7 +5574,7 @@ class CppFunction35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5383,6 +5596,7 @@ class CppFunction_WithFormals35 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5419,6 +5633,7 @@ class CppFunction_WithFormals35 : public CppFunction {
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34));
+            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5438,6 +5653,7 @@ class CppFunction_WithFormals35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5474,7 +5690,7 @@ class CppFunction_WithFormals35<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U33 >::type x33(args[33]);
             typename traits::input_parameter< U34 >::type x34(args[34]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 35; }
@@ -5495,6 +5711,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction36(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5532,6 +5749,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35));
+            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5548,6 +5766,7 @@ class CppFunction36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction36(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5585,7 +5804,7 @@ class CppFunction36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5607,6 +5826,7 @@ class CppFunction_WithFormals36 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5644,6 +5864,7 @@ class CppFunction_WithFormals36 : public CppFunction {
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35));
+            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5663,6 +5884,7 @@ class CppFunction_WithFormals36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5700,7 +5922,7 @@ class CppFunction_WithFormals36<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U34 >::type x34(args[34]);
             typename traits::input_parameter< U35 >::type x35(args[35]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 36; }
@@ -5721,6 +5943,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction37(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5759,6 +5982,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36));
+            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -5775,6 +5999,7 @@ class CppFunction37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction37(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5813,7 +6038,7 @@ class CppFunction37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -5835,6 +6060,7 @@ class CppFunction_WithFormals37 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5873,6 +6099,7 @@ class CppFunction_WithFormals37 : public CppFunction {
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36));
+            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -5892,6 +6119,7 @@ class CppFunction_WithFormals37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5930,7 +6158,7 @@ class CppFunction_WithFormals37<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U35 >::type x35(args[35]);
             typename traits::input_parameter< U36 >::type x36(args[36]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 37; }
@@ -5951,6 +6179,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction38(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -5990,6 +6219,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37));
+            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6006,6 +6236,7 @@ class CppFunction38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction38(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6045,7 +6276,7 @@ class CppFunction38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6067,6 +6298,7 @@ class CppFunction_WithFormals38 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6106,6 +6338,7 @@ class CppFunction_WithFormals38 : public CppFunction {
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37));
+            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6125,6 +6358,7 @@ class CppFunction_WithFormals38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6164,7 +6398,7 @@ class CppFunction_WithFormals38<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U36 >::type x36(args[36]);
             typename traits::input_parameter< U37 >::type x37(args[37]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 38; }
@@ -6185,6 +6419,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction39(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6225,6 +6460,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38));
+            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6241,6 +6477,7 @@ class CppFunction39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction39(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6281,7 +6518,7 @@ class CppFunction39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6303,6 +6540,7 @@ class CppFunction_WithFormals39 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6343,6 +6581,7 @@ class CppFunction_WithFormals39 : public CppFunction {
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38));
+            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6362,6 +6601,7 @@ class CppFunction_WithFormals39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6402,7 +6642,7 @@ class CppFunction_WithFormals39<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U37 >::type x37(args[37]);
             typename traits::input_parameter< U38 >::type x38(args[38]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 39; }
@@ -6423,6 +6663,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction40(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6464,6 +6705,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39));
+            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6480,6 +6722,7 @@ class CppFunction40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction40(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6521,7 +6764,7 @@ class CppFunction40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6543,6 +6786,7 @@ class CppFunction_WithFormals40 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6584,6 +6828,7 @@ class CppFunction_WithFormals40 : public CppFunction {
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39));
+            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6603,6 +6848,7 @@ class CppFunction_WithFormals40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6644,7 +6890,7 @@ class CppFunction_WithFormals40<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U38 >::type x38(args[38]);
             typename traits::input_parameter< U39 >::type x39(args[39]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 40; }
@@ -6665,6 +6911,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction41(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6707,6 +6954,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40));
+            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -6723,6 +6971,7 @@ class CppFunction41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction41(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6765,7 +7014,7 @@ class CppFunction41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -6787,6 +7036,7 @@ class CppFunction_WithFormals41 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6829,6 +7079,7 @@ class CppFunction_WithFormals41 : public CppFunction {
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40));
+            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -6848,6 +7099,7 @@ class CppFunction_WithFormals41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6890,7 +7142,7 @@ class CppFunction_WithFormals41<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U39 >::type x39(args[39]);
             typename traits::input_parameter< U40 >::type x40(args[40]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 41; }
@@ -6911,6 +7163,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction42(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -6954,6 +7207,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41));
+            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -6970,6 +7224,7 @@ class CppFunction42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction42(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7013,7 +7268,7 @@ class CppFunction42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7035,6 +7290,7 @@ class CppFunction_WithFormals42 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7078,6 +7334,7 @@ class CppFunction_WithFormals42 : public CppFunction {
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41));
+            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7097,6 +7354,7 @@ class CppFunction_WithFormals42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7140,7 +7398,7 @@ class CppFunction_WithFormals42<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U40 >::type x40(args[40]);
             typename traits::input_parameter< U41 >::type x41(args[41]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 42; }
@@ -7161,6 +7419,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction43(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7205,6 +7464,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42));
+            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7221,6 +7481,7 @@ class CppFunction43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction43(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7265,7 +7526,7 @@ class CppFunction43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7287,6 +7548,7 @@ class CppFunction_WithFormals43 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7331,6 +7593,7 @@ class CppFunction_WithFormals43 : public CppFunction {
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42));
+            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7350,6 +7613,7 @@ class CppFunction_WithFormals43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7394,7 +7658,7 @@ class CppFunction_WithFormals43<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U41 >::type x41(args[41]);
             typename traits::input_parameter< U42 >::type x42(args[42]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 43; }
@@ -7415,6 +7679,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction44(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7460,6 +7725,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43));
+            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7476,6 +7742,7 @@ class CppFunction44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction44(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7521,7 +7788,7 @@ class CppFunction44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7543,6 +7810,7 @@ class CppFunction_WithFormals44 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7588,6 +7856,7 @@ class CppFunction_WithFormals44 : public CppFunction {
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43));
+            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7607,6 +7876,7 @@ class CppFunction_WithFormals44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7652,7 +7922,7 @@ class CppFunction_WithFormals44<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U42 >::type x42(args[42]);
             typename traits::input_parameter< U43 >::type x43(args[43]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 44; }
@@ -7673,6 +7943,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction45(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7719,6 +7990,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44));
+            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -7735,6 +8007,7 @@ class CppFunction45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction45(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7781,7 +8054,7 @@ class CppFunction45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -7803,6 +8076,7 @@ class CppFunction_WithFormals45 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7849,6 +8123,7 @@ class CppFunction_WithFormals45 : public CppFunction {
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44));
+            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -7868,6 +8143,7 @@ class CppFunction_WithFormals45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7914,7 +8190,7 @@ class CppFunction_WithFormals45<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U43 >::type x43(args[43]);
             typename traits::input_parameter< U44 >::type x44(args[44]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 45; }
@@ -7935,6 +8211,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction46(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -7982,6 +8259,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45));
+            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -7998,6 +8276,7 @@ class CppFunction46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction46(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8045,7 +8324,7 @@ class CppFunction46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8067,6 +8346,7 @@ class CppFunction_WithFormals46 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8114,6 +8394,7 @@ class CppFunction_WithFormals46 : public CppFunction {
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45));
+            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8133,6 +8414,7 @@ class CppFunction_WithFormals46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8180,7 +8462,7 @@ class CppFunction_WithFormals46<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U44 >::type x44(args[44]);
             typename traits::input_parameter< U45 >::type x45(args[45]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 46; }
@@ -8201,6 +8483,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction47(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8249,6 +8532,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46));
+            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8265,6 +8549,7 @@ class CppFunction47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction47(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8313,7 +8598,7 @@ class CppFunction47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8335,6 +8620,7 @@ class CppFunction_WithFormals47 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8383,6 +8669,7 @@ class CppFunction_WithFormals47 : public CppFunction {
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46));
+            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8402,6 +8689,7 @@ class CppFunction_WithFormals47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8450,7 +8738,7 @@ class CppFunction_WithFormals47<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U45 >::type x45(args[45]);
             typename traits::input_parameter< U46 >::type x46(args[46]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 47; }
@@ -8471,6 +8759,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction48(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8520,6 +8809,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47));
+            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8536,6 +8826,7 @@ class CppFunction48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction48(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8585,7 +8876,7 @@ class CppFunction48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8607,6 +8898,7 @@ class CppFunction_WithFormals48 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8656,6 +8948,7 @@ class CppFunction_WithFormals48 : public CppFunction {
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47));
+            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8675,6 +8968,7 @@ class CppFunction_WithFormals48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8724,7 +9018,7 @@ class CppFunction_WithFormals48<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U46 >::type x46(args[46]);
             typename traits::input_parameter< U47 >::type x47(args[47]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 48; }
@@ -8745,6 +9039,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction49(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8795,6 +9090,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48));
+            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -8811,6 +9107,7 @@ class CppFunction49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction49(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8861,7 +9158,7 @@ class CppFunction49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -8883,6 +9180,7 @@ class CppFunction_WithFormals49 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -8933,6 +9231,7 @@ class CppFunction_WithFormals49 : public CppFunction {
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48));
+            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -8952,6 +9251,7 @@ class CppFunction_WithFormals49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9002,7 +9302,7 @@ class CppFunction_WithFormals49<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U47 >::type x47(args[47]);
             typename traits::input_parameter< U48 >::type x48(args[48]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 49; }
@@ -9023,6 +9323,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction50(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9074,6 +9375,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49));
+            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9090,6 +9392,7 @@ class CppFunction50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction50(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9141,7 +9444,7 @@ class CppFunction50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9163,6 +9466,7 @@ class CppFunction_WithFormals50 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9214,6 +9518,7 @@ class CppFunction_WithFormals50 : public CppFunction {
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49));
+            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9233,6 +9538,7 @@ class CppFunction_WithFormals50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9284,7 +9590,7 @@ class CppFunction_WithFormals50<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U48 >::type x48(args[48]);
             typename traits::input_parameter< U49 >::type x49(args[49]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 50; }
@@ -9305,6 +9611,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction51(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9357,6 +9664,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50));
+            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9373,6 +9681,7 @@ class CppFunction51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction51(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9425,7 +9734,7 @@ class CppFunction51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9447,6 +9756,7 @@ class CppFunction_WithFormals51 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9499,6 +9809,7 @@ class CppFunction_WithFormals51 : public CppFunction {
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50));
+            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9518,6 +9829,7 @@ class CppFunction_WithFormals51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9570,7 +9882,7 @@ class CppFunction_WithFormals51<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U49 >::type x49(args[49]);
             typename traits::input_parameter< U50 >::type x50(args[50]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 51; }
@@ -9591,6 +9903,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction52(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9644,6 +9957,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51));
+            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -9660,6 +9974,7 @@ class CppFunction52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction52(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9713,7 +10028,7 @@ class CppFunction52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -9735,6 +10050,7 @@ class CppFunction_WithFormals52 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9788,6 +10104,7 @@ class CppFunction_WithFormals52 : public CppFunction {
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51));
+            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -9807,6 +10124,7 @@ class CppFunction_WithFormals52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9860,7 +10178,7 @@ class CppFunction_WithFormals52<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U50 >::type x50(args[50]);
             typename traits::input_parameter< U51 >::type x51(args[51]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 52; }
@@ -9881,6 +10199,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction53(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -9935,6 +10254,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52));
+            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -9951,6 +10271,7 @@ class CppFunction53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction53(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10005,7 +10326,7 @@ class CppFunction53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10027,6 +10348,7 @@ class CppFunction_WithFormals53 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10081,6 +10403,7 @@ class CppFunction_WithFormals53 : public CppFunction {
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52));
+            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10100,6 +10423,7 @@ class CppFunction_WithFormals53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10154,7 +10478,7 @@ class CppFunction_WithFormals53<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U51 >::type x51(args[51]);
             typename traits::input_parameter< U52 >::type x52(args[52]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 53; }
@@ -10175,6 +10499,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction54(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10230,6 +10555,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53));
+            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10246,6 +10572,7 @@ class CppFunction54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction54(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10301,7 +10628,7 @@ class CppFunction54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10323,6 +10650,7 @@ class CppFunction_WithFormals54 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10378,6 +10706,7 @@ class CppFunction_WithFormals54 : public CppFunction {
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53));
+            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10397,6 +10726,7 @@ class CppFunction_WithFormals54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10452,7 +10782,7 @@ class CppFunction_WithFormals54<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U52 >::type x52(args[52]);
             typename traits::input_parameter< U53 >::type x53(args[53]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 54; }
@@ -10473,6 +10803,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction55(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10529,6 +10860,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54));
+            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10545,6 +10877,7 @@ class CppFunction55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction55(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10601,7 +10934,7 @@ class CppFunction55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10623,6 +10956,7 @@ class CppFunction_WithFormals55 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10679,6 +11013,7 @@ class CppFunction_WithFormals55 : public CppFunction {
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54));
+            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10698,6 +11033,7 @@ class CppFunction_WithFormals55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10754,7 +11090,7 @@ class CppFunction_WithFormals55<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U53 >::type x53(args[53]);
             typename traits::input_parameter< U54 >::type x54(args[54]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 55; }
@@ -10775,6 +11111,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction56(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10832,6 +11169,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55));
+            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -10848,6 +11186,7 @@ class CppFunction56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction56(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10905,7 +11244,7 @@ class CppFunction56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -10927,6 +11266,7 @@ class CppFunction_WithFormals56 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -10984,6 +11324,7 @@ class CppFunction_WithFormals56 : public CppFunction {
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55));
+            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11003,6 +11344,7 @@ class CppFunction_WithFormals56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11060,7 +11402,7 @@ class CppFunction_WithFormals56<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U54 >::type x54(args[54]);
             typename traits::input_parameter< U55 >::type x55(args[55]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 56; }
@@ -11081,6 +11423,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction57(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11139,6 +11482,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56));
+            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11155,6 +11499,7 @@ class CppFunction57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction57(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11213,7 +11558,7 @@ class CppFunction57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11235,6 +11580,7 @@ class CppFunction_WithFormals57 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11293,6 +11639,7 @@ class CppFunction_WithFormals57 : public CppFunction {
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56));
+            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11312,6 +11659,7 @@ class CppFunction_WithFormals57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11370,7 +11718,7 @@ class CppFunction_WithFormals57<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U55 >::type x55(args[55]);
             typename traits::input_parameter< U56 >::type x56(args[56]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 57; }
@@ -11391,6 +11739,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction58(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11450,6 +11799,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57));
+            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11466,6 +11816,7 @@ class CppFunction58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction58(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11525,7 +11876,7 @@ class CppFunction58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11547,6 +11898,7 @@ class CppFunction_WithFormals58 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11606,6 +11958,7 @@ class CppFunction_WithFormals58 : public CppFunction {
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57));
+            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11625,6 +11978,7 @@ class CppFunction_WithFormals58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11684,7 +12038,7 @@ class CppFunction_WithFormals58<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U56 >::type x56(args[56]);
             typename traits::input_parameter< U57 >::type x57(args[57]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 58; }
@@ -11705,6 +12059,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction59(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11765,6 +12120,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58));
+            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -11781,6 +12137,7 @@ class CppFunction59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction59(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11841,7 +12198,7 @@ class CppFunction59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -11863,6 +12220,7 @@ class CppFunction_WithFormals59 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -11923,6 +12281,7 @@ class CppFunction_WithFormals59 : public CppFunction {
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58));
+            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -11942,6 +12301,7 @@ class CppFunction_WithFormals59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12002,7 +12362,7 @@ class CppFunction_WithFormals59<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U57 >::type x57(args[57]);
             typename traits::input_parameter< U58 >::type x58(args[58]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 59; }
@@ -12023,6 +12383,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction60(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12084,6 +12445,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59));
+            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12100,6 +12462,7 @@ class CppFunction60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction60(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12161,7 +12524,7 @@ class CppFunction60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12183,6 +12546,7 @@ class CppFunction_WithFormals60 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12244,6 +12608,7 @@ class CppFunction_WithFormals60 : public CppFunction {
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59));
+            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12263,6 +12628,7 @@ class CppFunction_WithFormals60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12324,7 +12690,7 @@ class CppFunction_WithFormals60<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U58 >::type x58(args[58]);
             typename traits::input_parameter< U59 >::type x59(args[59]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 60; }
@@ -12345,6 +12711,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction61(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12407,6 +12774,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60));
+            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12423,6 +12791,7 @@ class CppFunction61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction61(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12485,7 +12854,7 @@ class CppFunction61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12507,6 +12876,7 @@ class CppFunction_WithFormals61 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12569,6 +12939,7 @@ class CppFunction_WithFormals61 : public CppFunction {
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60));
+            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12588,6 +12959,7 @@ class CppFunction_WithFormals61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12650,7 +13022,7 @@ class CppFunction_WithFormals61<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U59 >::type x59(args[59]);
             typename traits::input_parameter< U60 >::type x60(args[60]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 61; }
@@ -12671,6 +13043,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction62(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12734,6 +13107,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61));
+            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -12750,6 +13124,7 @@ class CppFunction62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction62(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12813,7 +13188,7 @@ class CppFunction62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -12835,6 +13210,7 @@ class CppFunction_WithFormals62 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12898,6 +13274,7 @@ class CppFunction_WithFormals62 : public CppFunction {
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61));
+            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -12917,6 +13294,7 @@ class CppFunction_WithFormals62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -12980,7 +13358,7 @@ class CppFunction_WithFormals62<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U60 >::type x60(args[60]);
             typename traits::input_parameter< U61 >::type x61(args[61]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 62; }
@@ -13001,6 +13379,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction63(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13065,6 +13444,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62));
+            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13081,6 +13461,7 @@ class CppFunction63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction63(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13145,7 +13526,7 @@ class CppFunction63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13167,6 +13548,7 @@ class CppFunction_WithFormals63 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13231,6 +13613,7 @@ class CppFunction_WithFormals63 : public CppFunction {
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62));
+            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13250,6 +13633,7 @@ class CppFunction_WithFormals63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13314,7 +13698,7 @@ class CppFunction_WithFormals63<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U61 >::type x61(args[61]);
             typename traits::input_parameter< U62 >::type x62(args[62]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 63; }
@@ -13335,6 +13719,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction64(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13400,6 +13785,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63));
+            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13416,6 +13802,7 @@ class CppFunction64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction64(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13481,7 +13868,7 @@ class CppFunction64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13503,6 +13890,7 @@ class CppFunction_WithFormals64 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13568,6 +13956,7 @@ class CppFunction_WithFormals64 : public CppFunction {
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63));
+            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13587,6 +13976,7 @@ class CppFunction_WithFormals64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13652,7 +14042,7 @@ class CppFunction_WithFormals64<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U62 >::type x62(args[62]);
             typename traits::input_parameter< U63 >::type x63(args[63]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 64; }
@@ -13673,6 +14063,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
         CppFunction65(RESULT_TYPE (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63,U64) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13739,6 +14130,7 @@ template <typename RESULT_TYPE, typename U0,typename U1,typename U2,typename U3,
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64));
+            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -13755,6 +14147,7 @@ class CppFunction65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
         CppFunction65(void (*fun)(U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U16,U17,U18,U19,U20,U21,U22,U23,U24,U25,U26,U27,U28,U29,U30,U31,U32,U33,U34,U35,U36,U37,U38,U39,U40,U41,U42,U43,U44,U45,U46,U47,U48,U49,U50,U51,U52,U53,U54,U55,U56,U57,U58,U59,U60,U61,U62,U63,U64) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13821,7 +14214,7 @@ class CppFunction65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U13,U14,U15,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -13843,6 +14236,7 @@ class CppFunction_WithFormals65 : public CppFunction {
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13909,6 +14303,7 @@ class CppFunction_WithFormals65 : public CppFunction {
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64));
+            END_RCPP
         }
 
         inline int nargs() { return 65; }
@@ -13928,6 +14323,7 @@ class CppFunction_WithFormals65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
 
         SEXP operator()(SEXP* args) {
+            BEGIN_RCPP
             typename traits::input_parameter< U0 >::type x0(args[0]);
             typename traits::input_parameter< U1 >::type x1(args[1]);
             typename traits::input_parameter< U2 >::type x2(args[2]);
@@ -13994,7 +14390,7 @@ class CppFunction_WithFormals65<void,U0,U1,U2,U3,U4,U5,U6,U7,U8,U9,U10,U11,U12,U
             typename traits::input_parameter< U63 >::type x63(args[63]);
             typename traits::input_parameter< U64 >::type x64(args[64]);
             ptr_fun(x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x18,x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,x30,x31,x32,x33,x34,x35,x36,x37,x38,x39,x40,x41,x42,x43,x44,x45,x46,x47,x48,x49,x50,x51,x52,x53,x54,x55,x56,x57,x58,x59,x60,x61,x62,x63,x64);
-            return R_NilValue ;
+            END_RCPP
         }
 
         inline int nargs() { return 65; }

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -121,7 +121,8 @@
         }
 
         SEXP newInstance( SEXP* args, int nargs ){
-            signed_constructor_class* p ;
+            BEGIN_RCPP
+                signed_constructor_class* p ;
             int n = constructors.size() ;
             for( int i=0; i<n; i++ ){
                 p = constructors[i];
@@ -131,7 +132,7 @@
                     return XP( ptr, true ) ;
                 }
             }
-            
+
             signed_factory_class* pfact ;
             n = factories.size() ;
             for( int i=0; i<n; i++){
@@ -142,9 +143,10 @@
                 return XP( ptr, true ) ;
               }
             }
-            
+
             throw std::range_error( "no valid constructor available for the argument list" ) ;
-        }
+            END_RCPP
+                }
 
         bool has_default_constructor(){
             int n = constructors.size() ;
@@ -163,7 +165,9 @@
         }
 
         SEXP invoke( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            BEGIN_RCPP
+
+                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -184,10 +188,13 @@
             } else {
                 return Rcpp::List::create( false, m->operator()( XP(object), args ) ) ;
             }
-        }
+            END_RCPP
+                }
 
         SEXP invoke_void( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            BEGIN_RCPP
+
+                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -203,11 +210,13 @@
                 throw std::range_error( "could not find valid method" ) ;
             }
             m->operator()( XP(object), args );
-            return R_NilValue ;
-        }
+            END_RCPP
+                }
 
         SEXP invoke_notvoid( SEXP method_xp, SEXP object, SEXP *args, int nargs ){
-            vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
+            BEGIN_RCPP
+
+                vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( EXTPTR_PTR( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
             int n = mets->size() ;
             method_class* m = 0 ;
@@ -223,7 +232,8 @@
                 throw std::range_error( "could not find valid method" ) ;
             }
             return m->operator()( XP(object), args ) ;
-        }
+            END_RCPP
+                }
 
 
         self& AddMethod( const char* name_, method_class* m, ValidMethod valid = &yes, const char* docstring = 0){
@@ -382,14 +392,18 @@
         }
 
         SEXP getProperty( SEXP field_xp , SEXP object) {
-            prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
+            BEGIN_RCPP
+                prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
             return prop->get( XP(object) );
-        }
+            END_RCPP
+                }
 
         void setProperty( SEXP field_xp, SEXP object, SEXP value)  {
-            prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
+            BEGIN_RCPP
+                prop_class* prop = reinterpret_cast< prop_class* >( EXTPTR_PTR( field_xp ) ) ;
             return prop->set( XP(object), value );
-        }
+            VOID_END_RCPP
+                }
 
 
         Rcpp::List fields( const XP_Class& class_xp ){

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -135,14 +135,12 @@ END_RCPP
 }
 
 SEXP class__newInstance(SEXP args) {
-BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	XP_Module module(CAR(p)); p = CDR(p);
 	XP_Class clazz(CAR(p)); p = CDR(p);
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 	return clazz->newInstance(cargs, nargs);
-END_RCPP
 }
 
 // relies on being set in .onLoad()
@@ -166,7 +164,6 @@ SEXP class__dummyInstance(SEXP args) {
 }
 
 SEXP CppMethod__invoke(SEXP args) {
-BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -181,13 +178,11 @@ BEGIN_RCPP
 
 	// additional arguments, processed the same way as .Call does
 	UNPACK_EXTERNAL_ARGS(cargs,p)
-	
+
    	return clazz->invoke(met, obj, cargs, nargs);
-END_RCPP
 }
 
 SEXP CppMethod__invoke_void(SEXP args) {
-BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -204,11 +199,9 @@ BEGIN_RCPP
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 	clazz->invoke_void(met, obj, cargs, nargs);
    	return R_NilValue;
-END_RCPP
 }
 
 SEXP CppMethod__invoke_notvoid(SEXP args) {
-BEGIN_RCPP
 	SEXP p = CDR(args);
 
 	// the external pointer to the class
@@ -225,7 +218,6 @@ BEGIN_RCPP
 	UNPACK_EXTERNAL_ARGS(cargs,p)
 
    	return clazz->invoke_notvoid(met, obj, cargs, nargs);
-END_RCPP
 }
 
 namespace Rcpp{


### PR DESCRIPTION
It appears as if moving the BEGIN/END handling out to the highest level of the modules code allowed exceptions to propagate across the boundary between user DLLs and the Rcpp DLL, thus causing a crash on Windows.

This changes reverts all of the modules related changes to BEGIN/END handling, essentially leaving them exactly as they were (and allowing our tests to continue passing).

AFAIK we need to either do this or need to rework the modules code so that the exceptions no longer propagate (I don't think just suppressing the test on Windows is an option as this represents a change in behavior which may crash packages currently on CRAN).