### PR TITLE
R_xlen_t as the vector length to support long vector

### DIFF
--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -110,7 +110,7 @@ namespace Rcpp{
         }
 
         operator SEXP() const {
-            size_t n = data.size();
+            R_xlen_t n = data.size();
             NumericVector out(n);
             CharacterVector names(n);
             for (size_t i=0; i<n; i++) {

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -103,7 +103,7 @@ namespace Rcpp{
             bool use_default_strings_as_factors = true ;
             bool strings_as_factors = true ;
             int strings_as_factors_index = -1 ;
-            int n = obj.size() ;
+            R_xlen_t n = obj.size() ;
             CharacterVector names = obj.attr( "names" ) ;
             if( !names.isNULL() ){
                 for( int i=0; i<n; i++){

--- a/inst/include/Rcpp/DottedPairImpl.h
+++ b/inst/include/Rcpp/DottedPairImpl.h
@@ -63,11 +63,11 @@ namespace Rcpp{
         template <typename T>
         void replace( const int& index, const T& object ) ;
 
-        inline R_len_t length() const {
+        inline R_xlen_t length() const {
             return ::Rf_length(static_cast<const CLASS&>(*this).get__()) ;
         }
 
-        inline R_len_t size() const {
+        inline R_xlen_t size() const {
             return ::Rf_length(static_cast<const CLASS&>(*this).get__()) ;
         }
 

--- a/inst/include/Rcpp/DottedPairImpl.h
+++ b/inst/include/Rcpp/DottedPairImpl.h
@@ -64,11 +64,11 @@ namespace Rcpp{
         void replace( const int& index, const T& object ) ;
 
         inline R_xlen_t length() const {
-            return ::Rf_length(static_cast<const CLASS&>(*this).get__()) ;
+            return ::Rf_xlength(static_cast<const CLASS&>(*this).get__()) ;
         }
 
         inline R_xlen_t size() const {
-            return ::Rf_length(static_cast<const CLASS&>(*this).get__()) ;
+            return ::Rf_xlength(static_cast<const CLASS&>(*this).get__()) ;
         }
 
         /**

--- a/inst/include/Rcpp/Fast.h
+++ b/inst/include/Rcpp/Fast.h
@@ -30,9 +30,9 @@ public:
 
     Fast( const VECTOR& v_) : v(v_), data( v_.begin() ){}
 
-    inline value_type& operator[]( int i){ return data[i] ; }
-    inline const value_type& operator[]( int i) const { return data[i] ; }
-    inline int size() const { return v.size() ; }
+    inline value_type& operator[]( R_xlen_t i){ return data[i] ; }
+    inline const value_type& operator[]( R_xlen_t i) const { return data[i] ; }
+    inline R_xlen_t size() const { return v.size() ; }
 
 private:
     const VECTOR& v ;

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -180,7 +180,7 @@ namespace Rcpp{
     class unary_call : public std::unary_function<T,RESULT_TYPE> {
     public:
         unary_call( Language call_ ) : call(call_), proxy(call_,1) {}
-        unary_call( Language call_, int index ) : call(call_), proxy(call_,index){}
+        unary_call( Language call_, R_xlen_t index ) : call(call_), proxy(call_,index){}
         unary_call( Function fun ) : call( fun, R_NilValue), proxy(call,1) {}
 
         RESULT_TYPE operator()( const T& object ){
@@ -197,7 +197,7 @@ namespace Rcpp{
     class binary_call : public std::binary_function<T1,T2,RESULT_TYPE> {
     public:
         binary_call( Language call_ ) : call(call_), proxy1(call_,1), proxy2(call_,2) {}
-        binary_call( Language call_, int index1, int index2 ) : call(call_), proxy1(call_,index1), proxy2(call_,index2){}
+        binary_call( Language call_, R_xlen_t index1, R_xlen_t index2 ) : call(call_), proxy1(call_,index1), proxy2(call_,index2){}
         binary_call( Function fun) : call(fun, R_NilValue, R_NilValue), proxy1(call,1), proxy2(call,2){}
 
         RESULT_TYPE operator()( const T1& o1, const T2& o2 ){

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -53,7 +53,7 @@ namespace Rcpp{
 		} else {
 			if( ref.isNULL( ) ) throw index_out_of_bounds() ;
 
-                        if( static_cast<R_xlen_t>(index) > ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+                        if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
 
 			size_t i=1;
 			SEXP x = ref.get__() ;
@@ -70,7 +70,7 @@ namespace Rcpp{
     template <typename T>
 	void DottedPairImpl<CLASS>::replace( const int& index, const T& object ) {
 	    CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
 
         Shield<SEXP> x( pairlist( object ) );
         SEXP y = ref.get__() ;
@@ -84,7 +84,7 @@ namespace Rcpp{
 	template <typename CLASS>
     void DottedPairImpl<CLASS>::remove( const size_t& index ) {
         CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
         if( index == 0 ){
             ref.set__( CDR( ref.get__() ) ) ;
         } else{

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -53,7 +53,7 @@ namespace Rcpp{
 		} else {
 			if( ref.isNULL( ) ) throw index_out_of_bounds() ;
 
-			if( static_cast<R_len_t>(index) > ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+                        if( static_cast<R_xlen_t>(index) > ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
 
 			size_t i=1;
 			SEXP x = ref.get__() ;
@@ -70,7 +70,7 @@ namespace Rcpp{
     template <typename T>
 	void DottedPairImpl<CLASS>::replace( const int& index, const T& object ) {
 	    CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_len_t>(index) >= ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= ::Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
 
         Shield<SEXP> x( pairlist( object ) );
         SEXP y = ref.get__() ;
@@ -84,7 +84,7 @@ namespace Rcpp{
 	template <typename CLASS>
     void DottedPairImpl<CLASS>::remove( const size_t& index ) {
         CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_len_t>(index) >= Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= Rf_length(ref.get__()) ) throw index_out_of_bounds() ;
         if( index == 0 ){
             ref.set__( CDR( ref.get__() ) ) ;
         } else{

--- a/inst/include/Rcpp/api/meat/export.h
+++ b/inst/include/Rcpp/api/meat/export.h
@@ -27,7 +27,7 @@ namespace internal{
 
     template <typename InputIterator, typename value_type>
     void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_generic_tag ) {
-        R_xlen_t n = ::Rf_length(x) ;
+        R_xlen_t n = ::Rf_xlength(x) ;
         for( R_xlen_t i=0; i<n; i++, ++first ){
             *first = ::Rcpp::as<value_type>( VECTOR_ELT(x, i) ) ;
         }
@@ -49,9 +49,9 @@ namespace internal{
             Container get(){
                 if( TYPEOF(object) == RTYPE ){
                    T* start = Rcpp::internal::r_vector_start<RTYPE>(object) ;
-                   return Container( start, start + Rf_length(object) ) ;
+                   return Container( start, start + Rf_xlength(object) ) ;
                 }
-                Container vec( ::Rf_length(object) );
+                Container vec( ::Rf_xlength(object) );
                 ::Rcpp::internal::export_range( object, vec.begin() ) ;
                 return vec ;
             }

--- a/inst/include/Rcpp/api/meat/export.h
+++ b/inst/include/Rcpp/api/meat/export.h
@@ -27,8 +27,8 @@ namespace internal{
 
     template <typename InputIterator, typename value_type>
     void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_generic_tag ) {
-        R_len_t n = ::Rf_length(x) ;
-        for( R_len_t i=0; i<n; i++, ++first ){
+        R_xlen_t n = ::Rf_length(x) ;
+        for( R_xlen_t i=0; i<n; i++, ++first ){
             *first = ::Rcpp::as<value_type>( VECTOR_ELT(x, i) ) ;
         }
     }

--- a/inst/include/Rcpp/api/meat/wrap.h
+++ b/inst/include/Rcpp/api/meat/wrap.h
@@ -28,13 +28,13 @@ namespace internal{
 template <typename InputIterator, typename KEY, typename VALUE, int RTYPE>
 inline SEXP range_wrap_dispatch___impl__pair( InputIterator first, InputIterator last, Rcpp::traits::true_type ){
 	RCPP_DEBUG_3( "range_wrap_dispatch___impl__pair<KEY = %s, VALUE = %s, RTYPE = %d>\n", DEMANGLE(KEY), DEMANGLE(VALUE), RTYPE)
-    size_t size = std::distance( first, last ) ;
+    R_xlen_t size = std::distance( first, last ) ;
 	//typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
 	CharacterVector names(size) ;
 	Vector<RTYPE> x(size) ;
 	Rcpp::String buffer ;
-	for( size_t i = 0; i < size ; i++, ++first){
+	for( R_xlen_t i = 0; i < size ; i++, ++first){
         buffer   = first->first ;
         x[i]     = first->second ;
         names[i] = buffer ;
@@ -45,12 +45,12 @@ inline SEXP range_wrap_dispatch___impl__pair( InputIterator first, InputIterator
 
 template <typename InputIterator, typename KEY, typename VALUE, int RTYPE>
 inline SEXP range_wrap_dispatch___impl__pair( InputIterator first, InputIterator last, Rcpp::traits::false_type ){
-	size_t size = std::distance( first, last ) ;
+	R_xlen_t size = std::distance( first, last ) ;
 
 	Shield<SEXP> names( Rf_allocVector(STRSXP, size) ) ;
 	Shield<SEXP> x( Rf_allocVector(VECSXP, size) ) ;
 	Rcpp::String buffer ;
-	for( size_t i = 0; i < size ; i++, ++first){
+	for( R_xlen_t i = 0; i < size ; i++, ++first){
         buffer = first->first ;
         SET_VECTOR_ELT( x, i, Rcpp::wrap(first->second) );
         SET_STRING_ELT( names, i, buffer.get_sexp() ) ;

--- a/inst/include/Rcpp/internal/Proxy_Iterator.h
+++ b/inst/include/Rcpp/internal/Proxy_Iterator.h
@@ -112,7 +112,7 @@ public:
 
 		inline int index() const { return proxy.index ; }
 
-		inline PROXY operator[](int i){ return PROXY(*proxy.parent, proxy.index + i) ; }
+		inline PROXY operator[](R_xlen_t i){ return PROXY(*proxy.parent, proxy.index + i) ; }
 
 private:
 	PROXY proxy ;

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -28,19 +28,19 @@ namespace Rcpp{
 
 
 		template <typename T>
-		std::wstring as_string_elt__impl( SEXP x, R_len_t i, Rcpp::traits::true_type ){
+		std::wstring as_string_elt__impl( SEXP x, R_xlen_t i, Rcpp::traits::true_type ){
 			const char* y = char_get_string_elt( x, i ) ;
 			return std::wstring(y, y+strlen(y) ) ;
 		}
 
 		template <typename T>
-		std::string as_string_elt__impl( SEXP x, R_len_t i, Rcpp::traits::false_type ){
+		std::string as_string_elt__impl( SEXP x, R_xlen_t i, Rcpp::traits::false_type ){
 			return char_get_string_elt( x, i ) ;
 		}
 
 		template <typename T>
 		const std::basic_string< typename Rcpp::traits::char_type<T>::type >
-		as_string_elt( SEXP x, R_len_t i ){
+		as_string_elt( SEXP x, R_xlen_t i ){
 			return as_string_elt__impl<T>( x, i, typename Rcpp::traits::is_wide_string<T>::type() ) ;
 		}
 
@@ -80,8 +80,8 @@ namespace Rcpp{
 		template <typename InputIterator, typename value_type>
 		void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_string_tag ) {
 			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "expecting a string vector" ) ;
-			R_len_t n = ::Rf_length(x) ;
-			for( R_len_t i=0; i<n; i++, ++first ){
+			R_xlen_t n = ::Rf_length(x) ;
+			for( R_xlen_t i=0; i<n; i++, ++first ){
 				*first = as_string_elt<typename std::iterator_traits<InputIterator>::value_type> ( x, i ) ;
 			}
 		}
@@ -104,8 +104,8 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) ) ;
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			R_len_t size = ::Rf_length(y)  ;
-			for( R_len_t i=0; i<size; i++){
+			R_xlen_t size = ::Rf_length(y)  ;
+			for( R_xlen_t i=0; i<size; i++){
 				res[i] =  start[i] ;
 			}
 		}
@@ -116,8 +116,8 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) );
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			R_len_t size = ::Rf_length(y)  ;
-			for( R_len_t i=0; i<size; i++){
+			R_xlen_t size = ::Rf_length(y)  ;
+			for( R_xlen_t i=0; i<size; i++){
 				res[i] = caster<STORAGE,value_type>(start[i]) ;
 			}
 		}
@@ -134,8 +134,8 @@ namespace Rcpp{
 		template <typename T, typename value_type>
 		void export_indexing__dispatch( SEXP x, T& res, ::Rcpp::traits::r_type_string_tag ) {
 			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "expecting a string vector" ) ;
-			R_len_t n = ::Rf_length(x) ;
-			for( R_len_t i=0; i<n; i++ ){
+			R_xlen_t n = ::Rf_length(x) ;
+			for( R_xlen_t i=0; i<n; i++ ){
 				res[i] = as_string_elt< value_type >( x, i) ;
 			}
 		}

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -52,7 +52,7 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) ) ;
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			std::copy( start, start + ::Rf_length(y), first ) ;
+			std::copy( start, start + ::Rf_xlength(y), first ) ;
 		}
 
 		template <typename InputIterator, typename value_type>
@@ -61,7 +61,7 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) ) ;
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			std::transform( start, start + ::Rf_length(y) , first, caster<STORAGE,value_type> ) ;
+			std::transform( start, start + ::Rf_xlength(y) , first, caster<STORAGE,value_type> ) ;
         }
 
         // implemented in meat
@@ -80,7 +80,7 @@ namespace Rcpp{
 		template <typename InputIterator, typename value_type>
 		void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_string_tag ) {
 			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "expecting a string vector" ) ;
-			R_xlen_t n = ::Rf_length(x) ;
+			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++, ++first ){
 				*first = as_string_elt<typename std::iterator_traits<InputIterator>::value_type> ( x, i ) ;
 			}
@@ -104,7 +104,7 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) ) ;
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			R_xlen_t size = ::Rf_length(y)  ;
+			R_xlen_t size = ::Rf_xlength(y)  ;
 			for( R_xlen_t i=0; i<size; i++){
 				res[i] =  start[i] ;
 			}
@@ -116,7 +116,7 @@ namespace Rcpp{
 			typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 			Shield<SEXP> y( ::Rcpp::r_cast<RTYPE>(x) );
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
-			R_xlen_t size = ::Rf_length(y)  ;
+			R_xlen_t size = ::Rf_xlength(y)  ;
 			for( R_xlen_t i=0; i<size; i++){
 				res[i] = caster<STORAGE,value_type>(start[i]) ;
 			}
@@ -134,7 +134,7 @@ namespace Rcpp{
 		template <typename T, typename value_type>
 		void export_indexing__dispatch( SEXP x, T& res, ::Rcpp::traits::r_type_string_tag ) {
 			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "expecting a string vector" ) ;
-			R_xlen_t n = ::Rf_length(x) ;
+			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++ ){
 				res[i] = as_string_elt< value_type >( x, i) ;
 			}

--- a/inst/include/Rcpp/internal/r_vector.h
+++ b/inst/include/Rcpp/internal/r_vector.h
@@ -61,7 +61,7 @@ inline Rcomplex get_zero<CPLXSXP,Rcomplex>(){
 template<int RTYPE> void r_init_vector(SEXP x){
 	typedef typename ::Rcpp::traits::storage_type<RTYPE>::type CTYPE ;
 	CTYPE* start=r_vector_start<RTYPE>(x) ;
-	std::fill( start, start + Rf_length(x), get_zero<RTYPE,CTYPE>() ) ;
+	std::fill( start, start + Rf_xlength(x), get_zero<RTYPE,CTYPE>() ) ;
 }
 /**
  * Initializes a generic vector (VECSXP). Does nothing since

--- a/inst/include/Rcpp/sugar/block/SugarBlock_1.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_1.h
@@ -31,10 +31,10 @@ public:
     typedef RESULT_TYPE (*FunPtr)(U1) ;
     SugarBlock_1( FunPtr ptr_, const T1 & vec_) : ptr(ptr_), vec(vec_){}
 
-    inline RESULT_TYPE operator[]( int i) const {
+    inline RESULT_TYPE operator[]( R_xlen_t i) const {
         return ptr( vec[i] ) ;
     }
-    inline int size() const { return vec.size() ; }
+    inline R_xlen_t size() const { return vec.size() ; }
 
 private:
     FunPtr ptr ;

--- a/inst/include/Rcpp/sugar/block/SugarBlock_2.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_2.h
@@ -34,10 +34,10 @@ public:
         // TODO: check that x and y have same size
     }
 
-    inline RESULT_TYPE operator[]( int i) const {
+    inline RESULT_TYPE operator[]( R_xlen_t i) const {
         return ptr( x[i], y[i] ) ;
     }
-    inline int size() const { return x.size() ; }
+    inline R_xlen_t size() const { return x.size() ; }
 
 private:
     FunPtr ptr ;
@@ -53,10 +53,10 @@ public:
     SugarBlock_2__VP( FunPtr ptr_, const T1 & x_, U2 u2 ) :
         ptr(ptr_), x(x_), y(u2){}
 
-    inline RESULT_TYPE operator[]( int i) const {
+    inline RESULT_TYPE operator[]( R_xlen_t i) const {
         return ptr( x[i], y ) ;
     }
-    inline int size() const { return x.size() ; }
+    inline R_xlen_t size() const { return x.size() ; }
 
 private:
     FunPtr ptr ;
@@ -71,10 +71,10 @@ public:
     SugarBlock_2__PV( FunPtr ptr_, U1 u1, const T2& y_ ) :
         ptr(ptr_), x(u1), y(y_){}
 
-    inline RESULT_TYPE operator[]( int i) const {
+    inline RESULT_TYPE operator[]( R_xlen_t i) const {
         return ptr( x, y[i] ) ;
     }
-    inline int size() const { return y.size() ; }
+    inline R_xlen_t size() const { return y.size() ; }
 
 private:
     FunPtr ptr ;

--- a/inst/include/Rcpp/sugar/block/SugarBlock_3.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_3.h
@@ -41,10 +41,10 @@ public:
         ptr(ptr_), x(x_), y(y_), z(z_) {
         // TODO: size checks, recycling, etc ...
     }
-    inline RESULT_TYPE operator[]( int i) const {
+    inline RESULT_TYPE operator[]( R_xlen_t i) const {
         return ptr( x[i], y[i], z[i] ) ;
     }
-    inline int size() const { return x.size() ; }
+    inline R_xlen_t size() const { return x.size() ; }
 
 private:
     FunPtr ptr ;

--- a/inst/include/Rcpp/sugar/block/SugarMath.h
+++ b/inst/include/Rcpp/sugar/block/SugarMath.h
@@ -37,12 +37,12 @@ public:
 
 	SugarMath_1( FunPtr ptr_, const VEC_TYPE & vec_) : ptr(ptr_), vec(vec_){}
 
-	inline RESULT_TYPE operator[]( int i) const {
+	inline RESULT_TYPE operator[]( R_xlen_t i) const {
 		U1 x = vec[i] ;
 		if( ISNAN(x) ) return x;
 		return ptr( x ) ;
 	}
-	inline int size() const { return vec.size() ; }
+	inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	FunPtr ptr ;
@@ -60,12 +60,12 @@ public:
 
 	SugarMath_1( FunPtr ptr_, const VEC_TYPE & vec_) : ptr(ptr_), vec(vec_){}
 
-	inline RESULT_TYPE operator[]( int i) const {
+	inline RESULT_TYPE operator[]( R_xlen_t i) const {
 		int x = vec[i] ;
 		if( Rcpp::traits::is_na<INTSXP>(x) ) return Rcpp::traits::get_na<REALSXP>( ) ;
 		return ptr( x ) ;
 	}
-	inline int size() const { return vec.size() ; }
+	inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	FunPtr ptr ;
@@ -83,10 +83,10 @@ public:
 	typedef Rcpp::VectorBase< INTSXP ,false,T1> VEC_TYPE ;
 	SugarMath_1( FunPtr ptr_, const VEC_TYPE & vec_) : ptr(ptr_), vec(vec_){}
 
-	inline RESULT_TYPE operator[]( int i) const {
+	inline RESULT_TYPE operator[]( R_xlen_t i) const {
 		return ptr( vec[i] ) ;
 	}
-	inline int size() const { return vec.size() ; }
+	inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	FunPtr ptr ;

--- a/inst/include/Rcpp/sugar/block/Vectorized_Math.h
+++ b/inst/include/Rcpp/sugar/block/Vectorized_Math.h
@@ -34,10 +34,10 @@ public:
     typedef typename Rcpp::traits::Extractor<REALSXP,NA,VEC>::type VEC_EXT ;
 
     Vectorized( const VEC_TYPE& object_) : object( object_.get_ref() ){}
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return Func( object[i] ) ;
     }
-    inline int size() const { return object.size(); }
+    inline R_xlen_t size() const { return object.size(); }
 
 private:
     const VEC_EXT& object ;
@@ -50,12 +50,12 @@ public:
     typedef typename Rcpp::traits::Extractor<INTSXP,NA,VEC>::type VEC_EXT ;
 
     Vectorized_INTSXP( const VEC_TYPE& object_) : object( object_.get_ref() ){}
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         int x = object[i] ;
         if( x == NA_INTEGER ) return NA_REAL ;
         return Func( x ) ;
     }
-    inline int size() const { return object.size(); }
+    inline R_xlen_t size() const { return object.size(); }
 
 private:
     const VEC_EXT& object ;
@@ -68,10 +68,10 @@ public:
     typedef typename Rcpp::traits::Extractor<INTSXP,false,VEC>::type VEC_EXT ;
 
     Vectorized_INTSXP( const VEC_TYPE& object_) : object( object_.get_ref() ){}
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return Func( object[i] ) ;
     }
-    inline int size() const { return object.size(); }
+    inline R_xlen_t size() const { return object.size(); }
 
 private:
     const VEC_EXT& object ;

--- a/inst/include/Rcpp/sugar/functions/all.h
+++ b/inst/include/Rcpp/sugar/functions/all.h
@@ -33,10 +33,10 @@ public:
 	All( const VEC_TYPE& t ) : PARENT() , object(t) {}
 
 	void apply(){
-		int n = object.size() ;
+		R_xlen_t n = object.size() ;
 		int current = 0 ;
 		PARENT::reset() ;
-		for( int i=0 ; i<n ; i++){
+		for( R_xlen_t i=0 ; i<n ; i++){
 			current = object[i] ;
 			if( current == FALSE ) {
 				PARENT::set_false() ;
@@ -64,9 +64,9 @@ public:
 	All( const VEC_TYPE& t ) : PARENT() , object(t) {}
 
 	void apply(){
-		int n = object.size() ;
+		R_xlen_t n = object.size() ;
 		PARENT::set_true() ;
-		for( int i=0 ; i<n ; i++){
+		for( R_xlen_t i=0 ; i<n ; i++){
 			if( object[i] == FALSE ) {
 				PARENT::set_false() ;
 				return ;

--- a/inst/include/Rcpp/sugar/functions/any.h
+++ b/inst/include/Rcpp/sugar/functions/any.h
@@ -33,10 +33,10 @@ public:
 	Any( const VEC_TYPE& t ) : PARENT() , object(t) {}
 
 	void apply(){
-		int n = object.size() ;
+		R_xlen_t n = object.size() ;
 		int current = 0 ;
 		PARENT::reset() ;
-		for( int i=0 ; i<n ; i++){
+		for( R_xlen_t i=0 ; i<n ; i++){
 			current = object[i] ;
 			if( current == TRUE ) {
 				PARENT::set_true() ;
@@ -62,9 +62,9 @@ public:
 	Any( const VEC_TYPE& t ) : PARENT() , object(t) {}
 
 	void apply(){
-		int n = object.size() ;
+		R_xlen_t n = object.size() ;
 		PARENT::set_false() ;
-		for( int i=0 ; i<n ; i++){
+		for( R_xlen_t i=0 ; i<n ; i++){
 			if( object[i] == TRUE ) {
 				PARENT::set_true() ;
 				return ;

--- a/inst/include/Rcpp/sugar/functions/clamp.h
+++ b/inst/include/Rcpp/sugar/functions/clamp.h
@@ -65,10 +65,10 @@ public:
 
 	Clamp_Primitive_Vector_Primitive( STORAGE lhs_, const T& vec_, STORAGE rhs_) : vec(vec_), op(lhs_,rhs_) {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return op( vec[i] ) ;
 	}
-	inline int size() const { return vec.size() ; }
+        inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	const T& vec ;

--- a/inst/include/Rcpp/sugar/functions/complex.h
+++ b/inst/include/Rcpp/sugar/functions/complex.h
@@ -44,13 +44,13 @@ public:
 
 	SugarComplex( FunPtr ptr_, const VEC_TYPE & vec_) : ptr(ptr_), vec(vec_){}
 
-	inline RESULT_TYPE operator[]( int i) const {
+        inline RESULT_TYPE operator[]( R_xlen_t i) const {
 		Rcomplex x = vec[i] ;
 		if( Rcpp::traits::is_na<CPLXSXP>( x ) )
 			return Rcpp::traits::get_na< Rcpp::traits::r_sexptype_traits<RESULT_TYPE>::rtype >() ;
 		return ptr( x );
 	}
-	inline int size() const { return vec.size() ; }
+        inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	FunPtr ptr ;

--- a/inst/include/Rcpp/sugar/functions/cumsum.h
+++ b/inst/include/Rcpp/sugar/functions/cumsum.h
@@ -35,13 +35,13 @@ public:
 	Cumsum( const VEC_TYPE& object_ ) : object(object_){}
 
 	VECTOR get() const {
-	    int n = object.size() ;
+	    R_xlen_t n = object.size() ;
 		VECTOR result( n, Rcpp::traits::get_na<RTYPE>() ) ;
 		STORAGE current = object[0] ;
 		if( Rcpp::traits::is_na<RTYPE>(current) )
 		    return result ;
 		result[0] = current ;
-		for( int i=1; i<n; i++){
+		for( R_xlen_t i=1; i<n; i++){
 		    current = object[i] ;
 		    if( Rcpp::traits::is_na<RTYPE>(current) )
 		        return result ;

--- a/inst/include/Rcpp/sugar/functions/diff.h
+++ b/inst/include/Rcpp/sugar/functions/diff.h
@@ -41,7 +41,7 @@ public:
 	    was_na(traits::is_na<RTYPE>(previous))
 	{}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
         STORAGE y = lhs[i+1] ;
         if( previous_index != i ){
             // we don't know the previous value, we need to get it.
@@ -56,18 +56,18 @@ public:
         return res ;
 	}
 
-	inline void set_previous(int i, STORAGE value) const {
+	inline void set_previous(R_xlen_t i, STORAGE value) const {
 	    previous = value ;
 	    was_na = traits::is_na<RTYPE>(previous) ;
 	    previous_index = i ;
 	}
 
-	inline int size() const { return lhs.size() - 1 ; }
+	inline R_xlen_t size() const { return lhs.size() - 1 ; }
 
 private:
 	const LHS_TYPE& lhs ;
 	mutable STORAGE previous ;
-	mutable int previous_index ;
+	mutable R_xlen_t previous_index ;
 	mutable bool was_na ;
 } ;
 
@@ -78,7 +78,7 @@ public:
 
 	Diff( const LHS_TYPE& lhs_ ) : lhs(lhs_), previous(lhs_[0]), previous_index(0) {}
 
-	inline double operator[]( int i ) const {
+	inline double operator[]( R_xlen_t i ) const {
 		double y = lhs[i+1] ;
 		if( previous_index != i ) previous = lhs[i] ;
 		double res = y - previous ;
@@ -86,12 +86,12 @@ public:
 		previous_index = i+1 ;
 		return res ;
 	}
-	inline int size() const { return lhs.size() - 1 ; }
+	inline R_xlen_t size() const { return lhs.size() - 1 ; }
 
 private:
 	const LHS_TYPE& lhs ;
 	mutable double previous ;
-	mutable int previous_index ;
+	mutable R_xlen_t previous_index ;
 } ;
 
 template <int RTYPE, typename LHS_T>
@@ -102,7 +102,7 @@ public:
 
 	Diff( const LHS_TYPE& lhs_ ) : lhs(lhs_), previous(lhs[0]), previous_index(0) {}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		STORAGE y = lhs[i+1] ;
 		if( previous_index != i ) previous = lhs[i] ;
 		STORAGE diff = y - previous ;
@@ -110,12 +110,12 @@ public:
 		previous_index = i+1 ;
 		return y - previous ;
 	}
-	inline int size() const { return lhs.size() - 1 ; }
+	inline R_xlen_t size() const { return lhs.size() - 1 ; }
 
 private:
 	const LHS_TYPE& lhs ;
 	mutable STORAGE previous ;
-	mutable int previous_index ;
+	mutable R_xlen_t previous_index ;
 } ;
 
 } // sugar

--- a/inst/include/Rcpp/sugar/functions/head.h
+++ b/inst/include/Rcpp/sugar/functions/head.h
@@ -31,16 +31,16 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Head( const VEC_TYPE& object_, int n_ ) : object(object_), n(n_) {
+	Head( const VEC_TYPE& object_, R_xlen_t n_ ) : object(object_), n(n_) {
 		if( n < 0 ){
 			n = object.size() + n ;
 		}
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[ i ] ;
 	}
-	inline int size() const { return n; }
+	inline R_xlen_t size() const { return n; }
 
 private:
 	const VEC_TYPE& object ;
@@ -52,7 +52,7 @@ private:
 template <int RTYPE,bool NA, typename T>
 inline sugar::Head<RTYPE,NA,T> head(
 	const VectorBase<RTYPE,NA,T>& t,
-	int n
+	R_xlen_t n
 	){
 	return sugar::Head<RTYPE,NA,T>( t, n ) ;
 }

--- a/inst/include/Rcpp/sugar/functions/ifelse.h
+++ b/inst/include/Rcpp/sugar/functions/ifelse.h
@@ -52,14 +52,14 @@ public:
 		RCPP_DEBUG( DEMANGLE(IfElse) ) ;
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		int x = cond[i] ;
 		if( Rcpp::traits::is_na<LGLSXP>(x) ) return Rcpp::traits::get_na<RTYPE>() ;
 		if( x ) return lhs[i] ;
 		return rhs[i] ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -93,12 +93,12 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the same size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		if( cond[i] ) return lhs[i] ;
 		return rhs[i] ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 
@@ -133,14 +133,14 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the sale size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		int x = cond[i] ;
 		if( Rcpp::traits::is_na<LGLSXP>(x) ) return x ;
 		if( x ) return lhs ;
 		return rhs[i] ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -170,12 +170,12 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the same size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		if( cond[i] ) return lhs ;
 		return rhs[i] ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -209,14 +209,14 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the same size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		int x = cond[i] ;
 		if( Rcpp::traits::is_na<LGLSXP>(x) ) return Rcpp::traits::get_na<RTYPE>() ;
 		if( x ) return lhs[i] ;
 		return rhs ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -246,12 +246,12 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the sale size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		if( cond[i] ) return lhs[i] ;
 		return rhs ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -284,13 +284,13 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the same size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		int x = cond[i] ;
 		if( Rcpp::traits::is_na<LGLSXP>(x) ) return Rcpp::traits::get_na<RTYPE>() ;
 		return x ? lhs : rhs ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -317,11 +317,11 @@ public:
 			/* FIXME : cond, lhs and rhs must all have the same size */
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		return cond[i] ? lhs : rhs ;
 	}
 
-	inline int size() const { return cond.size() ; }
+	inline R_xlen_t size() const { return cond.size() ; }
 
 private:
 	const COND_TYPE& cond ;
@@ -394,8 +394,8 @@ template<
 inline sugar::IfElse_Primitive_Primitive< INTSXP,COND_NA,COND_T >
 ifelse(
 	const Rcpp::VectorBase<LGLSXP,COND_NA,COND_T>& cond,
-	int lhs,
-	int rhs
+	R_xlen_t lhs,
+	R_xlen_t rhs
 	){
 	return sugar::IfElse_Primitive_Primitive<INTSXP,COND_NA,COND_T>( cond, lhs, rhs ) ;
 }

--- a/inst/include/Rcpp/sugar/functions/ifelse.h
+++ b/inst/include/Rcpp/sugar/functions/ifelse.h
@@ -394,8 +394,8 @@ template<
 inline sugar::IfElse_Primitive_Primitive< INTSXP,COND_NA,COND_T >
 ifelse(
 	const Rcpp::VectorBase<LGLSXP,COND_NA,COND_T>& cond,
-	R_xlen_t lhs,
-	R_xlen_t rhs
+	int lhs,
+	int rhs
 	){
 	return sugar::IfElse_Primitive_Primitive<INTSXP,COND_NA,COND_T>( cond, lhs, rhs ) ;
 }

--- a/inst/include/Rcpp/sugar/functions/is_finite.h
+++ b/inst/include/Rcpp/sugar/functions/is_finite.h
@@ -31,11 +31,11 @@ public:
 
 	IsFinite( const VEC_TYPE& obj_) : obj(obj_){}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		return ::Rcpp::traits::is_finite<RTYPE>( obj[i] ) ;
 	}
 
-	inline int size() const { return obj.size() ; }
+	inline R_xlen_t size() const { return obj.size() ; }
 
 private:
 	const VEC_TYPE& obj ;

--- a/inst/include/Rcpp/sugar/functions/is_infinite.h
+++ b/inst/include/Rcpp/sugar/functions/is_infinite.h
@@ -31,11 +31,11 @@ public:
 
 	IsInfinite( const VEC_TYPE& obj_) : obj(obj_){}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		return ::Rcpp::traits::is_infinite<RTYPE>( obj[i] ) ;
 	}
 
-	inline int size() const { return obj.size() ; }
+	inline R_xlen_t size() const { return obj.size() ; }
 
 private:
 	const VEC_TYPE& obj ;

--- a/inst/include/Rcpp/sugar/functions/is_na.h
+++ b/inst/include/Rcpp/sugar/functions/is_na.h
@@ -33,11 +33,11 @@ public:
 
 	IsNa( const BASE& obj_) : obj(obj_){}
 
-	inline int operator[]( int i ) const {
+        inline int operator[]( R_xlen_t i ) const {
 		return ::Rcpp::traits::is_na<RTYPE>( obj[i] ) ;
 	}
 
-	inline int size() const { return obj.size() ; }
+        inline R_xlen_t size() const { return obj.size() ; }
 
 private:
 	const BASE& obj ;
@@ -55,11 +55,11 @@ public:
 
 	IsNa( const BASE& obj_) : obj(obj_){}
 
-	inline int operator[]( int i ) const {
+        inline int operator[]( R_xlen_t i ) const {
 		return FALSE ;
 	}
 
-	inline int size() const { return obj.size() ; }
+        inline R_xlen_t size() const { return obj.size() ; }
 
 private:
 	const BASE& obj ;
@@ -71,11 +71,11 @@ class IsNa_Vector_is_na : public Rcpp::VectorBase<LGLSXP, false, IsNa_Vector_is_
    public:
        IsNa_Vector_is_na( const T& x) : ref(x){}
 
-       inline int operator[]( int i) const {
+       inline int operator[]( R_xlen_t i) const {
            return ref[i].is_na() ;
        }
 
-       inline int size() const { return ref.size() ; }
+       inline R_xlen_t size() const { return ref.size() ; }
 
    private:
         const T& ref ;

--- a/inst/include/Rcpp/sugar/functions/is_nan.h
+++ b/inst/include/Rcpp/sugar/functions/is_nan.h
@@ -31,11 +31,11 @@ public:
 
 	IsNaN( const VEC_TYPE& obj_) : obj(obj_){}
 
-	inline int operator[]( int i ) const {
+        inline int operator[]( R_xlen_t i ) const {
 		return ::Rcpp::traits::is_nan<RTYPE>( obj[i] ) ;
 	}
 
-	inline int size() const { return obj.size() ; }
+        inline R_xlen_t size() const { return obj.size() ; }
 
 private:
 	const VEC_TYPE& obj ;

--- a/inst/include/Rcpp/sugar/functions/lapply.h
+++ b/inst/include/Rcpp/sugar/functions/lapply.h
@@ -38,10 +38,10 @@ public:
 	Lapply( const VEC& vec_, Function fun_ ) :
 		vec(vec_), fun(fun_){}
 
-	inline SEXP operator[]( int i ) const {
+        inline SEXP operator[]( R_xlen_t i ) const {
 		return Rcpp::wrap( fun( vec[i] ) );
 	}
-	inline int size() const { return vec.size() ; }
+        inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	const VEC& vec ;

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
@@ -43,10 +43,10 @@ public:
 	Mapply_2( const T_1& vec_1_, const T_2& vec_2_, Function fun_ ) :
 		vec_1(vec_1_), vec_2(vec_2_), fun(fun_){}
 
-	inline result_type operator[]( int i ) const {
+        inline result_type operator[]( R_xlen_t i ) const {
 		return fun( vec_1[i], vec_2[i] );
 	}
-	inline int size() const { return vec_1.size() ; }
+        inline R_xlen_t size() const { return vec_1.size() ; }
 
 private:
 	const T_1& vec_1 ;
@@ -74,10 +74,10 @@ public:
 	Mapply_2_Vector_Primitive( const T_1& vec_1_, PRIM_2 prim_2_, Function fun_ ) :
 		vec_1(vec_1_), prim_2(prim_2_), fun(fun_){}
 
-	inline result_type operator[]( int i ) const {
+        inline result_type operator[]( R_xlen_t i ) const {
 		return fun( vec_1[i], prim_2 );
 	}
-	inline int size() const { return vec_1.size() ; }
+        inline R_xlen_t size() const { return vec_1.size() ; }
 
 private:
 	const T_1& vec_1 ;
@@ -105,10 +105,10 @@ public:
 	Mapply_2_Primitive_Vector( PRIM_1 prim_1_, const T_2& vec_2_, Function fun_ ) :
 		prim_1(prim_1_), vec_2(vec_2_), fun(fun_){}
 
-	inline result_type operator[]( int i ) const {
+        inline result_type operator[]( R_xlen_t i ) const {
 		return fun( prim_1, vec_2[i] );
 	}
-	inline int size() const { return vec_2.size() ; }
+        inline R_xlen_t size() const { return vec_2.size() ; }
 
 private:
 	PRIM_1 prim_1 ;

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
@@ -52,10 +52,10 @@ public:
 	Mapply_3( const VEC_1& vec_1_, const VEC_2& vec_2_, const VEC_3& vec_3_, Function fun_ ) :
 		vec_1(vec_1_.get_ref()), vec_2(vec_2_.get_ref()), vec_3(vec_3_.get_ref()), fun(fun_){}
 
-	inline result_type operator[]( int i ) const {
+        inline result_type operator[]( R_xlen_t i ) const {
 		return fun( vec_1[i], vec_2[i], vec_3[i] );
 	}
-	inline int size() const { return vec_1.size() ; }
+        inline R_xlen_t size() const { return vec_1.size() ; }
 
 private:
 	const EXT_1& vec_1 ;

--- a/inst/include/Rcpp/sugar/functions/max.h
+++ b/inst/include/Rcpp/sugar/functions/max.h
@@ -36,8 +36,8 @@ namespace sugar{
             max_ = obj[0] ;
             if( Rcpp::traits::is_na<RTYPE>( max_ ) ) return max_ ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( Rcpp::traits::is_na<RTYPE>( current ) ) return current;
                 if( current > max_ ) max_ = current ;
@@ -61,8 +61,8 @@ namespace sugar{
         operator STORAGE() {
             max_ = obj[0] ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( current > max_ ) max_ = current ;
             }

--- a/inst/include/Rcpp/sugar/functions/mean.h
+++ b/inst/include/Rcpp/sugar/functions/mean.h
@@ -35,12 +35,12 @@ public:
 
     double get() const {
         VECTOR input = object;
-        int n = input.size();           // double pass (as in summary.c)
+        R_xlen_t n = input.size();           // double pass (as in summary.c)
         long double s = std::accumulate(input.begin(), input.end(), 0.0L);
         s /= n;
         if (R_FINITE((double)s)) {
             long double t = 0.0;
-            for (int i = 0; i < n; i++) {
+            for (R_xlen_t i = 0; i < n; i++) {
                 t += input[i] - s;
             }
             s += t/n;
@@ -60,9 +60,9 @@ public:
 
     Rcomplex get() const {
         ComplexVector input = object;
-        int n = input.size();           // double pass (as in summary.c)
+        R_xlen_t n = input.size();           // double pass (as in summary.c)
         long double s = 0.0, si = 0.0;
-        for (int i=0; i<n; i++) {
+        for (R_xlen_t i=0; i<n; i++) {
             Rcomplex z = input[i];
             s += z.r;
             si += z.i;
@@ -71,7 +71,7 @@ public:
         si /= n;
         if (R_FINITE((double)s) && R_FINITE((double)si)) {
             long double t = 0.0, ti = 0.0;
-            for (int i = 0; i < n; i++) {
+            for (R_xlen_t i = 0; i < n; i++) {
                 Rcomplex z = input[i];
                 t += z.r - s;
                 ti += z.i - si;
@@ -97,9 +97,9 @@ public:
 
     double get() const {
         LogicalVector input = object;
-        int n = input.size();       
+        R_xlen_t n = input.size();
         long double s = 0.0;
-        for (int i=0; i<n; i++) {
+        for (R_xlen_t i=0; i<n; i++) {
             if (input[i] == NA_INTEGER) return NA_REAL;
             s += input[i];
         }
@@ -119,11 +119,11 @@ public:
 
     double get() const {
         IntegerVector input = object;
-        int n = input.size();           // double pass (as in summary.c)
+        R_xlen_t n = input.size();           // double pass (as in summary.c)
         long double s = std::accumulate(input.begin(), input.end(), 0.0L);
         s /= n;
         long double t = 0.0;
-        for (int i = 0; i < n; i++) {
+        for (R_xlen_t i = 0; i < n; i++) {
             if (input[i] == NA_INTEGER) return NA_REAL;
             t += input[i] - s;
         }

--- a/inst/include/Rcpp/sugar/functions/min.h
+++ b/inst/include/Rcpp/sugar/functions/min.h
@@ -36,8 +36,8 @@ namespace sugar{
             min_ = obj[0] ;
             if( Rcpp::traits::is_na<RTYPE>( min_ ) ) return min_ ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( Rcpp::traits::is_na<RTYPE>( current ) ) return current;
                 if( current < min_ ) min_ = current ;
@@ -60,8 +60,8 @@ namespace sugar{
         operator STORAGE() {
             min_ = obj[0] ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( current < min_ ) min_ = current ;
             }

--- a/inst/include/Rcpp/sugar/functions/na_omit.h
+++ b/inst/include/Rcpp/sugar/functions/na_omit.h
@@ -27,11 +27,11 @@ namespace sugar{
 
     template <int RTYPE, bool NA, typename T>
     Vector<RTYPE> na_omit_impl(const T& x, Rcpp::traits::false_type ) {
-        int n = x.size() ;
-        int n_out = n - sum( is_na(x) ) ;
+        R_xlen_t n = x.size() ;
+        R_xlen_t n_out = n - sum( is_na(x) ) ;
 
         Vector<RTYPE> out(n_out) ;
-        for( int i=0, j=0; i<n; i++){
+        for( R_xlen_t i=0, j=0; i<n; i++){
             if( Vector<RTYPE>::is_na( x[i] ) ) continue ;
             out[j++] = x[i];
         }
@@ -40,8 +40,8 @@ namespace sugar{
 
     template <int RTYPE, bool NA, typename T>
     Vector<RTYPE> na_omit_impl(const T& x, Rcpp::traits::true_type ) {
-        int n = x.size() ;
-        int n_out = n - sum( is_na(x) ) ;
+        R_xlen_t n = x.size() ;
+        R_xlen_t n_out = n - sum( is_na(x) ) ;
 
         Vector<RTYPE> out(n_out) ;
         bool has_name = x.attr("names") != R_NilValue ;
@@ -49,14 +49,14 @@ namespace sugar{
             CharacterVector names = x.attr("names") ;
             CharacterVector onames( n_out ) ;
 
-            for( int i=0, j=0; i<n; i++){
+            for( R_xlen_t i=0, j=0; i<n; i++){
                 if( Vector<RTYPE>::is_na( x[i] ) ) continue ;
                 onames[j] = names[i] ;
                 out[j++] = x[i];
             }
             out.attr("names") = onames ;
         } else {
-            for( int i=0, j=0; i<n; i++){
+            for( R_xlen_t i=0, j=0; i<n; i++){
                 if( Vector<RTYPE>::is_na( x[i] ) ) continue ;
                 out[j++] = x[i];
             }

--- a/inst/include/Rcpp/sugar/functions/pmax.h
+++ b/inst/include/Rcpp/sugar/functions/pmax.h
@@ -107,10 +107,10 @@ public:
 
 	Pmax_Vector_Vector( const LHS_T& lhs_, const RHS_T& rhs_ ) : lhs(lhs_), rhs(rhs_), op() {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return op( lhs[i], rhs[i] ) ;
 	}
-	inline int size() const { return lhs.size() ; }
+        inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_T& lhs ;
@@ -135,10 +135,10 @@ public:
 
 	Pmax_Vector_Primitive( const LHS_T& lhs_, STORAGE rhs_ ) : lhs(lhs_), op(rhs_) {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return op( lhs[i] ) ;
 	}
-	inline int size() const { return lhs.size() ; }
+        inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_T& lhs ;

--- a/inst/include/Rcpp/sugar/functions/pmin.h
+++ b/inst/include/Rcpp/sugar/functions/pmin.h
@@ -107,10 +107,10 @@ public:
 
 	Pmin_Vector_Vector( const LHS_T& lhs_, const RHS_T& rhs_ ) : lhs(lhs_), rhs(rhs_), op() {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return op( lhs[i], rhs[i] ) ;
 	}
-	inline int size() const { return lhs.size() ; }
+        inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_T& lhs ;
@@ -135,8 +135,8 @@ public:
 
 	Pmin_Vector_Primitive( const LHS_T& lhs_, STORAGE rhs_ ) : lhs(lhs_), op(rhs_) {}
 
-	inline STORAGE operator[]( int i ) const { return op( lhs[i] ) ; }
-	inline int size() const { return lhs.size() ; }
+        inline STORAGE operator[]( R_xlen_t i ) const { return op( lhs[i] ) ; }
+        inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_T& lhs ;

--- a/inst/include/Rcpp/sugar/functions/pow.h
+++ b/inst/include/Rcpp/sugar/functions/pow.h
@@ -32,10 +32,10 @@ public:
 
 	Pow( const T& object_, EXPONENT_TYPE exponent ) : object(object_), op(exponent) {}
 
-	inline double operator[]( int i ) const {
+        inline double operator[]( R_xlen_t i ) const {
 	    return ::pow( object[i], op );
 	}
-	inline int size() const { return object.size() ; }
+        inline R_xlen_t size() const { return object.size() ; }
 
 private:
 	const T& object ;
@@ -47,11 +47,11 @@ class Pow<INTSXP,NA,T,EXPONENT_TYPE> : public Rcpp::VectorBase< REALSXP ,NA, Pow
 public:
 	Pow( const T& object_, EXPONENT_TYPE exponent ) : object(object_), op(exponent) {}
 
-	inline double operator[]( int i ) const {
+        inline double operator[]( R_xlen_t i ) const {
 		int x = object[i] ;
 	    return x == NA_INTEGER ? NA_INTEGER : ::pow( x, op );
 	}
-	inline int size() const { return object.size() ; }
+        inline R_xlen_t size() const { return object.size() ; }
 
 private:
 	const T& object ;
@@ -62,10 +62,10 @@ class Pow<INTSXP,false,T,EXPONENT_TYPE> : public Rcpp::VectorBase< REALSXP ,fals
 public:
 	Pow( const T& object_, EXPONENT_TYPE exponent ) : object(object_), op(exponent) {}
 
-	inline double operator[]( int i ) const {
+        inline double operator[]( R_xlen_t i ) const {
 	    return ::pow( object[i], op );
 	}
-	inline int size() const { return object.size() ; }
+        inline R_xlen_t size() const { return object.size() ; }
 
 private:
 	const T& object ;

--- a/inst/include/Rcpp/sugar/functions/range.h
+++ b/inst/include/Rcpp/sugar/functions/range.h
@@ -36,8 +36,8 @@ namespace sugar{
             min_ = max_ = obj[0] ;
             if( Rcpp::traits::is_na<RTYPE>( min_ ) ) return Vector<RTYPE>::create( min_, max_ ) ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( Rcpp::traits::is_na<RTYPE>( current ) ) return Vector<RTYPE>::create( min_, max_ ) ;
                 if( current < min_ ) min_ = current ;
@@ -64,8 +64,8 @@ namespace sugar{
         operator Vector<RTYPE>(){
             min_ = max_ = obj[0] ;
 
-            int n = obj.size() ;
-            for( int i=1; i<n; i++){
+            R_xlen_t n = obj.size() ;
+            for( R_xlen_t i=1; i<n; i++){
                 current = obj[i] ;
                 if( current < min_ ) min_ = current ;
                 if( current > max_ ) max_ = current ;

--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -31,17 +31,17 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Rep( const VEC_TYPE& object_, int times_ ) :
+        Rep( const VEC_TYPE& object_, R_xlen_t times_ ) :
 		object(object_), times(times_), n(object_.size()){}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[ i % n ] ;
 	}
-	inline int size() const { return times * n ; }
+        inline R_xlen_t size() const { return times * n ; }
 
 private:
 	const VEC_TYPE& object ;
-	int times, n ;
+        R_xlen_t times, n ;
 } ;
 
 template <typename T>
@@ -51,38 +51,38 @@ class Rep_Single : public Rcpp::VectorBase<
 	Rep_Single<T>
 > {
 public:
-	Rep_Single( const T& x_, int n_) : x(x_), n(n_){}
+        Rep_Single( const T& x_, R_xlen_t n_) : x(x_), n(n_){}
 
-	inline T operator[]( int i ) const {
+        inline T operator[]( R_xlen_t i ) const {
 		return x;
 	}
-	inline int size() const { return n ; }
+        inline R_xlen_t size() const { return n ; }
 
 private:
 	const T& x ;
-	int n ;
+        int R_xlen_t ;
 } ;
 
 } // sugar
 
 template <int RTYPE, bool NA, typename T>
-inline sugar::Rep<RTYPE,NA,T> rep( const VectorBase<RTYPE,NA,T>& t, int n ){
+inline sugar::Rep<RTYPE,NA,T> rep( const VectorBase<RTYPE,NA,T>& t, R_xlen_t n ){
 	return sugar::Rep<RTYPE,NA,T>( t, n ) ;
 }
 
-inline sugar::Rep_Single<double> rep( const double& x, int n ){
+inline sugar::Rep_Single<double> rep( const double& x, R_xlen_t n ){
 	return sugar::Rep_Single<double>( x, n ) ;
 }
-inline sugar::Rep_Single<int> rep( const int& x, int n ){
+inline sugar::Rep_Single<int> rep( const int& x, R_xlen_t n ){
 	return sugar::Rep_Single<int>( x, n ) ;
 }
-inline sugar::Rep_Single<Rbyte> rep( const Rbyte& x, int n ){
+inline sugar::Rep_Single<Rbyte> rep( const Rbyte& x, R_xlen_t n ){
 	return sugar::Rep_Single<Rbyte>( x, n ) ;
 }
-inline sugar::Rep_Single<Rcomplex> rep( const Rcomplex& x, int n ){
+inline sugar::Rep_Single<Rcomplex> rep( const Rcomplex& x, R_xlen_t n ){
 	return sugar::Rep_Single<Rcomplex>( x, n ) ;
 }
-inline sugar::Rep_Single<bool> rep( const bool& x, int n ){
+inline sugar::Rep_Single<bool> rep( const bool& x, R_xlen_t n ){
 	return sugar::Rep_Single<bool>( x, n ) ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -60,7 +60,7 @@ public:
 
 private:
 	const T& x ;
-        int R_xlen_t ;
+        R_xlen_t n;
 } ;
 
 } // sugar

--- a/inst/include/Rcpp/sugar/functions/rep_each.h
+++ b/inst/include/Rcpp/sugar/functions/rep_each.h
@@ -31,24 +31,23 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Rep_each( const VEC_TYPE& object_, int times_ ) :
+        Rep_each( const VEC_TYPE& object_, R_xlen_t times_ ) :
 		object(object_), times(times_), n(object.size()) {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[ i / times ] ;
 	}
-	inline int size() const { return n * times ; }
+        inline R_xlen_t size() const { return n * times ; }
 
 private:
 	const VEC_TYPE& object ;
-	int times;
-	int n ;
+        R_xlen_t times, n ;
 } ;
 
 } // sugar
 
 template <int RTYPE, bool NA, typename T>
-inline sugar::Rep_each<RTYPE,NA,T> rep_each( const VectorBase<RTYPE,NA,T>& t, int times ){
+inline sugar::Rep_each<RTYPE,NA,T> rep_each( const VectorBase<RTYPE,NA,T>& t, R_xlen_t times ){
 	return sugar::Rep_each<RTYPE,NA,T>( t, times ) ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/rep_len.h
+++ b/inst/include/Rcpp/sugar/functions/rep_len.h
@@ -31,23 +31,23 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Rep_len( const VEC_TYPE& object_, int len_ ) :
+        Rep_len( const VEC_TYPE& object_, R_xlen_t len_ ) :
 		object(object_), len(len_), n(object_.size()){}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[ i % n ] ;
 	}
-	inline int size() const { return len ; }
+        inline R_xlen_t size() const { return len ; }
 
 private:
 	const VEC_TYPE& object ;
-	int len, n ;
+        R_xlen_t len, n ;
 } ;
 
 } // sugar
 
 template <int RTYPE, bool NA, typename T>
-inline sugar::Rep_len<RTYPE,NA,T> rep_len( const VectorBase<RTYPE,NA,T>& t, int len ){
+inline sugar::Rep_len<RTYPE,NA,T> rep_len( const VectorBase<RTYPE,NA,T>& t, R_xlen_t len ){
 	return sugar::Rep_len<RTYPE,NA,T>( t, len ) ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/rev.h
+++ b/inst/include/Rcpp/sugar/functions/rev.h
@@ -34,14 +34,14 @@ public:
 	Rev( const VEC_TYPE& object_ ) :
 		object(object_), n(object_.size() - 1) {}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[n - i] ;
 	}
-	inline int size() const { return n + 1; }
+        inline R_xlen_t size() const { return n + 1; }
 
 private:
 	const VEC_TYPE& object ;
-	int n ;
+        R_xlen_t n ;
 } ;
 
 } // sugar

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -49,11 +49,11 @@ public:
 	    RCPP_DEBUG_1( "Sapply Converter = %s", DEMANGLE(converter_type) )
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		STORAGE res = converter_type::get( fun( vec[i] ) );
 		return res ;
 	}
-	inline int size() const { return vec.size() ; }
+	inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	const EXT& vec ;
@@ -84,10 +84,10 @@ public:
 	    RCPP_DEBUG_1( "Sapply  = %s", DEMANGLE(Sapply) )
 	}
 
-	inline STORAGE operator[]( int i ) const {
+	inline STORAGE operator[]( R_xlen_t i ) const {
 		return fun( vec[i] ) ;
 	}
-	inline int size() const { return vec.size() ; }
+	inline R_xlen_t size() const { return vec.size() ; }
 
 private:
 	const EXT& vec ;

--- a/inst/include/Rcpp/sugar/functions/self_match.h
+++ b/inst/include/Rcpp/sugar/functions/self_match.h
@@ -30,7 +30,7 @@ class SelfInserter {
 public:
     SelfInserter( HASH& hash_ ) : hash(hash_), index(0) {}
 
-    inline int operator()( STORAGE value ){
+    inline R_xlen_t operator()( STORAGE value ){
         typename HASH::iterator it = hash.find( value ) ;
         if( it == hash.end() ){
             hash.insert( std::make_pair(value, ++index) ) ;
@@ -42,7 +42,7 @@ public:
 
 private:
     HASH& hash ;
-    int index;
+    R_xlen_t index;
 } ;
 
 template <int RTYPE, typename TABLE_T>

--- a/inst/include/Rcpp/sugar/functions/seq_along.h
+++ b/inst/include/Rcpp/sugar/functions/seq_along.h
@@ -27,15 +27,15 @@ namespace sugar{
 
 class SeqLen : public VectorBase< INTSXP,false,SeqLen > {
 public:
-	SeqLen( int len_ ) : len(len_){}
+        SeqLen( R_xlen_t len_ ) : len(len_){}
 
-	inline int operator[]( int i ) const {
+        inline R_xlen_t operator[]( R_xlen_t i ) const {
 		return 1 + i ;
 	}
-	inline int size() const { return len ; }
+        inline R_xlen_t size() const { return len ; }
 
 private:
-	int len ;
+        R_xlen_t len ;
 } ;
 
 } // sugar
@@ -49,7 +49,7 @@ inline sugar::SeqLen seq_len( const size_t& n){
 	return sugar::SeqLen( n ) ;
 }
 
-inline Range seq(int start, int end){
+inline Range seq(R_xlen_t start, R_xlen_t end){
 	return Range( start, end ) ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/setdiff.h
+++ b/inst/include/Rcpp/sugar/functions/setdiff.h
@@ -53,7 +53,7 @@ namespace sugar{
         }
 
         Vector<RTYPE> get() const {
-            int n = lhs_set.size() ;
+            R_xlen_t n = lhs_set.size() ;
             Vector<RTYPE> out = no_init(n) ;
             std::copy( lhs_set.begin(), lhs_set.end(), out.begin() ) ;
             return out ;
@@ -116,7 +116,7 @@ namespace sugar{
         }
 
         Vector<RTYPE> get() const {
-            int n = intersect.size() ;
+            R_xlen_t n = intersect.size() ;
             Vector<RTYPE> out = no_init(n) ;
             std::copy( intersect.begin(), intersect.end(), out.begin() ) ;
             return out ;
@@ -141,7 +141,7 @@ namespace sugar{
         }
 
         Vector<RTYPE> get() const {
-            int n = result.size() ;
+            R_xlen_t n = result.size() ;
             Vector<RTYPE> out = no_init(n) ;
             std::copy( result.begin(), result.end(), out.begin() ) ;
             return out ;

--- a/inst/include/Rcpp/sugar/functions/sign.h
+++ b/inst/include/Rcpp/sugar/functions/sign.h
@@ -53,13 +53,13 @@ public:
 
 	Sign( const VEC_TYPE& object_ ) : object(object_){}
 
-	inline int operator[]( int i ) const {
+        inline int operator[]( R_xlen_t i ) const {
 		return get(i) ;
 	}
-	inline int size() const { return object.size() ; }
+        inline R_xlen_t size() const { return object.size() ; }
 
 	operator SEXP() const { return wrap( *this ); }
-	inline int get(int i) const { return sign__impl<NA,RTYPE>::get( object[i] ); }
+        inline int get(R_xlen_t i) const { return sign__impl<NA,RTYPE>::get( object[i] ); }
 private:
 	const VEC_TYPE& object ;
 } ;

--- a/inst/include/Rcpp/sugar/functions/strings/collapse.h
+++ b/inst/include/Rcpp/sugar/functions/strings/collapse.h
@@ -25,10 +25,10 @@
 namespace Rcpp{
     namespace sugar {
         template <typename Iterator>
-        inline String collapse__impl( Iterator it, int n ){
+        inline String collapse__impl( Iterator it, R_xlen_t n ){
             static String buffer ;
             buffer = "" ;
-            for( int i=0; i<n; i++ ){
+            for( R_xlen_t i=0; i<n; i++ ){
                 buffer += it[i] ;
             }
             return buffer ;

--- a/inst/include/Rcpp/sugar/functions/sum.h
+++ b/inst/include/Rcpp/sugar/functions/sum.h
@@ -36,9 +36,9 @@ public:
 
 	STORAGE get() const {
 		STORAGE result = 0 ;
-		int n = object.size() ;
+		R_xlen_t n = object.size() ;
 		STORAGE current ;
-		for( int i=0; i<n; i++){
+		for( R_xlen_t i=0; i<n; i++){
 		    current = object[i] ;
 		    if( Rcpp::traits::is_na<RTYPE>(current) )
 		        return Rcpp::traits::get_na<RTYPE>() ;
@@ -60,8 +60,8 @@ public:
 
 	double get() const {
 		double result = 0 ;
-		int n = object.size() ;
-		for( int i=0; i<n; i++){
+		R_xlen_t n = object.size() ;
+		for( R_xlen_t i=0; i<n; i++){
 		   result += object[i] ;
 		}
 		return result ;
@@ -82,8 +82,8 @@ public:
 
 	STORAGE get() const {
 		STORAGE result = 0 ;
-		int n = object.size() ;
-		for( int i=0; i<n; i++){
+		R_xlen_t n = object.size() ;
+		for( R_xlen_t i=0; i<n; i++){
 		    result += object[i] ;
 		}
 		return result ;

--- a/inst/include/Rcpp/sugar/functions/table.h
+++ b/inst/include/Rcpp/sugar/functions/table.h
@@ -52,7 +52,7 @@ public:
 private:
     IntegerVector& res ;
     CharacterVector& names ;
-    int index ;
+    R_xlen_t index ;
 } ;
 
 // we define a different Table class depending on whether we are using
@@ -69,7 +69,7 @@ public:
     }
 
     inline operator IntegerVector() const {
-        int n = hash.size() ;
+        R_xlen_t n = hash.size() ;
         IntegerVector result = no_init(n) ;
         CharacterVector names = no_init(n) ;
         std::for_each( hash.begin(), hash.end(), Grabber<HASH, RTYPE>(result, names) ) ;
@@ -100,7 +100,7 @@ public:
 
     inline operator IntegerVector() const {
         // fill the result
-        int n = map.size() ;
+        R_xlen_t n = map.size() ;
         IntegerVector result = no_init(n) ;
         CharacterVector names = no_init(n) ;
         std::for_each( map.begin(), map.end(), Grabber<SORTED_MAP,RTYPE>(result, names) ) ;

--- a/inst/include/Rcpp/sugar/functions/tail.h
+++ b/inst/include/Rcpp/sugar/functions/tail.h
@@ -31,7 +31,7 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Tail( const VEC_TYPE& object_, int n_ ) : object(object_), start(0), n(n_) {
+        Tail( const VEC_TYPE& object_, R_xlen_t n_ ) : object(object_), start(0), n(n_) {
 		if( n > 0 ){
 			start = object.size() - n ;
 		} else {
@@ -40,14 +40,14 @@ public:
 		}
 	}
 
-	inline STORAGE operator[]( int i ) const {
+        inline STORAGE operator[]( R_xlen_t i ) const {
 		return object[ start + i ] ;
 	}
-	inline int size() const { return n; }
+        inline R_xlen_t size() const { return n; }
 
 private:
 	const VEC_TYPE& object ;
-	int start, n ;
+        R_xlen_t start, n ;
 } ;
 
 } // sugar
@@ -55,7 +55,7 @@ private:
 template <int RTYPE,bool NA, typename T>
 inline sugar::Tail<RTYPE,NA,T> tail(
 	const VectorBase<RTYPE,NA,T>& t,
-	int n
+	R_xlen_t n
 	){
 	return sugar::Tail<RTYPE,NA,T>( t, n ) ;
 }

--- a/inst/include/Rcpp/sugar/functions/var.h
+++ b/inst/include/Rcpp/sugar/functions/var.h
@@ -53,7 +53,7 @@ public:
 
     double get() const{
         double sq = 0, ssq = 0;
-        for(int i = 0;i < object.size();i++) {
+        for(R_xlen_t i = 0;i < object.size();i++) {
             Rcomplex z = object[i];
             sq += z.r;
             ssq += z.r * z.r;

--- a/inst/include/Rcpp/sugar/functions/which_max.h
+++ b/inst/include/Rcpp/sugar/functions/which_max.h
@@ -32,13 +32,13 @@ public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 	WhichMax(const VEC_TYPE& obj_ ) : obj(obj_){}
 
-	int get() const {
+        R_xlen_t get() const {
 	    STORAGE current = obj[0] ;
 	    STORAGE min = current ;
-	    int index = 0 ;
+	    R_xlen_t index = 0 ;
 	    if( Rcpp::traits::is_na<RTYPE>(current) ) return NA_INTEGER ;
-	    int n = obj.size() ;
-	    for( int i=1; i<n; i++){
+	    R_xlen_t n = obj.size() ;
+	    for( R_xlen_t i=1; i<n; i++){
 		    current = obj[i] ;
 		    if( Rcpp::traits::is_na<RTYPE>(current) ) return NA_INTEGER ;
 		    if( current > min ){
@@ -61,12 +61,12 @@ public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 	WhichMax(const VEC_TYPE& obj_ ) : obj(obj_){}
 
-	int get() const {
+        R_xlen_t get() const {
 	    STORAGE current = obj[0] ;
 	    STORAGE min = current ;
-	    int index = 0 ;
-	    int n = obj.size() ;
-	    for( int i=1; i<n; i++){
+	    R_xlen_t index = 0 ;
+	    R_xlen_t n = obj.size() ;
+	    for( R_xlen_t i=1; i<n; i++){
 		    current = obj[i] ;
 		    if( current > min ){
 		        min = current ;
@@ -87,7 +87,7 @@ private:
 
 
 template <int RTYPE, bool NA, typename T>
-int which_max( const VectorBase<RTYPE,NA,T>& t ){
+R_xlen_t which_max( const VectorBase<RTYPE,NA,T>& t ){
 	return sugar::WhichMax<RTYPE,NA,T>(t).get() ;
 }
 

--- a/inst/include/Rcpp/sugar/functions/which_min.h
+++ b/inst/include/Rcpp/sugar/functions/which_min.h
@@ -32,13 +32,13 @@ public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 	WhichMin(const VEC_TYPE& obj_ ) : obj(obj_){}
 
-	int get() const {
+        R_xlen_t get() const {
 	    STORAGE current = obj[0] ;
 	    STORAGE min = current ;
-	    int index = 0 ;
+	    R_xlen_t index = 0 ;
 	    if( Rcpp::traits::is_na<RTYPE>(current) ) return NA_INTEGER ;
-	    int n = obj.size() ;
-	    for( int i=1; i<n; i++){
+	    R_xlen_t n = obj.size() ;
+	    for( R_xlen_t i=1; i<n; i++){
 		    current = obj[i] ;
 		    if( Rcpp::traits::is_na<RTYPE>(current) ) return NA_INTEGER ;
 		    if( current < min ){
@@ -61,12 +61,12 @@ public:
     typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 	WhichMin(const VEC_TYPE& obj_ ) : obj(obj_){}
 
-	int get() const {
+        R_xlen_t get() const {
 	    STORAGE current = obj[0] ;
 	    STORAGE min = current ;
-	    int index = 0 ;
-	    int n = obj.size() ;
-	    for( int i=1; i<n; i++){
+	    R_xlen_t index = 0 ;
+	    R_xlen_t n = obj.size() ;
+	    for( R_xlen_t i=1; i<n; i++){
 		    current = obj[i] ;
 		    if( current < min ){
 		        min = current ;
@@ -87,7 +87,7 @@ private:
 
 
 template <int RTYPE, bool NA, typename T>
-int which_min( const VectorBase<RTYPE,NA,T>& t ){
+R_xlen_t which_min( const VectorBase<RTYPE,NA,T>& t ){
 	return sugar::WhichMin<RTYPE,NA,T>(t).get() ;
 }
 

--- a/inst/include/Rcpp/sugar/logical/and.h
+++ b/inst/include/Rcpp/sugar/logical/and.h
@@ -209,12 +209,12 @@ public:
 
     And_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE && rhs[i] == TRUE ) return TRUE ;
         if( lhs[i] == NA_LOGICAL || rhs[i] == NA_LOGICAL ) return NA_LOGICAL ;
         return FALSE ;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -229,12 +229,12 @@ public:
 
     And_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE && rhs[i] == TRUE ) return TRUE ;
         if( rhs[i] == NA_LOGICAL ) return NA_LOGICAL ;
         return FALSE ;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -249,12 +249,12 @@ public:
 
     And_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE && rhs[i] == TRUE ) return TRUE ;
         if( lhs[i] == NA_LOGICAL ) return NA_LOGICAL ;
         return FALSE;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -269,11 +269,11 @@ public:
 
     And_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE && rhs[i] == TRUE ) return TRUE ;
         return FALSE;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/logical/or.h
+++ b/inst/include/Rcpp/sugar/logical/or.h
@@ -206,12 +206,12 @@ public:
 
     Or_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE || rhs[i] == TRUE ) return TRUE ;
         if( lhs[i] == FALSE && rhs[i] == FALSE ) return FALSE ;
         return NA_LOGICAL;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -226,12 +226,12 @@ public:
 
     Or_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE || rhs[i] == TRUE ) return TRUE ;
         if( rhs[i] == NA_LOGICAL ) return NA_LOGICAL ;
         return FALSE ;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -246,12 +246,12 @@ public:
 
     Or_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE || rhs[i] == TRUE ) return TRUE ;
         if( lhs[i] == NA_LOGICAL ) return NA_LOGICAL ;
         return FALSE;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;
@@ -266,11 +266,11 @@ public:
 
     Or_LogicalExpression_LogicalExpression( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) : lhs(lhs_), rhs(rhs_){}
 
-    inline int operator[]( int i ) const{
+    inline int operator[]( R_xlen_t i ) const{
         if( lhs[i] == TRUE || rhs[i] == TRUE ) return TRUE ;
         return FALSE;
     }
-    inline int size() const { return lhs.size(); }
+    inline R_xlen_t size() const { return lhs.size(); }
 
 private:
     const LHS_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/matrix/as_vector.h
+++ b/inst/include/Rcpp/sugar/matrix/as_vector.h
@@ -30,7 +30,7 @@ inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::false_type ){
     T& ref = t.get_ref() ;
     int nc = ref.ncol(), nr = ref.nrow() ;
-    Vector<RTYPE> out (nr*nc) ;
+    Vector<RTYPE> out (((R_xlen_t)nr) * nc) ;
     R_xlen_t k =0;
     for( int col_index=0; col_index<nc; col_index++)
         for( int row_index=0; row_index<nr; row_index++, k++)
@@ -43,7 +43,7 @@ template <int RTYPE, bool NA, typename T>
 inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::true_type ){
     Matrix<RTYPE>& ref = t.get_ref() ;
-    R_xlen_t size = ref.ncol()*ref.nrow() ;
+    R_xlen_t size = ((R_xlen_t)ref.ncol())*ref.nrow() ;
     typename Rcpp::Vector<RTYPE>::const_iterator first(static_cast<const Rcpp::Vector<RTYPE>&>(ref).begin())  ;
     return Vector<RTYPE>(first, first+size );
 }

--- a/inst/include/Rcpp/sugar/matrix/as_vector.h
+++ b/inst/include/Rcpp/sugar/matrix/as_vector.h
@@ -30,7 +30,7 @@ inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::false_type ){
     T& ref = t.get_ref() ;
     int nc = ref.ncol(), nr = ref.nrow() ;
-    Vector<RTYPE> out (((R_xlen_t)nr) * nc) ;
+    Vector<RTYPE> out (static_cast<R_xlen_t>(nr) * nc) ;
     R_xlen_t k =0;
     for( int col_index=0; col_index<nc; col_index++)
         for( int row_index=0; row_index<nr; row_index++, k++)
@@ -43,7 +43,7 @@ template <int RTYPE, bool NA, typename T>
 inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::true_type ){
     Matrix<RTYPE>& ref = t.get_ref() ;
-    R_xlen_t size = ((R_xlen_t)ref.ncol())*ref.nrow() ;
+    R_xlen_t size = static_cast<R_xlen_t>(ref.ncol())*ref.nrow() ;
     typename Rcpp::Vector<RTYPE>::const_iterator first(static_cast<const Rcpp::Vector<RTYPE>&>(ref).begin())  ;
     return Vector<RTYPE>(first, first+size );
 }

--- a/inst/include/Rcpp/sugar/matrix/as_vector.h
+++ b/inst/include/Rcpp/sugar/matrix/as_vector.h
@@ -29,11 +29,11 @@ template <int RTYPE, bool NA, typename T>
 inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::false_type ){
     T& ref = t.get_ref() ;
-    int nc = ref.ncol(), nr = ref.nrow() ;
+    R_xlen_t nc = ref.ncol(), nr = ref.nrow() ;
     Vector<RTYPE> out (nr*nc) ;
-    int k =0;
-    for( int col_index=0; col_index<nc; col_index++)
-        for( int row_index=0; row_index<nr; row_index++, k++)
+    R_xlen_t k =0;
+    for( R_xlen_t col_index=0; col_index<nc; col_index++)
+        for( R_xlen_t row_index=0; row_index<nr; row_index++, k++)
             out[k] = ref( row_index, col_index ) ;
 
     return out ;
@@ -43,7 +43,7 @@ template <int RTYPE, bool NA, typename T>
 inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::true_type ){
     Matrix<RTYPE>& ref = t.get_ref() ;
-    int size = ref.ncol()*ref.nrow() ;
+    R_xlen_t size = ref.ncol()*ref.nrow() ;
     typename Rcpp::Vector<RTYPE>::const_iterator first(static_cast<const Rcpp::Vector<RTYPE>&>(ref).begin())  ;
     return Vector<RTYPE>(first, first+size );
 }

--- a/inst/include/Rcpp/sugar/matrix/as_vector.h
+++ b/inst/include/Rcpp/sugar/matrix/as_vector.h
@@ -29,11 +29,11 @@ template <int RTYPE, bool NA, typename T>
 inline Rcpp::Vector<RTYPE>
 as_vector__impl( MatrixBase<RTYPE,NA,T>& t, Rcpp::traits::false_type ){
     T& ref = t.get_ref() ;
-    R_xlen_t nc = ref.ncol(), nr = ref.nrow() ;
+    int nc = ref.ncol(), nr = ref.nrow() ;
     Vector<RTYPE> out (nr*nc) ;
     R_xlen_t k =0;
-    for( R_xlen_t col_index=0; col_index<nc; col_index++)
-        for( R_xlen_t row_index=0; row_index<nr; row_index++, k++)
+    for( int col_index=0; col_index<nc; col_index++)
+        for( int row_index=0; row_index<nr; row_index++, k++)
             out[k] = ref( row_index, col_index ) ;
 
     return out ;

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -40,7 +40,7 @@ public:
 		return j + 1 ;
 	}
 
-	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -40,7 +40,7 @@ public:
 		return j + 1 ;
 	}
 
-	inline R_xlen_t size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -40,7 +40,7 @@ public:
 		return j + 1 ;
 	}
 
-	inline int size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return nr * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/diag.h
+++ b/inst/include/Rcpp/sugar/matrix/diag.h
@@ -40,11 +40,11 @@ public:
 	inline STORAGE operator[]( int i ) const {
 		return object( i, i ) ;
 	}
-	inline int size() const { return n; }
+	inline R_xlen_t size() const { return n; }
 
 private:
 	const MAT_TYPE& object ;
-	int n ;
+	R_xlen_t n ;
 } ;
 
 

--- a/inst/include/Rcpp/sugar/matrix/diag.h
+++ b/inst/include/Rcpp/sugar/matrix/diag.h
@@ -59,7 +59,7 @@ public:
 	inline STORAGE operator()( int i, int j ) const {
 		return (i==j) ? object[i] : 0 ;
 	}
-	inline R_xlen_t size() const { return ((R_xlen_t)n) * n; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(n) * n; }
 	inline int ncol() const { return n; }
 	inline int nrow() const { return n; }
 

--- a/inst/include/Rcpp/sugar/matrix/diag.h
+++ b/inst/include/Rcpp/sugar/matrix/diag.h
@@ -59,7 +59,7 @@ public:
 	inline STORAGE operator()( int i, int j ) const {
 		return (i==j) ? object[i] : 0 ;
 	}
-	inline int size() const { return n * n; }
+	inline R_xlen_t size() const { return ((R_xlen_t)n) * n; }
 	inline int ncol() const { return n; }
 	inline int nrow() const { return n; }
 

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -47,7 +47,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline int size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return nr * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -47,7 +47,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -47,7 +47,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline R_xlen_t size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -57,7 +57,7 @@ public:
         return converter_type::get( fun( lhs[i], rhs[j] ) );
     }
 
-    inline R_xlen_t size() const { return nr * nc ; }
+    inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
     inline int nrow() const { return nr; }
     inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -57,7 +57,7 @@ public:
         return converter_type::get( fun( lhs[i], rhs[j] ) );
     }
 
-    inline int size() const { return nr * nc ; }
+    inline R_xlen_t size() const { return nr * nc ; }
     inline int nrow() const { return nr; }
     inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -57,7 +57,7 @@ public:
         return converter_type::get( fun( lhs[i], rhs[j] ) );
     }
 
-    inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
+    inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
     inline int nrow() const { return nr; }
     inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -40,7 +40,7 @@ public:
 		return i + 1 ;
 	}
 
-	inline int size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return nr * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -40,7 +40,7 @@ public:
 		return i + 1 ;
 	}
 
-	inline R_xlen_t size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -40,7 +40,7 @@ public:
 		return i + 1 ;
 	}
 
-	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -42,7 +42,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline R_xlen_t size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -42,7 +42,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline int size() const { return nr * nc ; }
+	inline R_xlen_t size() const { return nr * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -42,7 +42,7 @@ public:
 		return get(i,j) ;
 	}
 
-	inline R_xlen_t size() const { return ((R_xlen_t)nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 

--- a/inst/include/Rcpp/sugar/nona/nona.h
+++ b/inst/include/Rcpp/sugar/nona/nona.h
@@ -33,8 +33,8 @@ namespace sugar {
 
         Nona( const SUGAR_TYPE& expr) : data(expr.get_ref()){}
 
-        inline int size() const { return data.size() ; }
-        inline STORAGE operator[](int i) const { return data[i] ; }
+        inline R_xlen_t size() const { return data.size() ; }
+        inline STORAGE operator[](R_xlen_t i) const { return data[i] ; }
 
     private:
         const VECTOR& data ;
@@ -50,12 +50,12 @@ namespace sugar {
 
         Nona( const SUGAR_TYPE& expr) : data(expr.get_ref().begin()), n(expr.size()){}
 
-        inline int size() const { return n ; }
-        inline STORAGE operator[](int i) const { return data[i] ; }
+        inline R_xlen_t size() const { return n ; }
+        inline STORAGE operator[](R_xlen_t i) const { return data[i] ; }
 
     private:
         iterator data ;
-        int n ;
+        R_xlen_t n ;
     } ;
 
     template <typename T>

--- a/inst/include/Rcpp/sugar/operators/Comparator.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator.h
@@ -37,7 +37,7 @@ public:
 	Comparator( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_) :
 		lhs(lhs_), rhs(rhs_), op() {}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		STORAGE x = lhs[i] ;
 		if( Rcpp::traits::is_na<RTYPE>( x ) ) return NA_LOGICAL ;
 		STORAGE y = rhs[i] ;
@@ -45,7 +45,7 @@ public:
 		return op( x, y ) ;
 	}
 
-	inline int size() const { return lhs.size() ; }
+	inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_TYPE& lhs ;
@@ -68,13 +68,13 @@ public:
 	Comparator( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_) :
 		lhs(lhs_), rhs(rhs_), op() {}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		STORAGE y = rhs[i] ;
 		if( Rcpp::traits::is_na<RTYPE>( y ) ) return NA_LOGICAL ;
 		return op( lhs[i], y ) ;
 	}
 
-	inline int size() const { return lhs.size() ; }
+	inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_TYPE& lhs ;
@@ -96,11 +96,11 @@ public:
 	Comparator( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_) :
 		lhs(lhs_), rhs(rhs_), op() {}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		return op( lhs[i], rhs[i] ) ;
 	}
 
-	inline int size() const { return lhs.size() ; }
+	inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const LHS_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -54,7 +54,7 @@ private:
 	Operator op ;
 
 	inline int rhs_is_na(int i) const { return rhs ; }
-	inline int rhs_is_not_na(R_xlen_t i) const {
+	inline int rhs_is_not_na(int i) const {
 		STORAGE x = lhs[i] ;
 		return Rcpp::traits::is_na<RTYPE>(x) ? x : op( x, rhs ) ;
 	}

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -41,11 +41,11 @@ public:
 
 	}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		return (this->*m)(i) ;
 	}
 
-	inline int size() const { return lhs.size() ; }
+	inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const VEC_TYPE& lhs ;
@@ -54,7 +54,7 @@ private:
 	Operator op ;
 
 	inline int rhs_is_na(int i) const { return rhs ; }
-	inline int rhs_is_not_na(int i) const {
+	inline int rhs_is_not_na(R_xlen_t i) const {
 		STORAGE x = lhs[i] ;
 		return Rcpp::traits::is_na<RTYPE>(x) ? x : op( x, rhs ) ;
 	}
@@ -80,11 +80,11 @@ public:
 
 	}
 
-	inline int operator[]( int i ) const {
+	inline int operator[]( R_xlen_t i ) const {
 		return (this->*m)(i) ;
 	}
 
-	inline int size() const { return lhs.size() ; }
+	inline R_xlen_t size() const { return lhs.size() ; }
 
 private:
 	const VEC_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/operators/divides.h
+++ b/inst/include/Rcpp/sugar/operators/divides.h
@@ -37,14 +37,14 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( x ) ) return x ;
 			STORAGE y = rhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>( y ) ? y : ( x / y ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -63,11 +63,11 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -87,13 +87,13 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE y = rhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( y ) ) return y ;
 			return lhs[i] / y ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -112,11 +112,11 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -137,12 +137,12 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( x ) ) return x ;
 			return x / rhs[i] ;
 		}
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -161,10 +161,10 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs[i] ;
 		}
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -185,11 +185,11 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -208,11 +208,11 @@ namespace sugar{
 		Divides_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -234,13 +234,13 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {
 		}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if(rhs_na) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x / rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -259,11 +259,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_) {
 		}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -283,12 +283,12 @@ namespace sugar{
 		Divides_Vector_Primitive( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( rhs_na ) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x / rhs) ;
 		}
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -306,10 +306,10 @@ namespace sugar{
 		Divides_Vector_Primitive( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_), rhs(rhs_){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] / rhs ;
 		}
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -329,12 +329,12 @@ namespace sugar{
 		Divides_Primitive_Vector( STORAGE lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()), lhs_na( Rcpp::traits::is_na<RTYPE>(lhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( lhs_na ) return lhs ;
 			STORAGE x = rhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (lhs / x) ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 	private:
 		STORAGE lhs ;
 		const VEC_EXT& rhs ;
@@ -351,10 +351,10 @@ namespace sugar{
 		Divides_Primitive_Vector( double lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs / rhs[i] ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 	private:
 		double lhs ;
 		const VEC_EXT& rhs ;
@@ -373,11 +373,11 @@ namespace sugar{
 		Divides_Primitive_Vector( STORAGE lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()), lhs_na( Rcpp::traits::is_na<RTYPE>(lhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( lhs_na ) return lhs ;
 			return lhs / rhs[i] ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		STORAGE lhs ;
@@ -395,10 +395,10 @@ namespace sugar{
 		Divides_Primitive_Vector( double lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs / rhs[i] ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		double lhs ;

--- a/inst/include/Rcpp/sugar/operators/minus.h
+++ b/inst/include/Rcpp/sugar/operators/minus.h
@@ -38,14 +38,14 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( x ) ) return x ;
 			STORAGE y = rhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>( y ) ? y : ( x - y ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -64,11 +64,11 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 		    return lhs[i] - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -88,13 +88,13 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE y = rhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( y ) ) return y ;
 			return lhs[i] - y ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -113,11 +113,11 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -137,13 +137,13 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			if( Rcpp::traits::is_na<RTYPE>( x ) ) return x ;
 			return x - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -162,11 +162,11 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -187,11 +187,11 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -209,11 +209,11 @@ namespace sugar{
 		Minus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -235,13 +235,13 @@ namespace sugar{
 		Minus_Vector_Primitive( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( rhs_na ) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x - rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -258,11 +258,11 @@ namespace sugar{
 		Minus_Vector_Primitive( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -281,13 +281,13 @@ namespace sugar{
 		Minus_Vector_Primitive( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( rhs_na ) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x - rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -304,11 +304,11 @@ namespace sugar{
 		Minus_Vector_Primitive( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] - rhs ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_EXT& lhs ;
@@ -331,11 +331,11 @@ namespace sugar{
 		Minus_Primitive_Vector( STORAGE lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()), lhs_na( Rcpp::traits::is_na<RTYPE>(lhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( lhs_na ) return lhs ;
 			return lhs - rhs[i] ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		STORAGE lhs ;
@@ -352,10 +352,10 @@ namespace sugar{
 		Minus_Primitive_Vector( double lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs - rhs[i] ;
 		}
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		double lhs ;
@@ -375,12 +375,12 @@ namespace sugar{
 		Minus_Primitive_Vector( STORAGE lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()), lhs_na( Rcpp::traits::is_na<RTYPE>(lhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( lhs_na ) return lhs ;
 		    return lhs - rhs[i] ;
 		}
 
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		STORAGE lhs ;
@@ -398,11 +398,11 @@ namespace sugar{
 		Minus_Primitive_Vector( double lhs_, const VEC_TYPE& rhs_ ) :
 			lhs(lhs_), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs - rhs[i] ;
 		}
 
-		inline int size() const { return rhs.size() ; }
+		inline R_xlen_t size() const { return rhs.size() ; }
 
 	private:
 		double lhs ;

--- a/inst/include/Rcpp/sugar/operators/not.h
+++ b/inst/include/Rcpp/sugar/operators/not.h
@@ -82,11 +82,11 @@ namespace sugar{
 		Not_Vector( const VEC_TYPE& lhs_ ) :
 			lhs(lhs_), op() {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return op.apply( lhs[i] ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/operators/plus.h
+++ b/inst/include/Rcpp/sugar/operators/plus.h
@@ -38,14 +38,14 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE lhs_ = lhs[i] ;
 			if( traits::is_na<RTYPE>(lhs_) ) return lhs_ ;
 			STORAGE rhs_ = rhs[i] ;
 			return traits::is_na<RTYPE>(rhs_) ? rhs_ : (lhs_ + rhs_) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -68,11 +68,11 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] + rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -96,13 +96,13 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE rhs_ = rhs[i] ;
 			if( traits::is_na<RTYPE>(rhs_) ) return rhs_ ;
 			return lhs[i] + rhs_  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -122,11 +122,11 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] + rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -149,13 +149,13 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE lhs_ = lhs[i] ;
 			if( traits::is_na<RTYPE>(lhs_) ) return lhs_ ;
 			return lhs_ + rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -175,11 +175,11 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] + rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -203,11 +203,11 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return lhs[i] + rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -227,11 +227,11 @@ namespace sugar{
 		Plus_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] + rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -257,13 +257,13 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) )
 			{}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( rhs_na ) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x + rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -283,11 +283,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs + lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -307,11 +307,11 @@ namespace sugar{
 		Plus_Vector_Primitive( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return rhs_na ? rhs : (rhs + lhs[i] ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -330,11 +330,11 @@ namespace sugar{
 		Plus_Vector_Primitive( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs + lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -358,12 +358,12 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x + rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -381,11 +381,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs + lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -406,11 +406,11 @@ namespace sugar{
 		Plus_Vector_Primitive_nona( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return rhs + lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -428,11 +428,11 @@ namespace sugar{
 		Plus_Vector_Primitive_nona( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs + lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;

--- a/inst/include/Rcpp/sugar/operators/times.h
+++ b/inst/include/Rcpp/sugar/operators/times.h
@@ -39,14 +39,14 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {
 		}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE lhs_ = lhs[i] ;
 			if( traits::is_na<RTYPE>(lhs_) ) return lhs_ ;
 			STORAGE rhs_ = rhs[i] ;
 			return traits::is_na<RTYPE>(rhs_) ? rhs_ : (lhs_ * rhs_) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -67,11 +67,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()) {
 		}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs[i];
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -93,13 +93,13 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE rhs_ = rhs[i] ;
 			if( traits::is_na<RTYPE>(rhs_) ) return rhs_ ;
 			return lhs[i] * rhs_  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -119,11 +119,11 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -145,13 +145,13 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE lhs_ = lhs[i] ;
 			if( traits::is_na<RTYPE>(lhs_) ) return lhs_ ;
 			return lhs_ * rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -171,11 +171,11 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -196,11 +196,11 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -220,11 +220,11 @@ namespace sugar{
 		Times_Vector_Vector( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_.get_ref()){}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs[i]  ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const LHS_EXT& lhs ;
@@ -244,13 +244,13 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) )
 			{}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			if( rhs_na ) return rhs ;
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x * rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -269,11 +269,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs * lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -292,11 +292,11 @@ namespace sugar{
 		Times_Vector_Primitive( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_), rhs_na( Rcpp::traits::is_na<RTYPE>(rhs_) ) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return rhs_na ? rhs : (rhs * lhs[i] ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -315,11 +315,11 @@ namespace sugar{
 		Times_Vector_Primitive( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs * lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -343,12 +343,12 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			STORAGE x = lhs[i] ;
 			return Rcpp::traits::is_na<RTYPE>(x) ? x : (x * rhs) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -367,11 +367,11 @@ namespace sugar{
 			lhs(lhs_.get_ref()), rhs(rhs_)
 			{}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return lhs[i] * rhs ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -390,11 +390,11 @@ namespace sugar{
 		Times_Vector_Primitive_nona( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline STORAGE operator[]( int i ) const {
+		inline STORAGE operator[]( R_xlen_t i ) const {
 			return rhs * lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;
@@ -411,11 +411,11 @@ namespace sugar{
 		Times_Vector_Primitive_nona( const VEC_TYPE& lhs_, double rhs_ ) :
 			lhs(lhs_.get_ref()), rhs(rhs_) {}
 
-		inline double operator[]( int i ) const {
+		inline double operator[]( R_xlen_t i ) const {
 			return rhs * lhs[i] ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const EXT& lhs ;

--- a/inst/include/Rcpp/sugar/operators/unary_minus.h
+++ b/inst/include/Rcpp/sugar/operators/unary_minus.h
@@ -94,11 +94,11 @@ namespace sugar{
 		UnaryMinus_Vector( const VEC_TYPE& lhs_ ) :
 			lhs(lhs_), op() {}
 
-		inline RESULT operator[]( int i ) const {
+		inline RESULT operator[]( R_xlen_t i ) const {
 			return op.apply( lhs[i] ) ;
 		}
 
-		inline int size() const { return lhs.size() ; }
+		inline R_xlen_t size() const { return lhs.size() ; }
 
 	private:
 		const VEC_TYPE& lhs ;

--- a/inst/include/Rcpp/sugar/tools/iterator.h
+++ b/inst/include/Rcpp/sugar/tools/iterator.h
@@ -30,7 +30,7 @@ namespace sugar {
     class SugarIterator {
     public:
 
-        typedef int difference_type ;
+        typedef R_xlen_t difference_type ;
         typedef typename Rcpp::traits::storage_type< Rcpp::traits::r_sexptype_traits<T>::rtype >::type STORAGE_TYPE ;
         typedef STORAGE_TYPE reference ;
         typedef STORAGE_TYPE* pointer ;
@@ -38,7 +38,7 @@ namespace sugar {
         typedef SugarIterator iterator ;
 
         SugarIterator( const T& ref_ ) :ref(ref_), index(0) {}
-        SugarIterator( const T& ref_, int index_) : ref(ref_), index(index_) {}
+        SugarIterator( const T& ref_, R_xlen_t index_) : ref(ref_), index(index_) {}
         SugarIterator( const SugarIterator& other) : ref(other.ref), index(other.index){}
 
         inline iterator& operator++(){ index++; return *this ; }
@@ -67,7 +67,7 @@ namespace sugar {
 			index -= n;
 			return *this ;
 		}
-        inline reference operator[](int i){
+        inline reference operator[](R_xlen_t i){
 		    return ref[index+i] ;
 		}
 
@@ -104,7 +104,7 @@ namespace sugar {
 
     private:
         const T& ref ;
-        int index ;
+        R_xlen_t index ;
     } ;
 
     template <typename T> struct sugar_const_iterator_type {

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -1,0 +1,89 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
+//
+// is_wide_string.h: Rcpp R/C++ interface class library -- traits to help wrap
+//
+// Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__traits__is_arithmetic__h
+#define Rcpp__traits__is_arithmetic__h
+
+namespace Rcpp{
+namespace traits{
+
+    template<typename>
+    struct is_arithmetic : public false_type { };
+
+    template<>
+    struct is_arithmetic<int> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const int> : public true_type { };
+
+    template<>
+    struct is_arithmetic<unsigned int> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const unsigned int> : public true_type { };
+
+    template<>
+    struct is_arithmetic<long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const long> : public true_type { };
+    
+    template<>
+    struct is_arithmetic<unsigned long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const unsigned long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<long long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const long long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<unsigned long long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const unsigned long long> : public true_type { };
+
+    template<>
+    struct is_arithmetic<float> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const float> : public true_type { };
+
+    template<>
+    struct is_arithmetic<double> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const double> : public true_type { };
+
+    template<>
+    struct is_arithmetic<long double> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const long double> : public true_type { };
+
+} // traits
+} // Rcpp
+
+#endif

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -30,6 +30,60 @@ namespace traits{
     struct is_arithmetic : public false_type { };
 
     template<>
+    struct is_arithmetic<bool> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const bool> : public true_type { };
+
+    template<>
+    struct is_arithmetic<char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<signed char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const signed char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<unsigned char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const unsigned char> : public true_type { };
+
+    template<>
+    struct is_arithmetic<wchar_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const wchar_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<char16_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const char16_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<char32_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const char32_t> : public true_type { };
+
+    template<>
+    struct is_arithmetic<short> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const short> : public true_type { };
+
+    template<>
+    struct is_arithmetic<unsigned short> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const unsigned short> : public true_type { };
+
+    template<>
     struct is_arithmetic<int> : public true_type { };
 
     template<>

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -65,17 +65,21 @@ namespace traits{
     template<>
     struct is_arithmetic<const unsigned long> : public true_type { };
 
-    template<>
-    struct is_arithmetic<long long> : public true_type { };
+#if defined(RCPP_HAS_LONG_LONG_TYPES)
 
     template<>
-    struct is_arithmetic<const long long> : public true_type { };
+    struct is_arithmetic<rcpp_long_long_type> : public true_type { };
 
     template<>
-    struct is_arithmetic<unsigned long long> : public true_type { };
+    struct is_arithmetic<const rcpp_long_long_type> : public true_type { };
 
     template<>
-    struct is_arithmetic<const unsigned long long> : public true_type { };
+    struct is_arithmetic<rcpp_ulong_long_type> : public true_type { };
+
+    template<>
+    struct is_arithmetic<const rcpp_ulong_long_type> : public true_type { };
+
+#endif
 
     template<>
     struct is_arithmetic<float> : public true_type { };

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -60,18 +60,6 @@ namespace traits{
     struct is_arithmetic<const wchar_t> : public true_type { };
 
     template<>
-    struct is_arithmetic<char16_t> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const char16_t> : public true_type { };
-
-    template<>
-    struct is_arithmetic<char32_t> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const char32_t> : public true_type { };
-
-    template<>
     struct is_arithmetic<short> : public true_type { };
 
     template<>

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -30,36 +30,6 @@ namespace traits{
     struct is_arithmetic : public false_type { };
 
     template<>
-    struct is_arithmetic<bool> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const bool> : public true_type { };
-
-    template<>
-    struct is_arithmetic<char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<signed char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const signed char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<unsigned char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const unsigned char> : public true_type { };
-
-    template<>
-    struct is_arithmetic<wchar_t> : public true_type { };
-
-    template<>
-    struct is_arithmetic<const wchar_t> : public true_type { };
-
-    template<>
     struct is_arithmetic<short> : public true_type { };
 
     template<>

--- a/inst/include/Rcpp/traits/traits.h
+++ b/inst/include/Rcpp/traits/traits.h
@@ -39,6 +39,7 @@ struct int2type { enum { value = I }; };
 #include <Rcpp/traits/same_type.h>
 #include <Rcpp/traits/enable_if.h>
 #include <Rcpp/traits/is_wide_string.h>
+#include <Rcpp/traits/is_arithmetic.h>
 #include <Rcpp/traits/char_type.h>
 #include <Rcpp/traits/named_object.h>
 #include <Rcpp/traits/is_convertible.h>

--- a/inst/include/Rcpp/vector/ChildVector.h
+++ b/inst/include/Rcpp/vector/ChildVector.h
@@ -27,7 +27,7 @@ class ChildVector : public T {
 
     public:
 
-    ChildVector(SEXP data_, SEXP parent_, int i_):
+    ChildVector(SEXP data_, SEXP parent_, R_xlen_t i_):
         T(data_),
         parent(parent_),
         i(i_) {}
@@ -68,7 +68,7 @@ class ChildVector : public T {
 
     private:
         SEXP parent;
-        int i;
+        R_xlen_t i;
 };
 
 } // namespace Rcpp

--- a/inst/include/Rcpp/vector/LazyVector.h
+++ b/inst/include/Rcpp/vector/LazyVector.h
@@ -33,7 +33,7 @@ public:
 
     LazyVector( const VECTOR& vec_ ) : vec(vec_), n(vec_.size()), data(n), known(n,false){}
 
-    inline stored_type operator[]( int i) const {
+    inline stored_type operator[]( R_xlen_t i) const {
         stored_type res ;
         if( ! known[i] ) {
             data[i] = res = vec[i] ;
@@ -46,7 +46,7 @@ public:
 
 private:
     const VECTOR& vec ;
-    int n ;
+    R_xlen_t n ;
     mutable std::vector<stored_type> data ;
     mutable std::vector<bool> known ;
 } ;
@@ -58,7 +58,7 @@ public:
     typedef typename VECTOR::Proxy Proxy ;
 
     LazyVector( const VECTOR& vec_) : vec(vec_){}
-    inline Proxy operator[]( int i) const { return vec[i] ; }
+    inline Proxy operator[]( R_xlen_t i) const { return vec[i] ; }
 
 private:
     const VECTOR& vec ;

--- a/inst/include/Rcpp/vector/ListOf.h
+++ b/inst/include/Rcpp/vector/ListOf.h
@@ -95,7 +95,7 @@ public:
         return list.end();
     }
 
-    inline R_len_t size() const {
+    inline R_xlen_t size() const {
         return list.size() ;
     }
 

--- a/inst/include/Rcpp/vector/ListOf.h
+++ b/inst/include/Rcpp/vector/ListOf.h
@@ -61,11 +61,11 @@ public:
 
     // subsetting operators
 
-    ChildVector<T> operator[](int i) {
+    ChildVector<T> operator[](R_xlen_t i) {
         return ChildVector<T>(list[i], list, i);
     }
 
-    const ChildVector<T> operator[](int i) const {
+    const ChildVector<T> operator[](R_xlen_t i) const {
         return ChildVector<T>(list[i], list, i);
     }
 

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -121,10 +121,10 @@ public:
         return res ;
     }
 
-    inline Proxy operator[]( int i ) {
+    inline Proxy operator[]( R_xlen_t i ) {
       return static_cast< Vector<RTYPE>* >( this )->operator[]( i ) ;
     }
-    inline const_Proxy operator[]( int i ) const {
+    inline const_Proxy operator[]( R_xlen_t i ) const {
       return static_cast< const Vector<RTYPE>* >( this )->operator[]( i ) ;
     }
 
@@ -157,7 +157,7 @@ public:
 
 private:
 
-    inline int offset( int i, int j) const { return i + nrows * j ; }
+    inline R_xlen_t offset( int i, int j) const { return i + nrows * j ; }
 
     template <typename U>
     void fill_diag__dispatch( traits::false_type, const U& u) {

--- a/inst/include/Rcpp/vector/MatrixBase.h
+++ b/inst/include/Rcpp/vector/MatrixBase.h
@@ -43,9 +43,9 @@ namespace Rcpp{
             return static_cast<const MATRIX*>(this)->operator()(i, j) ;
         }
 
-        inline R_len_t size() const { return static_cast<const MATRIX&>(*this).size() ; }
-        inline R_len_t nrow() const { return static_cast<const MATRIX&>(*this).nrow() ; }
-        inline R_len_t ncol() const { return static_cast<const MATRIX&>(*this).ncol() ; }
+        inline R_xlen_t size() const { return static_cast<const MATRIX&>(*this).size() ; }
+        inline R_xlen_t nrow() const { return static_cast<const MATRIX&>(*this).nrow() ; }
+        inline R_xlen_t ncol() const { return static_cast<const MATRIX&>(*this).ncol() ; }
 
         class iterator {
         public:

--- a/inst/include/Rcpp/vector/MatrixBase.h
+++ b/inst/include/Rcpp/vector/MatrixBase.h
@@ -51,11 +51,11 @@ namespace Rcpp{
         public:
             typedef stored_type reference ;
             typedef stored_type* pointer ;
-            typedef int difference_type ;
+            typedef R_xlen_t difference_type ;
             typedef stored_type value_type;
             typedef std::random_access_iterator_tag iterator_category ;
 
-            iterator( const MatrixBase& object_, int index_ ) :
+            iterator( const MatrixBase& object_, R_xlen_t index_ ) :
                 object(object_), i(0), j(0), nr(object_.nrow()), nc(object_.ncol()) {
 
                 update_index( index_) ;
@@ -149,7 +149,7 @@ namespace Rcpp{
                 j = internal::get_column( index_, nr, i ) ;
             }
 
-            inline int index() const {
+            inline R_xlen_t index() const {
                 return i + nr * j ;
             }
 

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -92,12 +92,12 @@ public:
         return const_start + n ;
     }
 
-    inline R_xlen_t size() const {
+    inline int size() const {
         return n ;
     }
 
 private:
-    const R_xlen_t n ;
+    const int n ;
     iterator start ;
     const_iterator const_start ;
 

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -92,12 +92,12 @@ public:
         return const_start + n ;
     }
 
-    inline R_len_t size() const {
+    inline R_xlen_t size() const {
         return n ;
     }
 
 private:
-    const R_len_t n ;
+    const R_xlen_t n ;
     iterator start ;
     const_iterator const_start ;
 

--- a/inst/include/Rcpp/vector/RangeIndexer.h
+++ b/inst/include/Rcpp/vector/RangeIndexer.h
@@ -83,17 +83,17 @@ public:
 		UNROLL_LOOP(/=)
 	}
 
-	inline Proxy operator[]( int i ) const {
+	inline Proxy operator[]( R_xlen_t i ) const {
 	    return start[i] ;
 	}
 
-	inline int size() const {
+	inline R_xlen_t size() const {
 		return size_ ;
 	}
 
 private:
 	iterator start ;
-	int size_ ;
+	R_xlen_t size_ ;
 } ;
 
 }

--- a/inst/include/Rcpp/vector/SubMatrix.h
+++ b/inst/include/Rcpp/vector/SubMatrix.h
@@ -39,7 +39,7 @@ public:
         nr( row_range_.size() )
     {}
 
-    inline int size() const { return ncol() * nrow() ; }
+    inline R_xlen_t size() const { return ((R_xlen_t)ncol()) * nrow() ; }
     inline int ncol() const { return nc ; }
     inline int nrow() const { return nr ; }
 

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -83,14 +83,10 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, obj.get() ) ) ;
     }
 
-    Vector( const R_xlen_t& size, const stored_type& u ) {
-        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size = %d, const stored_type& u )", RTYPE, size)
-        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
-        fill( u ) ;
-    }
-
-    Vector( const int& size, const stored_type& u ) {
-        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size = %d, const stored_type& u )", RTYPE, size)
+    template<typename T>
+    Vector( const T& size, const stored_type& u,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
+        RCPP_DEBUG_2( "Vector<%d>( const T& size = %d, const stored_type& u )", RTYPE, size)
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill( u ) ;
     }
@@ -107,14 +103,10 @@ public:
         Storage::set__(internal::vector_from_string<RTYPE>(st) ) ;
     }
 
-    Vector( const int& siz, stored_type (*gen)(void) ) {
+    template<typename T>
+    Vector( const T& siz, stored_type (*gen)(void),
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         RCPP_DEBUG_2( "Vector<%d>( const int& siz = %s, stored_type (*gen)(void) )", RTYPE, siz )
-        Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        std::generate( begin(), end(), gen );
-    }
-
-    Vector( const R_xlen_t& siz, stored_type (*gen)(void) ) {
-        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& siz = %s, stored_type (*gen)(void) )", RTYPE, siz )
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
         std::generate( begin(), end(), gen );
     }
@@ -160,44 +152,44 @@ public:
         RCPP_DEBUG_2( "Vector<%d>( const VectorBase<RTYPE,NA,VEC>& ) [VEC = %s]", RTYPE, DEMANGLE(VEC) )
         import_sugar_expression( other, typename traits::same_type<Vector,VEC>::type() ) ;
     }
-    template <typename U>
-    Vector( const R_xlen_t& size, const U& u) {
-        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size, const U& u )", RTYPE, size )
+    
+    template <typename T, typename U>
+    Vector( const T& size, const U& u,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
+        RCPP_DEBUG_2( "Vector<%d>( const T& size, const U& u )", RTYPE, size )
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill_or_generate( u ) ;
     }
-    template <typename U>
-    Vector( const int& size, const U& u) {
-        RCPP_DEBUG_2( "Vector<%d>( const int& size, const U& u )", RTYPE, size )
-        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
-        fill_or_generate( u ) ;
-    }
+    
     template <bool NA, typename T>
     Vector( const sugar::SingleLogicalResult<NA,T>& obj ) {
         Storage::set__( r_cast<RTYPE>( const_cast<sugar::SingleLogicalResult<NA,T>&>(obj).get_sexp() ) ) ;
         RCPP_DEBUG_2( "Vector<%d>( const sugar::SingleLogicalResult<NA,T>& ) [T = %s]", RTYPE, DEMANGLE(T) )
     }
 
-    template <typename U1>
-    Vector( const R_xlen_t& siz, stored_type (*gen)(U1), const U1& u1) {
+    template <typename T, typename U1>
+    Vector( const T& siz, stored_type (*gen)(U1), const U1& u1,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1), const U1& u1 )", RTYPE, siz )
+        RCPP_DEBUG_2( "const T& siz, stored_type (*gen)(U1), const U1& u1 )", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1) ;
     }
 
-    template <typename U1, typename U2>
-    Vector( const R_xlen_t& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2) {
+    template <typename T, typename U1, typename U2>
+    Vector( const T& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2)", RTYPE, siz )
+        RCPP_DEBUG_2( "const T& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2)", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1,u2) ;
     }
 
-    template <typename U1, typename U2, typename U3>
-    Vector( const R_xlen_t& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3) {
+    template <typename T, typename U1, typename U2, typename U3>
+    Vector( const T& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3)", RTYPE, siz )
+        RCPP_DEBUG_2( "const T& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3)", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1,u2,u3) ;
     }
@@ -209,10 +201,11 @@ public:
         std::copy( first, last, begin() ) ;
     }
 
-    template <typename InputIterator>
-    Vector( InputIterator first, InputIterator last, R_xlen_t n) {
+    template <typename InputIterator, typename T>
+    Vector( InputIterator first, InputIterator last, T n,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__(Rf_allocVector(RTYPE, n)) ;
-        RCPP_DEBUG_2( "Vector<%d>( InputIterator first, InputIterator last, R_xlen_t n = %d)", RTYPE, n )
+        RCPP_DEBUG_2( "Vector<%d>( InputIterator first, InputIterator last, T n = %d)", RTYPE, n )
         std::copy( first, last, begin() ) ;
     }
 
@@ -223,10 +216,11 @@ public:
         std::transform( first, last, begin(), func) ;
     }
 
-    template <typename InputIterator, typename Func>
-    Vector( InputIterator first, InputIterator last, Func func, R_xlen_t n){
+    template <typename InputIterator, typename Func, typename T>
+    Vector( InputIterator first, InputIterator last, Func func, T n,
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0){
         Storage::set__( Rf_allocVector( RTYPE, n ) );
-        RCPP_DEBUG_2( "Vector<%d>( InputIterator, InputIterator, Func, R_xlen_t n = %d )", RTYPE, n )
+        RCPP_DEBUG_2( "Vector<%d>( InputIterator, InputIterator, Func, T n = %d )", RTYPE, n )
         std::transform( first, last, begin(), func) ;
     }
 

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -124,6 +124,11 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
     }
+    
+    Vector( const int& size ) {
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        init() ;
+    }
 
     Vector( const Dimension& dims) {
         Storage::set__( Rf_allocVector( RTYPE, dims.prod() ) ) ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -124,6 +124,11 @@ public:
         init() ;
     }
 
+    Vector( const size_t& size ) {
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        init() ;
+    }
+
     Vector( const int& size ) {
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -237,14 +237,14 @@ public:
     /**
      * the length of the vector, uses Rf_length
      */
-    inline R_len_t length() const {
+    inline R_xlen_t length() const {
         return ::Rf_length( Storage::get__() ) ;
     }
 
     /**
      * alias of length
      */
-    inline R_len_t size() const {
+    inline R_xlen_t size() const {
         return ::Rf_length( Storage::get__() ) ;
     }
 
@@ -267,15 +267,15 @@ public:
      * it is valid
      */
     size_t offset(const size_t& i) const {
-        if( static_cast<R_len_t>(i) >= ::Rf_length(Storage::get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(i) >= ::Rf_length(Storage::get__()) ) throw index_out_of_bounds() ;
         return i ;
     }
 
-    R_len_t offset(const std::string& name) const {
+    R_xlen_t offset(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES( Storage::get__() ) ;
         if( Rf_isNull(names) ) throw index_out_of_bounds();
-        R_len_t n=size() ;
-        for( R_len_t i=0; i<n; ++i){
+        R_xlen_t n=size() ;
+        for( R_xlen_t i=0; i<n; ++i){
             if( ! name.compare( CHAR(STRING_ELT(names, i)) ) ){
                 return i ;
             }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -128,6 +128,10 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
         init() ;
     }
+    Vector( const unsigned int& size ) {
+        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
+        init() ;
+    }
 
     Vector( const double& size ) {
         Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
@@ -138,7 +142,7 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
     }
-    
+
     Vector( const Dimension& dims) {
         Storage::set__( Rf_allocVector( RTYPE, dims.prod() ) ) ;
         init() ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -83,8 +83,8 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, obj.get() ) ) ;
     }
 
-    Vector( const int& size, const stored_type& u ) {
-        RCPP_DEBUG_2( "Vector<%d>( const int& size = %d, const stored_type& u )", RTYPE, size)
+    Vector( const R_xlen_t& size, const stored_type& u ) {
+        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size = %d, const stored_type& u )", RTYPE, size)
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill( u ) ;
     }
@@ -107,10 +107,22 @@ public:
         std::generate( begin(), end(), gen );
     }
 
+    Vector( const R_xlen_t& siz, stored_type (*gen)(void) ) {
+        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& siz = %s, stored_type (*gen)(void) )", RTYPE, siz )
+        Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
+        std::generate( begin(), end(), gen );
+    }
+
+    Vector( const R_xlen_t& size ) {
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        init() ;
+    }
+
     Vector( const int& size ) {
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
     }
+    
     Vector( const Dimension& dims) {
         Storage::set__( Rf_allocVector( RTYPE, dims.prod() ) ) ;
         init() ;
@@ -145,8 +157,8 @@ public:
         import_sugar_expression( other, typename traits::same_type<Vector,VEC>::type() ) ;
     }
     template <typename U>
-    Vector( const int& size, const U& u) {
-        RCPP_DEBUG_2( "Vector<%d>( const int& size, const U& u )", RTYPE, size )
+    Vector( const R_xlen_t& size, const U& u) {
+        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size, const U& u )", RTYPE, size )
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill_or_generate( u ) ;
     }
@@ -157,25 +169,25 @@ public:
     }
 
     template <typename U1>
-    Vector( const int& siz, stored_type (*gen)(U1), const U1& u1) {
+    Vector( const R_xlen_t& siz, stored_type (*gen)(U1), const U1& u1) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const int& siz, stored_type (*gen)(U1), const U1& u1 )", RTYPE, siz )
+        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1), const U1& u1 )", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1) ;
     }
 
     template <typename U1, typename U2>
-    Vector( const int& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2) {
+    Vector( const R_xlen_t& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const int& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2)", RTYPE, siz )
+        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1,U2), const U1& u1, const U2& u2)", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1,u2) ;
     }
 
     template <typename U1, typename U2, typename U3>
-    Vector( const int& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3) {
+    Vector( const R_xlen_t& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3) {
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
-        RCPP_DEBUG_2( "const int& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3)", RTYPE, siz )
+        RCPP_DEBUG_2( "const R_xlen_t& siz, stored_type (*gen)(U1,U2,U3), const U1& u1, const U2& u2, const U3& u3)", RTYPE, siz )
         iterator first = begin(), last = end() ;
         while( first != last ) *first++ = gen(u1,u2,u3) ;
     }
@@ -188,9 +200,9 @@ public:
     }
 
     template <typename InputIterator>
-    Vector( InputIterator first, InputIterator last, int n) {
+    Vector( InputIterator first, InputIterator last, R_xlen_t n) {
         Storage::set__(Rf_allocVector(RTYPE, n)) ;
-        RCPP_DEBUG_2( "Vector<%d>( InputIterator first, InputIterator last, int n = %d)", RTYPE, n )
+        RCPP_DEBUG_2( "Vector<%d>( InputIterator first, InputIterator last, R_xlen_t n = %d)", RTYPE, n )
         std::copy( first, last, begin() ) ;
     }
 
@@ -202,9 +214,9 @@ public:
     }
 
     template <typename InputIterator, typename Func>
-    Vector( InputIterator first, InputIterator last, Func func, int n){
+    Vector( InputIterator first, InputIterator last, Func func, R_xlen_t n){
         Storage::set__( Rf_allocVector( RTYPE, n ) );
-        RCPP_DEBUG_2( "Vector<%d>( InputIterator, InputIterator, Func, int n = %d )", RTYPE, n )
+        RCPP_DEBUG_2( "Vector<%d>( InputIterator, InputIterator, Func, R_xlen_t n = %d )", RTYPE, n )
         std::transform( first, last, begin(), func) ;
     }
 
@@ -450,23 +462,23 @@ public:
     }
 
     template <typename U>
-    static void replace_element( iterator it, SEXP names, int index, const U& u){
+    static void replace_element( iterator it, SEXP names, R_xlen_t index, const U& u){
         replace_element__dispatch( typename traits::is_named<U>::type(),
                                    it, names, index, u ) ;
     }
 
     template <typename U>
-    static void replace_element__dispatch( traits::false_type, iterator it, SEXP names, int index, const U& u){
+    static void replace_element__dispatch( traits::false_type, iterator it, SEXP names, R_xlen_t index, const U& u){
         *it = converter_type::get(u);
     }
 
     template <typename U>
-    static void replace_element__dispatch( traits::true_type, iterator it, SEXP names, int index, const U& u){
+    static void replace_element__dispatch( traits::true_type, iterator it, SEXP names, R_xlen_t index, const U& u){
         replace_element__dispatch__isArgument( typename traits::same_type<U,Argument>(), it, names, index, u ) ;
     }
 
     template <typename U>
-    static void replace_element__dispatch__isArgument( traits::false_type, iterator it, SEXP names, int index, const U& u){
+    static void replace_element__dispatch__isArgument( traits::false_type, iterator it, SEXP names, R_xlen_t index, const U& u){
         RCPP_DEBUG_2( "  Vector::replace_element__dispatch<%s>(true, index= %d) ", DEMANGLE(U), index ) ;
 
         *it = converter_type::get(u.object ) ;
@@ -474,7 +486,7 @@ public:
     }
 
     template <typename U>
-    static void replace_element__dispatch__isArgument( traits::true_type, iterator it, SEXP names, int index, const U& u){
+    static void replace_element__dispatch__isArgument( traits::true_type, iterator it, SEXP names, R_xlen_t index, const U& u){
         RCPP_DEBUG_2( "  Vector::replace_element__dispatch<%s>(true, index= %d) ", DEMANGLE(U), index ) ;
 
         *it = R_MissingArg ;
@@ -525,8 +537,8 @@ public:
     bool containsElementNamed( const char* target ) const {
           SEXP names = RCPP_GET_NAMES(Storage::get__()) ;
         if( Rf_isNull(names) ) return false ;
-        int n = Rf_length(names) ;
-        for( int i=0; i<n; i++){
+        R_xlen_t n = Rf_length(names) ;
+        for( R_xlen_t i=0; i<n; i++){
             if( !strcmp( target, CHAR(STRING_ELT(names, i)) ) )
                 return true ;
         }
@@ -536,8 +548,8 @@ public:
     int findName(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES(Storage::get__());
         if (Rf_isNull(names)) stop("'names' attribute is null");
-        int n = Rf_length(names);
-        for (int i=0; i < n; ++i) {
+        R_xlen_t n = Rf_length(names);
+        for (R_xlen_t i=0; i < n; ++i) {
             if (strcmp(name.c_str(), CHAR(STRING_ELT(names, i))) == 0) {
                 return i;
             }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -294,8 +294,8 @@ public:
 	inline const_iterator begin() const{ return cache.get_const() ; }
     inline const_iterator end() const{ return cache.get_const() + size() ; }
 
-    inline Proxy operator[]( int i ){ return cache.ref(i) ; }
-    inline const_Proxy operator[]( int i ) const { return cache.ref(i) ; }
+    inline Proxy operator[]( R_xlen_t i ){ return cache.ref(i) ; }
+    inline const_Proxy operator[]( R_xlen_t i ) const { return cache.ref(i) ; }
 
     inline Proxy operator()( const size_t& i) {
         return cache.ref( offset(i) ) ;
@@ -491,10 +491,10 @@ public:
     Vector& operator+=( const VectorBase<RTYPE,true,EXPR_VEC>& rhs ) {
           const EXPR_VEC& ref = rhs.get_ref() ;
         iterator start = begin() ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         // TODO: maybe unroll this
         stored_type tmp ;
-        for( int i=0; i<n; i++){
+        for( R_xlen_t i=0; i<n; i++){
             Proxy left = start[i] ;
             if( ! traits::is_na<RTYPE>( left ) ){
                 tmp = ref[i] ;
@@ -508,9 +508,9 @@ public:
     Vector& operator+=( const VectorBase<RTYPE,false,EXPR_VEC>& rhs ) {
           const EXPR_VEC& ref = rhs.get_ref() ;
         iterator start = begin() ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         stored_type tmp ;
-        for( int i=0; i<n; i++){
+        for( R_xlen_t i=0; i<n; i++){
             if( ! traits::is_na<RTYPE>(start[i]) ){
                 start[i] += ref[i] ;
             }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -91,6 +91,13 @@ public:
         fill( u ) ;
     }
 
+    template<>
+    Vector( const int& size, const stored_type& u) {
+        RCPP_DEBUG_2( "Vector<%d>( const int& size = %d, const stored_type& u )", RTYPE, size)
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        fill( u ) ;
+    }
+
     // constructor for CharacterVector()
     Vector( const std::string& st ){
         RCPP_DEBUG_2( "Vector<%d>( const std::string& = %s )", RTYPE, st.c_str() )

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -91,7 +91,6 @@ public:
         fill( u ) ;
     }
 
-    template<>
     Vector( const int& size, const stored_type& u) {
         RCPP_DEBUG_2( "Vector<%d>( const int& size = %d, const stored_type& u )", RTYPE, size)
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -118,27 +118,11 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
         std::generate( begin(), end(), gen );
     }
-
-    Vector( const R_xlen_t& size ) {
-        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
-        init() ;
-    }
-
-    Vector( const size_t& size ) {
-        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
-        init() ;
-    }
-    Vector( const unsigned int& size ) {
-        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
-        init() ;
-    }
-
-    Vector( const double& size ) {
-        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
-        init() ;
-    }
-
-    Vector( const int& size ) {
+    
+    // Add template class T and then restict T to arithmetic.
+    template <typename T>
+    Vector(T size, 
+        typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
     }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -259,17 +259,17 @@ public:
     #endif
 
     /**
-     * the length of the vector, uses Rf_length
+     * the length of the vector, uses Rf_xlength
      */
     inline R_xlen_t length() const {
-        return ::Rf_length( Storage::get__() ) ;
+        return ::Rf_xlength( Storage::get__() ) ;
     }
 
     /**
      * alias of length
      */
     inline R_xlen_t size() const {
-        return ::Rf_length( Storage::get__() ) ;
+        return ::Rf_xlength( Storage::get__() ) ;
     }
 
     /**
@@ -291,7 +291,7 @@ public:
      * it is valid
      */
     size_t offset(const size_t& i) const {
-        if( static_cast<R_xlen_t>(i) >= ::Rf_length(Storage::get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(i) >= ::Rf_xlength(Storage::get__()) ) throw index_out_of_bounds() ;
         return i ;
     }
 
@@ -549,7 +549,7 @@ public:
     bool containsElementNamed( const char* target ) const {
           SEXP names = RCPP_GET_NAMES(Storage::get__()) ;
         if( Rf_isNull(names) ) return false ;
-        R_xlen_t n = Rf_length(names) ;
+        R_xlen_t n = Rf_xlength(names) ;
         for( R_xlen_t i=0; i<n; i++){
             if( !strcmp( target, CHAR(STRING_ELT(names, i)) ) )
                 return true ;
@@ -560,7 +560,7 @@ public:
     int findName(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES(Storage::get__());
         if (Rf_isNull(names)) stop("'names' attribute is null");
-        R_xlen_t n = Rf_length(names);
+        R_xlen_t n = Rf_xlength(names);
         for (R_xlen_t i=0; i < n; ++i) {
             if (strcmp(name.c_str(), CHAR(STRING_ELT(names, i))) == 0) {
                 return i;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -563,7 +563,7 @@ private:
 
     void push_back__impl(const stored_type& object, traits::true_type ) {
         Shield<SEXP> object_sexp( object ) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         SEXP names = RCPP_GET_NAMES(Storage::get__()) ;
         iterator target_it( target.begin() ) ;
@@ -588,7 +588,7 @@ private:
     }
 
     void push_back__impl(const stored_type& object, traits::false_type ) {
-          int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         SEXP names = RCPP_GET_NAMES(Storage::get__()) ;
         iterator target_it( target.begin() ) ;
@@ -614,7 +614,7 @@ private:
 
     void push_back_name__impl(const stored_type& object, const std::string& name, traits::true_type ) {
         Shield<SEXP> object_sexp( object ) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         iterator target_it( target.begin() ) ;
         iterator it(begin()) ;
@@ -640,7 +640,7 @@ private:
         Storage::set__( target.get__() ) ;
     }
     void push_back_name__impl(const stored_type& object, const std::string& name, traits::false_type ) {
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         iterator target_it( target.begin() ) ;
         iterator it(begin()) ;
@@ -669,7 +669,7 @@ private:
 
     void push_front__impl(const stored_type& object, traits::true_type ) {
             Shield<SEXP> object_sexp( object ) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n+1);
         iterator target_it(target.begin());
         iterator it(begin());
@@ -695,7 +695,7 @@ private:
 
     }
     void push_front__impl(const stored_type& object, traits::false_type ) {
-          int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n+1);
         iterator target_it(target.begin());
         iterator it(begin());
@@ -723,7 +723,7 @@ private:
 
     void push_front_name__impl(const stored_type& object, const std::string& name, traits::true_type ) {
         Shield<SEXP> object_sexp(object) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         iterator target_it( target.begin() ) ;
         iterator it(begin()) ;
@@ -751,7 +751,7 @@ private:
 
     }
     void push_front_name__impl(const stored_type& object, const std::string& name, traits::false_type ) {
-          int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n + 1 ) ;
         iterator target_it( target.begin() ) ;
         iterator it(begin()) ;
@@ -782,7 +782,7 @@ private:
 
     iterator insert__impl( iterator position, const stored_type& object_, traits::true_type ) {
         Shield<SEXP> object( object_ ) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n+1 ) ;
         iterator target_it = target.begin();
         iterator it = begin() ;
@@ -822,7 +822,7 @@ private:
     }
 
     iterator insert__impl( iterator position, const stored_type& object, traits::false_type ) {
-            int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n+1 ) ;
         iterator target_it = target.begin();
         iterator it = begin() ;
@@ -863,7 +863,7 @@ private:
 
     iterator erase_single__impl( iterator position ) {
               if( position < begin() || position > end() ) throw index_out_of_bounds( ) ;
-        int n = size() ;
+        R_xlen_t n = size() ;
         Vector target( n - 1 ) ;
         iterator target_it(target.begin()) ;
         iterator it(begin()) ;
@@ -907,7 +907,7 @@ private:
         iterator it = begin() ;
         iterator this_end = end() ;
         int nremoved = std::distance(first,last) ;
-        int target_size = size() - nremoved  ;
+        R_xlen_t target_size = size() - nremoved  ;
         Vector target( target_size ) ;
         iterator target_it = target.begin() ;
 
@@ -944,7 +944,7 @@ private:
 
     template <typename T>
     inline void assign_sugar_expression( const T& x ) {
-        int n = size() ;
+        R_xlen_t n = size() ;
         if( n == x.size() ){
             // just copy the data
             import_expression<T>(x, n ) ;
@@ -974,7 +974,7 @@ private:
     template <bool NA, typename VEC>
     inline void import_sugar_expression( const Rcpp::VectorBase<RTYPE,NA,VEC>& other, traits::false_type ) {
         RCPP_DEBUG_4( "Vector<%d>::import_sugar_expression( VectorBase<%d,%d,%s>, false_type )", RTYPE, NA, RTYPE, DEMANGLE(VEC) ) ;
-        int n = other.size() ;
+        R_xlen_t n = other.size() ;
         Storage::set__( Rf_allocVector( RTYPE, n ) ) ;
         import_expression<VEC>( other.get_ref() , n ) ;
     }
@@ -1015,7 +1015,7 @@ private:
         // when this is not trivial, this is SEXP
         Shield<SEXP> elem( converter_type::get( u ) );
         iterator it(begin());
-        for( int i=0; i<size() ; i++, ++it){
+        for( R_xlen_t i=0; i<size() ; i++, ++it){
             *it = ::Rf_duplicate( elem ) ;
         }
     }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -125,7 +125,12 @@ public:
     }
 
     Vector( const size_t& size ) {
-        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
+        init() ;
+    }
+
+    Vector( const double& size ) {
+        Storage::set__( Rf_allocVector( RTYPE, static_cast<R_xlen_t>(size)) ) ;
         init() ;
     }
 

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -906,7 +906,7 @@ private:
 
         iterator it = begin() ;
         iterator this_end = end() ;
-        int nremoved = std::distance(first,last) ;
+        R_xlen_t nremoved = std::distance(first,last) ;
         R_xlen_t target_size = size() - nremoved  ;
         Vector target( target_size ) ;
         iterator target_it = target.begin() ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -89,6 +89,12 @@ public:
         fill( u ) ;
     }
 
+    explicit Vector( const int& size, const stored_type& u ) {
+        RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size = %d, const stored_type& u )", RTYPE, size)
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        fill( u ) ;
+    }
+
     // constructor for CharacterVector()
     Vector( const std::string& st ){
         RCPP_DEBUG_2( "Vector<%d>( const std::string& = %s )", RTYPE, st.c_str() )
@@ -101,7 +107,7 @@ public:
         Storage::set__(internal::vector_from_string<RTYPE>(st) ) ;
     }
 
-    Vector( const int& siz, stored_type (*gen)(void) ) {
+    explicit Vector( const int& siz, stored_type (*gen)(void) ) {
         RCPP_DEBUG_2( "Vector<%d>( const int& siz = %s, stored_type (*gen)(void) )", RTYPE, siz )
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
         std::generate( begin(), end(), gen );
@@ -159,6 +165,12 @@ public:
     template <typename U>
     Vector( const R_xlen_t& size, const U& u) {
         RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size, const U& u )", RTYPE, size )
+        Storage::set__( Rf_allocVector( RTYPE, size) ) ;
+        fill_or_generate( u ) ;
+    }
+    template <typename U>
+    Vector( const int& size, const U& u) {
+        RCPP_DEBUG_2( "Vector<%d>( const int& size, const U& u )", RTYPE, size )
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill_or_generate( u ) ;
     }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -89,7 +89,7 @@ public:
         fill( u ) ;
     }
 
-    explicit Vector( const int& size, const stored_type& u ) {
+    Vector( const int& size, const stored_type& u ) {
         RCPP_DEBUG_2( "Vector<%d>( const R_xlen_t& size = %d, const stored_type& u )", RTYPE, size)
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill( u ) ;
@@ -107,7 +107,7 @@ public:
         Storage::set__(internal::vector_from_string<RTYPE>(st) ) ;
     }
 
-    explicit Vector( const int& siz, stored_type (*gen)(void) ) {
+    Vector( const int& siz, stored_type (*gen)(void) ) {
         RCPP_DEBUG_2( "Vector<%d>( const int& siz = %s, stored_type (*gen)(void) )", RTYPE, siz )
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
         std::generate( begin(), end(), gen );

--- a/inst/include/Rcpp/vector/VectorBase.h
+++ b/inst/include/Rcpp/vector/VectorBase.h
@@ -42,21 +42,21 @@ public:
 		return static_cast<const VECTOR&>(*this) ;
 	}
 
-	inline stored_type operator[]( int i) const {
+	inline stored_type operator[]( R_xlen_t i) const {
 	    return static_cast<const VECTOR*>(this)->operator[](i) ;
 	}
 
-	inline int size() const { return static_cast<const VECTOR*>(this)->size() ; }
+	inline R_xlen_t size() const { return static_cast<const VECTOR*>(this)->size() ; }
 
 	class iterator {
 	public:
 		typedef stored_type reference ;
 		typedef stored_type* pointer ;
-		typedef int difference_type ;
+		typedef R_xlen_t difference_type ;
 		typedef stored_type value_type;
 		typedef std::random_access_iterator_tag iterator_category ;
 
-		iterator( const VectorBase& object_, int index_ ) : object(object_.get_ref()), index(index_){}
+		iterator( const VectorBase& object_, R_xlen_t index_ ) : object(object_.get_ref()), index(index_){}
 		iterator( const iterator& other) : object(other.object), index(other.index){};
 
 		inline iterator& operator++(){
@@ -95,7 +95,7 @@ public:
 			return *this ;
 		}
 
-		inline reference operator[](int i){
+		inline reference operator[](R_xlen_t i){
 		    return object[index+i] ;
 		}
 
@@ -132,7 +132,7 @@ public:
 
 	private:
 		const VECTOR& object ;
-		int index;
+		R_xlen_t index;
 	} ;
 
 	inline iterator begin() const { return iterator(*this, 0) ; }

--- a/inst/include/Rcpp/vector/const_generic_proxy.h
+++ b/inst/include/Rcpp/vector/const_generic_proxy.h
@@ -33,7 +33,7 @@ namespace internal{
 			const_generic_proxy( const const_generic_proxy& other ) :
 				parent(other.parent), index(other.index){} ;
 
-			const_generic_proxy( const VECTOR& v, int i ) : parent(&v), index(i){} ;
+			const_generic_proxy( const VECTOR& v, R_xlen_t i ) : parent(&v), index(i){} ;
 
 			operator SEXP() const {
 			    return get() ;
@@ -48,7 +48,7 @@ namespace internal{
 			operator int() const { return ::Rcpp::as<int>(get()) ; }
 
 			const VECTOR* parent;
-			int index ;
+			R_xlen_t index ;
 
 		private:
 

--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -40,7 +40,7 @@ namespace internal{
 		 * @param v reference to the associated character vector
 		 * @param index index
 		 */
-		const_string_proxy( VECTOR& v, int index_ ) : parent(&v), index(index_){}
+		const_string_proxy( VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
 
         const_string_proxy(SEXP x): parent(0), index(0) {
             Vector<RTYPE> tmp(x);
@@ -83,8 +83,8 @@ namespace internal{
 		friend std::string operator+( const std::string& x, const const_string_proxy<RT>& proxy);
 
 		const VECTOR* parent;
-		int index ;
-		inline void move( int n ){ index += n ;}
+		R_xlen_t index ;
+		inline void move( R_xlen_t n ){ index += n ;}
 
 		inline SEXP get() const {
 			return STRING_ELT( *parent, index ) ;
@@ -92,9 +92,9 @@ namespace internal{
 
 		inline iterator begin() const { return CHAR( STRING_ELT( *parent, index ) ) ; }
 		inline iterator end() const { return begin() + size() ; }
-		inline int size() const { return strlen( begin() ) ; }
+		inline R_xlen_t size() const { return strlen( begin() ) ; }
 		inline bool empty() const { return *begin() == '\0' ; }
-		inline reference operator[]( int n ){ return *( begin() + n ) ; }
+		inline reference operator[]( R_xlen_t n ){ return *( begin() + n ) ; }
 
 		bool operator==( const char* other){
 			return strcmp( begin(), other ) == 0 ;

--- a/inst/include/Rcpp/vector/generic_proxy.h
+++ b/inst/include/Rcpp/vector/generic_proxy.h
@@ -33,7 +33,7 @@ namespace internal{
 			generic_proxy( const generic_proxy& other ) :
 				parent(other.parent), index(other.index){} ;
 
-			generic_proxy( VECTOR& v, int i ) : parent(&v), index(i){} ;
+			generic_proxy( VECTOR& v, R_xlen_t i ) : parent(&v), index(i){} ;
 
 			generic_proxy& operator=(SEXP rhs) {
 				set(rhs) ;
@@ -70,8 +70,8 @@ namespace internal{
 			}
 
 			VECTOR* parent;
-			int index ;
-			inline void move(int n) { index += n ; }
+			R_xlen_t index ;
+			inline void move(R_xlen_t n) { index += n ; }
 
 			void import( const generic_proxy& other){
 				parent = other.parent ;

--- a/inst/include/Rcpp/vector/no_init.h
+++ b/inst/include/Rcpp/vector/no_init.h
@@ -29,9 +29,9 @@ class Matrix;
 
 class no_init_vector {
 public:
-    no_init_vector(int size_): size(size_){}
+    no_init_vector(R_xlen_t size_): size(size_){}
 
-    inline int get() const {
+    inline R_xlen_t get() const {
         return size;
     }
 
@@ -41,7 +41,7 @@ public:
     }
 
 private:
-    int size ;
+    R_xlen_t size ;
 } ;
 
 class no_init_matrix {

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -65,7 +65,7 @@ namespace internal{
 		VECTOR& parent ;
 		std::string name;
 		void set( CTYPE rhs ){
-			int index = 0 ;
+			R_xlen_t index = 0 ;
 			try{
 				index = parent.offset(name) ;
 				parent[ index ] = rhs ;
@@ -110,14 +110,14 @@ namespace internal{
 
 		inline iterator begin() { return get() ; }
 		inline iterator end(){ return begin() + size() ; }
-		inline reference operator[]( int i ){ return *( get() + i ) ; }
-		inline int size(){ return strlen( get() ) ; }
+		inline reference operator[]( R_xlen_t i ){ return *( get() + i ) ; }
+		inline R_xlen_t size(){ return strlen( get() ) ; }
 
 	private:
 		VECTOR& parent ;
 		std::string name;
 		void set( const std::string& rhs ){
-			int index = 0 ;
+			R_xlen_t index = 0 ;
 			try{
 				index = parent.offset(name) ;
 				parent[ index ] = rhs ;
@@ -176,7 +176,7 @@ namespace internal{
 		VECTOR& parent ;
 		std::string name;
 		void set( SEXP rhs ){
-			int index = 0 ;
+			R_xlen_t index = 0 ;
 			try{
 				index = parent.offset(name) ;
 				parent[ index ] = rhs ;

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -40,7 +40,7 @@ namespace internal{
 		 * @param v reference to the associated character vector
 		 * @param index index
 		 */
-		string_proxy( VECTOR& v, int index_ ) : parent(&v), index(index_){}
+		string_proxy( VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
 
 		string_proxy( const string_proxy& other ) :
 			parent(other.parent), index(other.index){} ;
@@ -141,8 +141,8 @@ namespace internal{
 		}
 
 		VECTOR* parent;
-		int index ;
-		inline void move( int n ){ index += n ;}
+		R_xlen_t index ;
+		inline void move( R_xlen_t n ){ index += n ;}
 
 		inline SEXP get() const {
 			return STRING_ELT( *parent, index ) ;
@@ -157,9 +157,9 @@ namespace internal{
 
 		inline iterator begin() const { return CHAR( STRING_ELT( *parent, index ) ) ; }
 		inline iterator end() const { return begin() + size() ; }
-		inline int size() const { return strlen( begin() ) ; }
+		inline R_xlen_t size() const { return strlen( begin() ) ; }
 		inline bool empty() const { return *begin() == '\0' ; }
-		inline reference operator[]( int n ){ return *( begin() + n ) ; }
+		inline reference operator[]( R_xlen_t n ){ return *( begin() + n ) ; }
 
 		template <typename UnaryOperator>
 		void transform( UnaryOperator op ){

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -43,10 +43,10 @@ namespace traits{
 		inline const_iterator get_const() const { return start; }
 
 		inline proxy ref() { return *start ;}
-		inline proxy ref(int i) { return start[i] ; }
+		inline proxy ref(R_xlen_t i) { return start[i] ; }
 
 		inline proxy ref() const { return *start ;}
-		inline proxy ref(int i) const { return start[i] ; }
+		inline proxy ref(R_xlen_t i) const { return start[i] ; }
 
 		private:
 			iterator start ;
@@ -70,10 +70,10 @@ namespace traits{
 		inline const_iterator get_const() const { return get_vector_ptr(*p) ; }
 
 		inline proxy ref() { return proxy(*p,0) ; }
-		inline proxy ref(int i) { return proxy(*p,i);}
+		inline proxy ref(R_xlen_t i) { return proxy(*p,i);}
 
 		inline const_proxy ref() const { return const_proxy(*p,0) ; }
-		inline const_proxy ref(int i) const { return const_proxy(*p,i);}
+		inline const_proxy ref(R_xlen_t i) const { return const_proxy(*p,i);}
 
 		private:
 			VECTOR* p ;

--- a/inst/unitTests/cpp/ListOf.cpp
+++ b/inst/unitTests/cpp/ListOf.cpp
@@ -84,8 +84,8 @@ NVList test_binary_ops(NVList x) {
 }
 
 // [[Rcpp::export]]
-int test_sub_calls(NVList x) {
-    int sz = x[0].size() + x[1].size() + x[2].size();
+R_xlen_t test_sub_calls(NVList x) {
+    R_xlen_t sz = x[0].size() + x[1].size() + x[2].size();
     return sz;
 }
 

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -648,13 +648,6 @@ IntegerVector IntegerVector_int_init(){
 }
 
 // [[Rcpp::export]]
-R_xlen_t Long_IntegerVector_length(){
-	R_xlen_t l = INT_MAX + 100L;
-    IntegerVector x(l,4) ;
-    return x.size() ;
-}
-
-// [[Rcpp::export]]
 bool containsElementNamed( List l, CharacterVector n){
     return l.containsElementNamed(n[0]);
 }

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -19,6 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <climits>
 #include <Rcpp.h>
 using namespace Rcpp ;
 
@@ -644,6 +645,13 @@ CharacterVector factors( CharacterVector s){
 IntegerVector IntegerVector_int_init(){
     IntegerVector x(2,4) ;
     return x ;
+}
+
+// [[Rcpp::export]]
+R_xlen_t Long_IntegerVector_length(){
+	R_xlen_t l = INT_MAX + 100L;
+    IntegerVector x(l,4) ;
+    return x.size() ;
 }
 
 // [[Rcpp::export]]

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -567,6 +567,11 @@ if (.runThisTest) {
         checkEquals( fun(), c(4L,4L), msg = "IntegerVector int init regression test" )
     }
 
+    test.Long_IntegerVector_length <- function(){
+        fun <-  Long_IntegerVector_length
+        checkTrue( fun() > 0, msg = "Long IntegerVector length test" )
+    }
+
     test.containsElementNamed <- function() {
         fun <- containsElementNamed
 

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -567,11 +567,6 @@ if (.runThisTest) {
         checkEquals( fun(), c(4L,4L), msg = "IntegerVector int init regression test" )
     }
 
-    test.Long_IntegerVector_length <- function(){
-        fun <-  Long_IntegerVector_length
-        checkTrue( fun() > 0, msg = "Long IntegerVector length test" )
-    }
-
     test.containsElementNamed <- function() {
         fun <- containsElementNamed
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -268,7 +268,7 @@ SEXP stack_trace(const char* file, int line) {
 
             /* inspired from http://tombarta.wordpress.com/2008/08/01/c-stack-traces-with-gcc/  */
             const size_t max_depth = 100;
-            size_t stack_depth;
+            int stack_depth;
             void *stack_addrs[max_depth];
             char **stack_strings;
 


### PR DESCRIPTION
Most of changes are about `R_xlen_t` and `Rf_xlength`.

Please take a careful review on `Vector.h` and `is_arithmetic` added. 

The type trait is used because many packages depend the implicit conversion in `Vector` constructor.