### PR TITLE
Resolve #213: Cannot sapply lambda functions

### DIFF
--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -58,6 +58,11 @@
     #endif
 #endif
 
+// Check for the presence of C++0x (or later) support
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+  #define RCPP_USING_CXX0X_OR_LATER
+#endif
+
 // Check C++0x/11 features
 #if defined(__INTEL_COMPILER)
     #if __cplusplus >= 201103L

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -22,19 +22,42 @@
 #ifndef Rcpp__sugar__sapply_h
 #define Rcpp__sugar__sapply_h
 
+#if (__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X__)
+	#define RCPP_USE_CXX11 1
+#else
+	#define RCPP_USE_CXX11 0
+#endif 
+
+#if RCPP_USE_CXX11
+	#include <type_traits>
+#endif
+
 namespace Rcpp{
 namespace sugar{
+
+template <typename Function, typename SugarExpression>
+struct sapply_application_result_of
+{
+#if RCPP_USE_CXX11
+	typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
+#else
+	typedef typename ::Rcpp::traits::result_of<Function>::type type;
+#endif
+} ;
+
+// template <typename Function, typename SugarExpression>
+// using sapply_application_result_of_t = typename sapply_application_result_of<Function, SugarExpression>::type;
 
 template <int RTYPE, bool NA, typename T, typename Function, bool NO_CONVERSION>
 class Sapply : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::traits::result_of<Function>::type
+		typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type
 	>::rtype ,
 	true ,
 	Sapply<RTYPE,NA,T,Function,NO_CONVERSION>
 > {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type result_type ;
 	const static int RESULT_R_TYPE =
 		Rcpp::traits::r_sexptype_traits<result_type>::rtype ;
 
@@ -65,13 +88,13 @@ private:
 template <int RTYPE, bool NA, typename T, typename Function>
 class Sapply<RTYPE,NA,T,Function,true> : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::traits::result_of<Function>::type
+		typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type
 	>::rtype ,
 	true ,
 	Sapply<RTYPE,NA,T,Function,true>
 > {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type result_type ;
 	const static int RESULT_R_TYPE =
 		Rcpp::traits::r_sexptype_traits<result_type>::rtype ;
 
@@ -102,15 +125,15 @@ template <int RTYPE, bool NA, typename T, typename Function >
 inline sugar::Sapply<
     RTYPE,NA,T,Function,
     traits::same_type<
-        typename ::Rcpp::traits::result_of<Function>::type ,
-        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::traits::result_of<Function>::type >::rtype >::type
+        typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type ,
+        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type >::rtype >::type
     >::value
 >
 sapply( const Rcpp::VectorBase<RTYPE,NA,T>& t, Function fun ){
 	return sugar::Sapply<RTYPE,NA,T,Function,
 	traits::same_type<
-        typename ::Rcpp::traits::result_of<Function>::type ,
-        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::traits::result_of<Function>::type >::rtype >::type
+        typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type ,
+        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type >::rtype >::type
     >::value >( t, fun ) ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -22,14 +22,8 @@
 #ifndef Rcpp__sugar__sapply_h
 #define Rcpp__sugar__sapply_h
 
-#if (__cplusplus >= 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X__)
-	#define RCPP_USE_CXX11 1
-#else
-	#define RCPP_USE_CXX11 0
-#endif 
-
-#if RCPP_USE_CXX11
-	#include <type_traits>
+#if defined(RCPP_USING_CXX0X_OR_LATER)
+	#include <type_traits> // ::std::result_of
 #endif
 
 namespace Rcpp{
@@ -38,7 +32,7 @@ namespace sugar{
 template <typename Function, typename SugarExpression>
 struct sapply_application_result_of
 {
-#if RCPP_USE_CXX11
+#if defined(RCPP_USING_CXX0X_OR_LATER)
 	typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
 #else
 	typedef typename ::Rcpp::traits::result_of<Function>::type type;


### PR DESCRIPTION
Explanation: https://github.com/RcppCore/Rcpp/issues/213#issuecomment-101023263

I think this can benefit from another pair of eyes for review and advice -- in particular, regarding the placement and naming of the constructs mentioned in the explanation (including the location of `RCPP_USE_CXX11`). Hence, feedback very much welcome! :-)