### PR TITLE
added plugins= support to evalCpp()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-06-18  Dirk Eddelbuettel  <edd@debian.org>
+
+        * R/Attributes.R (evalCpp): Add support for plugings argument
+        * man/evalCpp.Rd: Document argument
+
 2015-06-07  JJ Allaire <jj@rstudio.org>
 
         * src/attributes.cpp: Don't load sourceCpp dynamic library if it's

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -297,6 +297,7 @@ print.bytes <- function( x, ...){
 # Evaluate a simple c++ expression
 evalCpp <- function(code,
                     depends = character(),
+                    plugins = character(), 
                     includes = character(),
                     rebuild = FALSE,
                     showOutput = verbose,
@@ -305,7 +306,8 @@ evalCpp <- function(code,
 
     code <- sprintf( "SEXP get_value(){ return wrap( %s ) ; }", code )
     env <- new.env()
-    cppFunction(code, depends = depends, includes = includes, env = env,
+    cppFunction(code, depends = depends, plugins = plugins,
+                includes = includes, env = env,
                 rebuild = rebuild, showOutput = showOutput, verbose = verbose )
     fun <- env[["get_value"]]
     fun()

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,6 +15,8 @@
     \itemize{
       \item Don't load \code{sourceCpp} dynamic library if it's already 
       been loaded.
+      \item The \code{evalCpp} function now also supports the \code{plugins}
+      argument.
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/man/evalCpp.Rd
+++ b/man/evalCpp.Rd
@@ -9,8 +9,8 @@ Evaluates a C++ expression. This creates a C++ function using
 \code{\link{cppFunction}} and calls it to get the result. 
 }
 \usage{
-evalCpp(code, depends = character(), includes = character(), 
-        rebuild = FALSE, showOutput = verbose, 
+evalCpp(code, depends = character(), plugins = character(),
+        includes = character(), rebuild = FALSE, showOutput = verbose, 
         verbose = getOption("verbose"))
 areMacrosDefined(names, depends = character(), includes = character(), 
         rebuild = FALSE, showOutput = verbose, 
@@ -22,6 +22,9 @@ C++ expression to evaluate
 }
   \item{names}{
 names of the macros we want to test
+}
+  \item{plugins}{
+see \code{\link{cppFunction}}
 }
   \item{depends}{
 see \code{\link{cppFunction}}


### PR DESCRIPTION
just a pass-through to `cppFunction()` so now we can do 

```.r
evalCpp('std::vector<std::string> s = { "a", "b", "c" };', plugins="cpp11")
```