### PR TITLE
Safer `DataFrame(SEXP)` ctor

### DIFF
--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -2,7 +2,7 @@
 //
 // DataFrame.h: Rcpp R/C++ interface class library -- data frames
 //
-// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -40,7 +40,7 @@ namespace Rcpp{
         typedef Vector<VECSXP, StoragePolicy> Parent ;
 
         DataFrame_Impl() : Parent( internal::empty_data_frame() ){}
-        DataFrame_Impl(SEXP x) {
+        DataFrame_Impl(SEXP x) : Parent(x) {
             set__(x);
         }
         DataFrame_Impl( const DataFrame_Impl& other){

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION Rcpp_Version(0,11,6)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,11,6,0)
+#define RCPP_DEV_VERSION RcppDevVersion(0,11,6,1)
 
 #endif
 


### PR DESCRIPTION
The motivations are clearly explained in hadley/dplyr#998 reported by @spkal 

There was a risk of garbage collection triggered by the default constructor of `Vector`, called implicitly by the `DataFrame(SEXP)` constructor before the `SEXP` gets a chance of being protected. 

This trivial change should fix it. 