### PR TITLE
Reset errors after evaluation (closes #312)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2015-06-25  Kevin Ushey  <kevinushey@gmail.com>
 
+	* inst/include/Rcpp/api/meat/Rcpp_eval.h: reset error after Rcpp_eval
         * inst/include/Rcpp/Function.h: catch empty error messages
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: protect call
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
-2015-06-25  Kevin Ushey  <kevinushey@gmail.com>
+2015-06-25 Kevin Ushey  <kevinushey@gmail.com>
 
 	* inst/include/Rcpp/api/meat/Rcpp_eval.h: reset error after Rcpp_eval
+	* inst/unitTests/cpp/Function.cpp: unit tests
+	* inst/unitTests/runit.Function.R: unit tests
         * inst/include/Rcpp/Function.h: catch empty error messages
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: protect call
 

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -38,8 +38,6 @@ namespace Rcpp{
 
         Shield<SEXP> expr(evalCall->expr) ;
 
-        reset_current_error() ;
-
         Environment RCPP = Environment::Rcpp_namespace();
         SEXP withCallingHandlersSym    = ::Rf_install("withCallingHandlers");
         SEXP tryCatchSym               = ::Rf_install("tryCatch");
@@ -87,6 +85,9 @@ namespace Rcpp{
             evalCall->error_occurred = false;
             evalCall->result = res;
         }
+        
+        reset_current_error() ;
+
     }
 
     inline SEXP Rcpp_eval(SEXP expr_, SEXP env) {

--- a/inst/unitTests/cpp/Function.cpp
+++ b/inst/unitTests/cpp/Function.cpp
@@ -76,3 +76,7 @@ Function function_namespace_env(){
     Function fun = ns[".asSparse"] ;  // accesses a non-exported function
     return fun;
 }
+
+// [[Rcpp::export]]
+void exec(Function f) { f(); }
+

--- a/inst/unitTests/runit.Function.R
+++ b/inst/unitTests/runit.Function.R
@@ -84,6 +84,12 @@ if (.runThisTest) {
         checkException(function_cons_ns("sourceCpp", "Rcppp"), msg = "namespace-lookup constructor: fail when ns does not exist")
         checkException(function_cons_ns("sourceCppp", "Rcpp"), msg = "namespace-lookup constructor: fail when function not found")
     }
+    
+    test.Function.eval <- function() {
+        checkException(exec(stop))
+        # should not throw exception
+        exec(function() try(silent = TRUE, exec(stop)))
+    }
 
     # also check function is found in parent env
 


### PR DESCRIPTION
This fixes a bug where nested calls to Rcpp functions (through `Rcpp_eval`) would end up seeing the same error stack, and hence all would report the same error.