### PR TITLE
Add encoding in Rcpp::String class

### DIFF
--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -58,8 +58,7 @@ namespace Rcpp {
         }
 
         /** copy constructor */
-        String( const String& other) : data( other.get_sexp()), valid(true), buffer_ready(false), 
-                                       enc(Rf_getCharCE(other.get_sexp())) {
+        String( const String& other) : data( other.get_sexp()), valid(true), buffer_ready(false), enc(Rf_getCharCE(other.get_sexp())) {
             RCPP_STRING_DEBUG( "String(const String&)" ) ;
         }
 
@@ -69,46 +68,41 @@ namespace Rcpp {
         }
 
         /** construct a string from a single CHARSXP SEXP */
-        String(SEXP charsxp) : data(charsxp), valid(true), buffer_ready(false), 
-                               enc(Rf_getCharCE(charsxp)) {
+        String(SEXP charsxp) : data(charsxp), valid(true), buffer_ready(false), enc(Rf_getCharCE(charsxp)) {
             RCPP_STRING_DEBUG( "String(SEXP)" ) ;
         }
 
         String(SEXP charsxp, const char * enc) : data(charsxp), valid(true), buffer_ready(false) {
-		    set_encoding(enc);
+            set_encoding(enc);
             RCPP_STRING_DEBUG( "String(SEXP)" ) ;
         }
 
         /** from string proxy */
-        String( const StringProxy& proxy ): data( proxy.get() ), valid(true), buffer_ready(false), 
-                                            enc(Rf_getCharCE(proxy.get())){
+        String( const StringProxy& proxy ): data( proxy.get() ), valid(true), buffer_ready(false), enc(Rf_getCharCE(proxy.get())){
             RCPP_STRING_DEBUG( "String( const StringProxy&)" ) ;
         }
 
         String( const StringProxy& proxy, const char * enc ): data( proxy.get() ), valid(true), buffer_ready(false) {
-		    set_encoding(enc);
+            set_encoding(enc);
             RCPP_STRING_DEBUG( "String( const StringProxy&)" ) ;
         }
 
         /** from string proxy */
-        String( const const_StringProxy& proxy ): data( proxy.get() ), valid(true), buffer_ready(false), 
-                                                  enc(Rf_getCharCE(proxy.get())){
+        String( const const_StringProxy& proxy ): data( proxy.get() ), valid(true), buffer_ready(false), enc(Rf_getCharCE(proxy.get())){
             RCPP_STRING_DEBUG( "String( const const_StringProxy&)" ) ;
         }
 
         String( const const_StringProxy& proxy, const char * enc ): data( proxy.get() ), valid(true), buffer_ready(false) {
-			set_encoding(enc);
+            set_encoding(enc);
             RCPP_STRING_DEBUG( "String( const const_StringProxy&)" ) ;
         }
 
         /** from a std::string */
-        String( const std::string& s) : buffer(s), valid(false), buffer_ready(true), 
-                                        enc(CE_NATIVE) {
+        String( const std::string& s) : buffer(s), valid(false), buffer_ready(true), enc(CE_NATIVE) {
             RCPP_STRING_DEBUG( "String(const std::string& )" ) ;
         }
 
-        String( const std::wstring& s) : data(internal::make_charsexp(s)), valid(true), buffer_ready(false), 
-                                         enc(CE_NATIVE) {
+        String( const std::wstring& s) : data(internal::make_charsexp(s)), valid(true), buffer_ready(false), enc(CE_NATIVE) {
             RCPP_STRING_DEBUG( "String(const std::wstring& )" ) ;
         }
 
@@ -117,8 +111,7 @@ namespace Rcpp {
             RCPP_STRING_DEBUG( "String(const char*)" ) ;
         }
 
-        String( const wchar_t* s) : data(internal::make_charsexp(s)), valid(true), buffer_ready(false),
-                                    enc(CE_NATIVE) {
+        String( const wchar_t* s) : data(internal::make_charsexp(s)), valid(true), buffer_ready(false), enc(CE_NATIVE) {
             RCPP_STRING_DEBUG( "String(const wchar_t* s)" ) ;
         }
 
@@ -160,7 +153,7 @@ namespace Rcpp {
             setBuffer() ; buffer += s ; valid = false ;
             return *this ;
         }
-        
+
         inline String& operator+=( const char* s){
             RCPP_STRING_DEBUG( "String::operator+=( const char*)" ) ;
             if( is_na() ) return *this ;
@@ -357,7 +350,7 @@ namespace Rcpp {
         inline const char* get_cstring() const {
             return buffer_ready ? buffer.c_str() : CHAR(data) ;
         }
-        
+
         inline const std::string get_encoding() const {
             switch (enc) {
                 case CE_BYTES:
@@ -370,7 +363,7 @@ namespace Rcpp {
                     return "unknown";
             }
         }
-		
+
         inline void set_encoding( cetype_t encoding ) {
             enc = encoding;
             if (data != NULL)
@@ -386,9 +379,8 @@ namespace Rcpp {
                 enc = CE_UTF8;
             } else {
                 enc = CE_ANY;
-                Rcout << "Unknown encoding" << std::endl;
             }
-			set_encoding(enc);
+            set_encoding(enc);
         }
 
         bool operator<( const Rcpp::String& other ) const {
@@ -410,7 +402,7 @@ namespace Rcpp {
 
         /** the CHARSXP this String encapsulates */
         SEXP data ;
-        
+
         /** the encoding of encapsulated CHARSXP */
         cetype_t enc;
 

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -407,9 +407,6 @@ namespace Rcpp {
         /** the CHARSXP this String encapsulates */
         SEXP data ;
 
-        /** the encoding of encapsulated CHARSXP */
-        cetype_t enc;
-
         /** a buffer used to do string operations withough going back to the SEXP */
         std::string buffer ;
 
@@ -418,6 +415,9 @@ namespace Rcpp {
 
         /** is the buffer initialized */
         bool buffer_ready ;
+
+        /** the encoding of encapsulated CHARSXP */
+        cetype_t enc;
 
         inline bool is_na() const { return data == NA_STRING ; }
         inline void setBuffer(){

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -373,9 +373,11 @@ namespace Rcpp {
         }
 		
         inline void set_encoding( cetype_t encoding ) {
-            enc = encoding;
-            if (data != NULL)
-                data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);
+            if (enc != encoding) {
+			    enc = encoding;
+                if (data != NULL)
+                    data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);	
+			}
         }
 
         inline void set_encoding(const char* encoding) {

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -354,12 +354,11 @@ namespace Rcpp {
             return std::wstring( s, s + strlen(s) );
         }
 
-
         inline const char* get_cstring() const {
             return buffer_ready ? buffer.c_str() : CHAR(data) ;
         }
         
-        inline const char* get_encoding() const {
+        inline const std::string get_encoding() const {
             switch (enc) {
                 case CE_BYTES:
                     return "bytes";
@@ -373,14 +372,12 @@ namespace Rcpp {
         }
 		
         inline void set_encoding( cetype_t encoding ) {
-            if (enc != encoding) {
-			    enc = encoding;
-                if (data != NULL)
-                    data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);	
-			}
+            enc = encoding;
+            if (data != NULL)
+                data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);	
         }
 
-        inline void set_encoding(const char* encoding) {
+        inline void set_encoding(const std::string & encoding) {
             if ( encoding == "bytes" ) {
                 enc = CE_BYTES;
             } else if ( encoding == "latin1" ) {

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -360,37 +360,37 @@ namespace Rcpp {
         }
         
         inline const char* get_encoding() const {
-			switch (enc) {
-				case CE_BYTES:
-					return "bytes";
-				case CE_LATIN1:
-					return "latin1";
-				case CE_UTF8:
-					return "UTF-8";
-				default:
-					return "unknown";
-			}
-		}
+            switch (enc) {
+                case CE_BYTES:
+                    return "bytes";
+                case CE_LATIN1:
+                    return "latin1";
+                case CE_UTF8:
+                    return "UTF-8";
+                default:
+                    return "unknown";
+            }
+        }
 		
-		inline void set_encoding( cetype_t encoding ) {
-			enc = encoding;
-			if (data != NULL)
-			    data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);
-		}
+        inline void set_encoding( cetype_t encoding ) {
+            enc = encoding;
+            if (data != NULL)
+                data = Rf_mkCharCE(Rf_translateCharUTF8(data), enc);
+        }
 
         inline void set_encoding(const char* encoding) {
-			if ( encoding == "bytes" ) {
-				enc = CE_BYTES;
-			} else if ( encoding == "latin1" ) {
-				enc = CE_LATIN1;
-			} else if ( encoding == "UTF-8" ) {
-				enc = CE_UTF8;
-			} else {
-				enc = CE_ANY;
-				Rcout << "Unknown encoding" << std::endl;
-			}
+            if ( encoding == "bytes" ) {
+                enc = CE_BYTES;
+            } else if ( encoding == "latin1" ) {
+                enc = CE_LATIN1;
+            } else if ( encoding == "UTF-8" ) {
+                enc = CE_UTF8;
+            } else {
+                enc = CE_ANY;
+                Rcout << "Unknown encoding" << std::endl;
+            }
 			set_encoding(enc);
-		}
+        }
 
         bool operator<( const Rcpp::String& other ) const {
             return strcmp( get_cstring(), other.get_cstring() ) < 0;

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -69,13 +69,13 @@ String test_String_encoding(String x) {
 
 // [[Rcpp::export]]
 String test_String_set_encoding(String x) {
-    String y(x);
-    y.set_encoding("UTF-8");
-    return y;
+    x.set_encoding("UTF-8");
+    return x;
 }
 
 // [[Rcpp::export]]
 String test_String_ctor_encoding(String x) {
-    String y(x, "UTF-8");
+    String y(x);
+    y.set_encoding("UTF-8");
     return y;
 }

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -79,3 +79,11 @@ String test_String_ctor_encoding(String x) {
     y.set_encoding("UTF-8");
     return y;
 }
+
+
+// [[Rcpp::export]]
+String test_String_ctor_encoding2() {
+    String y("å");
+    y.set_encoding("UTF-8");
+    return y;
+}

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -61,3 +61,21 @@ String test_push_front(String x) {
     x.push_front("abc");
     return x;
 }
+
+// [[Rcpp::export]]
+String test_String_encoding(String x) {
+    return x.get_encoding();
+}
+
+// [[Rcpp::export]]
+String test_String_set_encoding(String x) {
+    String y(x);
+    y.set_encoding("UTF-8");
+    return y;
+}
+
+// [[Rcpp::export]]
+String test_String_ctor_encoding(String x) {
+    String y(x, "UTF-8");
+    return y;
+}

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -54,4 +54,15 @@ if (.runThisTest) {
         res <- test_push_front("def")
         checkIdentical(res, "abcdef")
     }
+
+    test.String.encoding <- function() {
+        a <- b <- "å"
+        Encoding(a) <- "unknown"
+        Encoding(b) <- "UTF-8"
+        checkEquals(test_String_encoding(a), "unknown")
+        checkEquals(test_String_encoding(b), "UTF-8")
+        checkEquals(Encoding(test_String_set_encoding(a)), "UTF-8")
+        checkEquals(Encoding(test_String_ctor_encoding(a)), "UTF-8")
+    }
+
 }

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -63,6 +63,7 @@ if (.runThisTest) {
         checkEquals(test_String_encoding(b), "UTF-8")
         checkEquals(Encoding(test_String_set_encoding(a)), "UTF-8")
         checkEquals(Encoding(test_String_ctor_encoding(a)), "UTF-8")
+        checkEquals(Encoding(test_String_ctor_encoding2()), "UTF-8")
     }
 
 }


### PR DESCRIPTION
Encoding info in String class and getter/setter. 

**CE_NATIVE** is used if no encoding info provided.