### PR TITLE
import rcpp-scripts to Rcpp repo

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ doxyfile
 .dir-locals.el
 .clang_format
 vignettes/getCurrentVersionsOfCitedPackages.R
+^internal/

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-07-02  Kevin Ushey  <kevinushey@gmail.com>
+
+        * internal/scripts: Import Rcpp scripts to repository
+        * .Rbuildignore: ignore 'internal' directory
+
 2015-07-07  Matt P. Dziubinski  <matdzb@gmail.com>
 
         * inst/include/Rcpp/sugar/functions/var.h: Variance -- changed from

--- a/internal/scripts/DataFrame.R
+++ b/internal/scripts/DataFrame.R
@@ -1,0 +1,52 @@
+#!/usr/bin/r
+##
+## use this script to generate the file DataFrame_generated.h
+##
+
+DataFrame_generator <- function( i ) {
+    src <-
+    sprintf('
+template <%s>
+static DataFrame create( %s ) {
+    return DataFrame::from_list( List::create( %s ) ) ;
+} ',
+            paste( sprintf( "typename T%d", 1:i ), collapse = ", "),
+            paste( sprintf( "const T%d& t%d", 1:i, 1:i ), collapse = ", "),
+            paste( sprintf( "t%d", 1:i ), collapse = ", ")
+            )
+}
+
+
+content <- sprintf( '// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// DataFrame_generated.h: Rcpp R/C++ interface class library -- data frames
+//
+// Copyright (C) 2010 - 2013  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#ifndef Rcpp__DataFrame_generated_h
+#define Rcpp__DataFrame_generated_h
+
+%s
+
+#endif
+' ,
+paste( sapply( 1:20, DataFrame_generator ), collapse = "\n\n" )
+)
+writeLines( content, "Rcpp/inst/include/Rcpp/generated/DataFrame_generated.h" )
+

--- a/internal/scripts/checkFastLm.r
+++ b/internal/scripts/checkFastLm.r
@@ -1,0 +1,43 @@
+#!/usr/bin/r
+library(datasets)
+
+data(trees)
+
+firstTest <- function() {
+    f1 <- lm(log(Girth) ~ log(Volume), data=trees)
+    print(f1)
+    print(summary(f1))
+
+    suppressMessages(library(RcppGSL))
+    f2 <- fastLm(log(Girth) ~ log(Volume), data=trees)
+    print(f2)
+    print(summary(f2))
+
+    suppressMessages(library(RcppArmadillo))
+    f3 <- fastLm(log(Girth) ~ log(Volume), data=trees)
+    print(f3)
+    print(summary(f3))
+}
+
+secondTest <- function() {
+    y <- log(trees$Girth)
+    X <- cbind(1, log(trees$Volume))
+    colnames(X) <- c("iota", "logVol")
+
+    f1 <- lm.fit(X, y)
+    print(f1)
+    #print(summary(f1))
+
+    suppressMessages(library(RcppGSL))
+    f2 <- fastLm(X, y)
+    print(f2)
+    print(summary(f2))
+
+    suppressMessages(library(RcppArmadillo))
+    f3 <- fastLm(X, y)
+    print(f3)
+    print(summary(f3))
+}
+
+firstTest()
+secondTest()

--- a/internal/scripts/codebloat.R
+++ b/internal/scripts/codebloat.R
@@ -1,0 +1,107 @@
+
+#
+# to change the maximum number of arguments to 20
+# move to the root directory of Rcpp and do : 
+# Rscript ../../scripts/codebloat.R 20
+#
+
+target <- commandArgs(TRUE)[1]
+
+typenames <- function( n = 1, txt){
+	paste( sprintf( "typename T%d", 1:n ), collapse = ", " )
+}
+
+arguments <- function( n = 1, txt){
+	paste( sprintf( "const T%d& t%d", 1:n, 1:n ), collapse = ", " )	
+}
+
+parameters <- function( n = 1, txt ){
+	paste( sprintf( "t%d", 1:n ), collapse = ", " )	
+}
+
+grow <- function( n = 1, txt ){
+	grow__ <- function( n, m){
+		if( m > n ){
+			"R_NilValue"
+		} else{
+			sprintf( "grow( t%d, %s )", m, grow__( n , m+1) )	
+		}
+	}
+	grow__( n, 1 ) ;
+}
+
+for_each <- function(n = 1, txt ){
+	
+	rx <- "^.*__FOR_EACH__[{][{](.*)[}][}].*$"
+	while( any( grepl( rx, txt ) ) ){
+		line <- grep( rx, txt )[1]
+		
+		expr <- sub( rx , "\\1", txt[line] )
+		res <- sapply( 1:n, function(index){
+			out <- gsub( "___I___", index - 1, expr )
+			out <- gsub( "___X___", sprintf( "t%d", index ), out )
+			out
+		} )
+		txt <- c( txt[ 1:(line-1) ], res, txt[ (line+1) : length(txt) ] )
+	}
+	txt
+}
+
+or <- function( n = 1, txt ){
+	rx <- "^.*[{][{](.*)[}][}].*$"
+	line <- grep( rx, txt )
+	expr <- sub( rx , "\\1", txt[line] )
+	res <- sapply( 1:n, function(index){
+		out <- gsub( "___T___", sprintf("T%d", index), expr )
+		out
+	} )
+	txt[line] <- paste( res, collapse = "||" )
+	txt
+}
+
+modify <- function(txt, token, n, fun){
+	if( any( grepl( token, txt ) ) ){
+		gsub( token, fun(n, txt), txt )
+	} else {
+		txt
+	}
+}                        
+
+path <- file.path( "src", "Rcpp" )
+for( f in list.files(path, full.names = TRUE) ){
+#	f <- "src/Rcpp/Vector.h"
+	content <- readLines( f )
+	if( any( grepl( "code-bloat", content ) ) ){
+		first <- grep( "<code-bloat>", content )
+		last <- grep( "</code-bloat>", content )
+		code.end <- grep( "^[*]/", content[first:last] )[1] - 2
+		code <- content[ first + (2:code.end) ]
+		
+		result <- lapply( 1:target, function(n){
+			txt <- code
+			txt <- modify( txt, "TYPENAMES" , n, typenames  )
+			txt <- modify( txt, "ARGUMENTS" , n, arguments  )
+			txt <- modify( txt, "PARAMETERS", n, parameters )
+			txt <- modify( txt, "GROW"      , n, grow )
+			txt <- modify( txt, "___N___"   , n, function(n,txt){ as.character(n) }  )
+			if( any( grepl( "__FOR_EACH__[{][{].*[}][}]", txt ) ) ){
+				txt <- for_each( n, txt )	
+			}
+			if( any( grepl( "__OR__[{][{].*[}][}]", txt ) ) ){
+				txt <- or( n, txt )	
+			}
+			txt
+		} )
+		
+		output <- unlist( result )
+		
+		new.content <- c( 
+			content[1:(first+code.end+1)], 
+			output, 
+			content[last:length(content)] )
+		
+		cat( new.content, file = f , sep = "\n" )
+			
+	}
+}
+

--- a/internal/scripts/countTests.sh
+++ b/internal/scripts/countTests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd Rcpp/inst/unitTests/
+echo -n "Functions: "
+egrep "test.* function\(" runit.*R | wc -l
+echo -n "Tests    : "
+egrep "check(Equals|Exception|True)" runit.*R  | wc -l 

--- a/internal/scripts/findSlowTests.r
+++ b/internal/scripts/findSlowTests.r
@@ -1,0 +1,8 @@
+#!/usr/bin/Rscript
+#  this should really be /usr/bin/r but you-know-who on a Mac ...
+
+dir <- "Rcpp/inst/unitTests"
+files <- list.files( dir, pattern = "^runit[.]", full = TRUE )
+ntests <- sapply( files, function(.) sum( grepl( "^test[.]", readLines( . ) ) ) )
+fast <- sapply( files, function(.) any( grepl( "cxxfunction.*signatures", readLines( . ) ) ) )
+print(head(subset( data.frame( ntests, fast )[ order(-ntests), ], !fast ),10))

--- a/internal/scripts/generator_InternalFunction.R
+++ b/internal/scripts/generator_InternalFunction.R
@@ -1,0 +1,58 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/generated/InternalFunction__ctors.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+        
+    txt <- sprintf( '
+
+    template <typename RESULT_TYPE%s>
+    InternalFunction_Impl(RESULT_TYPE (*fun)(%s)) {
+        set(XPtr<CppFunction%d<RESULT_TYPE%s> >(new CppFunction%d<RESULT_TYPE%s>(fun), false));
+    }
+', 
+                   if (i == 0) ""     else paste0(",", paste(sprintf("typename U%d", (1:i)-1), collapse = ", ")), 
+                   if (i == 0) "void" else paste(sprintf("U%d u%d", (1:i)-1, (1:i)-1 ), collapse = ", "), 
+                   i, 
+                   if (i == 0) ""     else paste0(",", paste(sprintf("U%d", (1:i)-1), collapse = ", ")), 
+                   i, 
+                   if (i == 0) ""     else paste0(",", paste(sprintf("U%d", (1:i)-1), collapse = ", "))
+                   )
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// InternalFunction_Impl_ctors.h -- generated helper code for InternalFunction__ctors.h
+//                                  see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__generated__InternalFunction_Impl_ctors_h
+#define Rcpp__generated__InternalFunction_Impl_ctors_h
+
+%s
+
+#endif
+', paste(sapply(0:65, fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/generated/"))
+writeLines(file, "inst/include/Rcpp/generated/InternalFunction__ctors.h")

--- a/internal/scripts/generator_InternalFunctionWithStdFunction.R
+++ b/internal/scripts/generator_InternalFunctionWithStdFunction.R
@@ -1,0 +1,56 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/generated/InternalFunctionWithStdFunction_call.h
+#
+# Copyright (C) 2014 Christian Authmann
+
+fun <- function(i) {
+        
+    txt <- sprintf( '
+    template <typename RESULT_TYPE%s>
+    RESULT_TYPE call(const std::function<RESULT_TYPE(%s)> &fun, SEXP* args) {%s
+        return fun(%s);
+    }
+', 
+                   if (i == 0) ""     else paste0(",", paste(sprintf("typename U%d", (1:i)-1), collapse = ", ")),
+                   if (i == 0) ""     else paste(sprintf("U%d", (1:i)-1), collapse = ","),  
+                   if (i == 0) ""     else paste0("\n", paste(sprintf("        typename traits::input_parameter<U%d>::type x%d(args[%d]);", (1:i)-1, (1:i)-1, (1:i)-1 ), collapse = "\n")),
+                   if (i == 0) ""     else paste(sprintf("x%d", (1:i)-1), collapse = ",")
+              )
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// InternalFunctionWithStdFunction_call.h -- generated helper code for
+//                                  InternalFunctionWithStdFunction.h
+//                                  see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__generated__InternalFunctionWithStdFunction_calls_h
+#define Rcpp__generated__InternalFunctionWithStdFunction_calls_h
+
+%s
+
+#endif
+', paste(sapply(0:65, fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/generated/"))
+writeLines(file, "inst/include/Rcpp/generated/InternalFunctionWithStdFunction_call.h")

--- a/internal/scripts/generator_Module_CppFunction.R
+++ b/internal/scripts/generator_Module_CppFunction.R
@@ -1,0 +1,258 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_CppFunction.h
+#
+# Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+
+    index <- (1:i)-1
+    collapse <- function(x, sep = ",") paste(x, collapse = sep)
+
+txt <- sprintf( '
+template <typename RESULT_TYPE, %s> class CppFunction%d : public CppFunction {
+    public:
+
+        CppFunction%d(RESULT_TYPE (*fun)(%s) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
+
+        SEXP operator()(SEXP* args) {
+            %s
+            return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(%s));
+        }
+
+        inline int nargs() { return %d; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun ; }
+
+    private:
+        RESULT_TYPE (*ptr_fun)(%s) ;
+};
+
+template <%s>
+class CppFunction%d<void,%s> : public CppFunction {
+    public:
+        CppFunction%d(void (*fun)(%s) , const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
+
+        SEXP operator()(SEXP* args) {
+            %s
+            ptr_fun(%s);
+            return R_NilValue;
+        }
+
+        inline int nargs() { return %d; }
+        inline bool is_void() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,%s>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        void (*ptr_fun)(%s) ;
+};
+
+
+
+template <typename RESULT_TYPE, %s>
+class CppFunction_WithFormals%d : public CppFunction {
+    public:
+
+        CppFunction_WithFormals%d(RESULT_TYPE (*fun)(%s) , Rcpp::List formals_, const char* docstring = 0) :
+            CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
+
+        SEXP operator()(SEXP* args) {
+            %s
+            return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun(%s));
+        }
+
+        inline int nargs() { return %d; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+        SEXP get_formals() { return formals; }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        Rcpp::List formals;
+        RESULT_TYPE (*ptr_fun)(%s);
+};
+
+template <%s>
+class CppFunction_WithFormals%d<void,%s> : public CppFunction {
+    public:
+        CppFunction_WithFormals%d(void (*fun)(%s), Rcpp::List formals_, const char* docstring = 0) :
+            CppFunction(docstring), formals(formals_), ptr_fun(fun) {}
+
+        SEXP operator()(SEXP* args) {
+            %s
+            ptr_fun(%s);
+            return R_NilValue;
+        }
+
+        inline int nargs() { return %d; }
+        inline bool is_void() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,%s>(s, name); }
+        SEXP get_formals() { return formals; }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        Rcpp::List formals;
+        void (*ptr_fun)(%s);
+};
+',
+               collapse(sprintf("typename U%d", index)),
+               i,
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("typename traits::input_parameter< U%d >::type x%d(args[%d]);",
+                                index, index, index ), sep = "\n            "),
+               collapse(sprintf("x%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse( sprintf( "U%d", index)),
+
+               paste(sprintf("typename U%d", index), collapse = ", "),
+               i,
+               collapse(sprintf("U%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("typename traits::input_parameter< U%d >::type x%d(args[%d]);",
+                                index, index, index), sep = "\n            " ),
+               collapse(sprintf("x%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("U%d", index)),
+
+               ## _ WithFormals
+               collapse(sprintf("typename U%d", index)),
+               i,
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("typename traits::input_parameter< U%d >::type x%d(args[%d]);",
+                                index, index, index ), sep = "\n            " ),
+               collapse(sprintf("x%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("U%d", index)),
+
+
+               paste(sprintf("typename U%d", index), collapse = ", "),
+               i,
+               collapse(sprintf("U%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("typename traits::input_parameter< U%d >::type x%d(args[%d]);",
+                                index, index, index), sep = "\n            " ),
+               collapse(sprintf("x%d", index)),
+               i,
+               collapse(sprintf("U%d", index)),
+               collapse(sprintf("U%d", index))
+               )
+}
+
+file <- sprintf(
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_CppFunction.h: -- generated helper code for Modules
+//                                    see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_CppFunction_h
+#define Rcpp_Module_generated_CppFunction_h
+
+namespace Rcpp {
+
+template <typename RESULT_TYPE>
+class CppFunction0 : public CppFunction {
+    public:
+        CppFunction0(RESULT_TYPE (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
+        SEXP operator()(SEXP*) {
+            return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
+        }
+
+        inline int nargs() { return 0; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        RESULT_TYPE (*ptr_fun)(void);
+};
+
+
+template <>
+class CppFunction0<void> : public CppFunction {
+    public:
+        CppFunction0(void (*fun)(void), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {};
+
+        SEXP operator()(SEXP*) {
+            ptr_fun();
+            return R_NilValue;
+        }
+
+        inline int nargs() { return 0; }
+        inline bool is_void() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        void (*ptr_fun)(void);
+};
+
+
+template <typename RESULT_TYPE>
+class CppFunction_WithFormals0 : public CppFunction {
+    public:
+        CppFunction_WithFormals0(RESULT_TYPE (*fun)(void), Rcpp::List,  const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
+        SEXP operator()(SEXP*) {
+            return Rcpp::module_wrap<RESULT_TYPE>(ptr_fun());
+        }
+
+        inline int nargs() { return 0; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        RESULT_TYPE (*ptr_fun)(void);
+};
+
+
+template <>
+class CppFunction_WithFormals0<void> : public CppFunction {
+    public:
+        CppFunction_WithFormals0(void (*fun)(void), Rcpp::List, const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {} ;
+
+        SEXP operator()(SEXP*) {
+            ptr_fun() ;
+            return R_NilValue;
+        }
+
+        inline int nargs() { return 0; }
+        inline bool is_void() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type>(s, name); }
+        inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+
+    private:
+        void (*ptr_fun)(void) ;
+};
+
+%s
+
+}
+
+#endif
+', paste(sapply( 1:65, fun), collapse = "\n")
+    )
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines(file, "inst/include/Rcpp/module/Module_generated_CppFunction.h")

--- a/internal/scripts/generator_Module_CppMethod.R
+++ b/internal/scripts/generator_Module_CppMethod.R
@@ -1,0 +1,248 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_CppMethod.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+
+    index <- (1:i)-1
+    collapse <- function(x, collapse = ", ") paste( x, collapse = collapse)
+	
+    typenames <- collapse(sprintf( "typename U%d", index))
+    u <- collapse(sprintf("U%d u%d", index, index))
+    input_parameter <- collapse(sprintf("typename Rcpp::traits::input_parameter<U%d>::type x%d(args[%d]);",
+                                        index, index, index), collapse = "\n")  
+    x <- collapse(sprintf( "x%d", index))
+    U <- collapse(sprintf( "U%d", index))
+       
+    txt <- sprintf('
+
+template <typename Class, typename RESULT_TYPE, %s> class CppMethod%d : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (Class::*Method)(%s);
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+    
+    CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP* args) {
+        %s
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>((object->*met)(%s));
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return false; }
+    inline bool is_const() { return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class, %s> class CppMethod%d<Class,void,%s> : public CppMethod<Class> {
+public:
+    typedef void (Class::*Method)(%s);
+    typedef CppMethod<Class> method_class;
+    
+    CppMethod%d( Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP* args) {
+        %s
+        (object->*met)(%s);
+        return R_NilValue;
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,%s>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class, typename RESULT_TYPE, %s> class const_CppMethod%d : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (Class::*Method)(%s) const;
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+    
+    const_CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP* args) {
+        %s
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>((object->*met)(%s));
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return false; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+
+private:
+    Method met;
+} ;
+    
+template < typename Class, %s > class const_CppMethod%d<Class,void,%s> : public CppMethod<Class> {
+public:
+    typedef void (Class::*Method)(%s) const;
+    typedef CppMethod<Class> method_class;
+    
+    const_CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP* args) {
+        %s
+        (object->*met)(%s);
+        return R_NilValue;
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name ) { Rcpp::signature<void_type,%s>(s, name); }
+
+private:
+    Method met ;
+};', 
+    typenames,  # typename U0, ...
+    i,           
+    u,          # U0 u0, ...
+    i,
+    input_parameter,
+    x,         # Rcpp::as<U0>( args[0] ) , ...
+    i, 
+    U,
+
+    typenames,  # typename U0, ...
+    i, 
+    U, 			# U0, ...
+    u,          # U0 u0, ...
+    i,
+    input_parameter,
+    x, 
+    i, 
+    U,
+
+
+    typenames,  # typename U0, ...
+    i,           
+    u,          # U0 u0, ...
+    i, 
+    input_parameter,
+    x,         # Rcpp::as<U0>( args[0] ) , ...
+    i, 
+    U, 
+
+    typenames,  # typename U0, ...
+    i, 
+    U, 			 # U0, ...
+    u,          # U0 u0, ...
+    i, 
+    input_parameter,
+    x, 
+    i,
+    U 
+    )   
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_CppMethod.h: -- generated helper code for Modules
+//                                  see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_CppMethod_h
+#define Rcpp_Module_generated_CppMethod_h
+
+template <typename Class, typename RESULT_TYPE> class CppMethod0 : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (Class::*Method)(void);
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+    
+    CppMethod0( Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP*) {
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>((object->*met)());
+    }
+    inline int nargs() { return 0; }
+    inline bool is_void() { return false; }
+    inline bool is_const() { return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class> class CppMethod0<Class,void> : public CppMethod<Class> {
+public:
+    typedef void (Class::*Method)(void);
+    typedef CppMethod<Class> method_class;
+    CppMethod0( Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP* ) {
+        (object->*met)();
+        return R_NilValue;
+    }
+    inline int nargs() { return 0; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class, typename RESULT_TYPE> class const_CppMethod0 : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (Class::*Method)(void) const;
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+    
+    const_CppMethod0( Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP*) {
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>((object->*met)());
+    }
+    inline int nargs() { return 0; }
+    inline bool is_void() { return false; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class> class const_CppMethod0<Class,void> : public CppMethod<Class> {
+public:
+    typedef void (Class::*Method)(void) const;
+    typedef CppMethod<Class> method_class;
+    const_CppMethod0( Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP*) {
+        (object->*met)( );
+        return R_NilValue;
+    }
+    inline int nargs() { return 0; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type>(s, name); }
+
+private:
+    Method met;
+};
+
+%s
+
+#endif
+', paste(sapply(1:65 , fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines(file, "inst/include/Rcpp/module/Module_generated_CppMethod.h" )

--- a/internal/scripts/generator_Module_PointerCppMethod.R
+++ b/internal/scripts/generator_Module_PointerCppMethod.R
@@ -1,0 +1,253 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_PointerCppMethod.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+
+    index <- (1:i)-1
+    collapse <- function(x, collapse = ", ") paste(x, collapse = collapse)
+	
+    typenames <- collapse(sprintf("typename U%d", index))
+    u <- collapse(sprintf("U%d u%d", index, index))
+    input_parameter <- collapse(sprintf("typename Rcpp::traits::input_parameter< U%d >::type x%d( args[%d] ) ;", index, index, index), collapse = "\n")  
+    x <- collapse(sprintf("x%d", index))
+    U <- collapse(sprintf("U%d", index))
+       
+    txt <- sprintf('
+
+template <typename Class, typename RESULT_TYPE, %s> class Pointer_CppMethod%d : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (*Method)(Class*, %s);
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+
+    Pointer_CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP* args) {
+        %s
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>(met(object, %s));
+    }
+    inline int nargs(){ return %d; }
+    inline bool is_void(){ return false; }
+    inline bool is_const(){ return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class, %s> class Pointer_CppMethod%d<Class,void,%s> : public CppMethod<Class> {
+public:
+    typedef void (*Method)(Class*, %s);
+    typedef CppMethod<Class> method_class;
+
+    Pointer_CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP* args) {
+    	%s
+        met(object, %s);
+        return R_NilValue;
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return false; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,%s>(s, name); }
+
+private:
+    Method met;
+};
+
+
+// const
+
+template <typename Class, typename RESULT_TYPE, %s> class Const_Pointer_CppMethod%d : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (*Method)(const Class*, %s);
+    typedef CppMethod<Class> method_class;
+    typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+
+    Const_Pointer_CppMethod%d(Method m) : method_class(), met(m) {} 
+    SEXP operator()(Class* object, SEXP* args) {
+        %s
+        return Rcpp::module_wrap<CLEANED_RESULT_TYPE>(met(object, %s));
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return false; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,%s>(s, name); }
+
+private:
+    Method met;
+};
+
+template <typename Class, %s> class Const_Pointer_CppMethod%d<Class,void,%s> : public CppMethod<Class> {
+public:
+    typedef void (*Method)(const Class*, %s);
+    typedef CppMethod<Class> method_class;
+
+    Const_Pointer_CppMethod%d( Method m) : method_class(), met(m) {} 
+    SEXP operator()( Class* object, SEXP* args) {
+        %s
+        met(object, %s);
+        return R_NilValue;
+    }
+    inline int nargs() { return %d; }
+    inline bool is_void() { return true; }
+    inline bool is_const() { return true; }
+    inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,%s>(s, name); }
+
+private:
+    Method met;
+};
+                   ', 
+                   typenames,  # typename U0, ...
+                   i,           
+                   u,          # U0 u0, ...
+                   i, 
+                   input_parameter,
+                   x,
+                   i,
+                   U, 
+                   
+                   typenames,  # typename U0, ...
+                   i, 
+                   U, 			# U0, ...
+                   u,          # U0 u0, ...
+                   i, 
+                   input_parameter,
+                   x,
+                   i,
+                   U, 
+                   
+                   
+                   ## const 
+                   typenames,  # typename U0, ...
+                   i,           
+                   u,          # U0 u0, ...
+                   i, 
+                   input_parameter,
+                   x,
+                   i,
+                   U, 
+                   
+                   typenames,  # typename U0, ...
+                   i, 
+                   U, 			# U0, ...
+                   u,          # U0 u0, ...
+                   i, 
+                   input_parameter,
+                   x,
+                   i,
+                   U
+                   )   
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_PointerCppMethod.h: -- generated helper code for Modules
+//                                         see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Doug Bates, Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_Pointer_CppMethod_h
+#define Rcpp_Module_generated_Pointer_CppMethod_h
+
+
+template <typename Class, typename RESULT_TYPE> class Pointer_CppMethod0 : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (*Method)(Class*) ;
+    typedef CppMethod<Class> method_class ;
+    Pointer_CppMethod0( Method m) : method_class(), met(m){} 
+    SEXP operator()( Class* object, SEXP* ){
+        return Rcpp::module_wrap<RESULT_TYPE>( met(object) ) ;
+    }
+    inline int nargs(){ return 0 ; }
+    inline bool is_void(){ return false ; }
+    inline bool is_const(){ return false ; }
+    inline void signature(std::string& s, const char* name){ Rcpp::signature<RESULT_TYPE>(s, name) ; }
+
+private:
+    Method met ;
+} ;
+
+template <typename Class> class Pointer_CppMethod0<Class,void> : public CppMethod<Class> {
+public:
+    typedef void (*Method)(Class*) ;
+    typedef CppMethod<Class> method_class ;
+    Pointer_CppMethod0( Method m) : method_class(), met(m){} 
+    SEXP operator()( Class* object, SEXP* ){
+        met( object ) ;
+        return R_NilValue ;
+    }
+    inline int nargs(){ return 0 ; }
+    inline bool is_void(){ return true ; }
+    inline bool is_const(){ return false ; }
+    inline void signature(std::string& s, const char* name){ Rcpp::signature<void_type>(s, name) ; }
+
+private:
+    Method met ;
+} ;
+
+
+
+
+template <typename Class, typename RESULT_TYPE> class Const_Pointer_CppMethod0 : public CppMethod<Class> {
+public:
+    typedef RESULT_TYPE (*Method)(const Class*) ;
+    typedef CppMethod<Class> method_class ;
+    Const_Pointer_CppMethod0( Method m) : method_class(), met(m){} 
+    SEXP operator()( Class* object, SEXP* ){
+        return Rcpp::module_wrap<RESULT_TYPE>( met(object) ) ;
+    }
+    inline int nargs(){ return 0 ; }
+    inline bool is_void(){ return false ; }
+    inline bool is_const(){ return true ; }
+    inline void signature(std::string& s, const char* name){ Rcpp::signature<RESULT_TYPE>(s, name) ; }
+
+private:
+    Method met ;
+} ;
+
+template <typename Class> class Const_Pointer_CppMethod0<Class,void> : public CppMethod<Class> {
+public:
+    typedef void (*Method)(const Class*) ;
+    typedef CppMethod<Class> method_class ;
+    Const_Pointer_CppMethod0( Method m) : method_class(), met(m){} 
+    SEXP operator()( Class* object, SEXP* ){
+        met( object ) ;
+        return R_NilValue ;
+    }
+    inline int nargs(){ return 0 ; }
+    inline bool is_void(){ return true ; }
+    inline bool is_const(){ return true ; }
+
+    inline void signature(std::string& s, const char* name){ Rcpp::signature<void_type>(s, name) ; }
+
+private:
+    Method met ;
+};
+
+%s
+
+#endif
+', paste( sapply( 1:65 , fun), collapse = "\n" ) 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines( file, "inst/include/Rcpp/module/Module_generated_Pointer_CppMethod.h" )

--- a/internal/scripts/generator_Module_Pointer_method.R
+++ b/internal/scripts/generator_Module_Pointer_method.R
@@ -1,0 +1,94 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_Pointer_method.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+
+    index <- (1:i)-1
+    collapse <- function(x) paste(x, collapse = ", ")
+	
+    typenames <- collapse(sprintf("typename U%d", index))
+    u <- collapse(sprintf("U%d u%d", index, index))
+    as <- collapse(sprintf("Rcpp::as< typename Rcpp::traits::remove_const_and_reference<U%d>::type>(args[%d])",
+                           index, index))  
+    U <- collapse(sprintf("U%d", index))
+    
+    txt <- sprintf('
+
+template <typename RESULT_TYPE, %s>
+self& method(const char* name_, RESULT_TYPE (*fun)(Class*, %s),
+             const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod(name_, new Pointer_CppMethod%d<Class,RESULT_TYPE,%s>(fun), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE, %s>
+self& const_method(const char* name_, RESULT_TYPE (*fun)(const Class*, %s),
+                   const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod(name_, new Const_Pointer_CppMethod%d<Class,RESULT_TYPE,%s>(fun), valid, docstring);
+    return *this ;
+}',
+                   typenames,   # typename U0, ...
+                   u,           # U0 u0, ...
+                   i,
+                   i,
+                   U,           # U0, ...
+                   
+                   typenames,   # typename U0, ...
+                   u,           # U0 u0, ...
+                   i,
+                   i,
+                   U            # U0, ...
+                   )   
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_Pointer_method.h: -- generated helper code for Modules
+//                                       see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_Pointer_method_h
+#define Rcpp_Module_generated_Pointer_method_h
+
+template <typename RESULT_TYPE>
+self& method(const char* name_, RESULT_TYPE (*fun)(Class*),
+             const char* docstring = 0, ValidMethod valid = &yes) {
+    AddMethod(name_, new Pointer_CppMethod0<Class,RESULT_TYPE>(fun), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE>
+self& const_method(const char* name_, RESULT_TYPE (*fun)(const Class*),
+                   const char* docstring = 0, ValidMethod valid = &yes ){
+    AddMethod(name_, new Const_Pointer_CppMethod0<Class,RESULT_TYPE>( fun ), valid, docstring);
+    return *this;
+}
+
+%s
+
+#endif
+', paste(sapply(1:65, fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines( file, "inst/include/Rcpp/module/Module_generated_Pointer_method.h")

--- a/internal/scripts/generator_Module_function.R
+++ b/internal/scripts/generator_Module_function.R
@@ -1,0 +1,79 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_function.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+	
+    typename <- if (i == 0) "" else paste0(",", paste(sprintf( "typename U%d", (1:i)-1), collapse = ", "))
+    Uu <- if( i == 0 ) "void" else paste(sprintf("U%d u%d", (1:i)-1, (1:i)-1), collapse = ", ")
+    U <- if( i == 0 ) "" else paste0(",", paste(sprintf( "U%d", (1:i)-1), collapse = ", "))
+    
+    txt <- sprintf('
+template <typename RESULT_TYPE%s>
+void function(const char* name_,  RESULT_TYPE (*fun)(%s), const char* docstring = 0) {
+    Rcpp::Module* scope = ::getCurrentScope();
+    if (scope) {
+        scope->Add(name_, new CppFunction%d<RESULT_TYPE%s>(fun, docstring));
+    }
+}
+
+template <typename RESULT_TYPE%s>
+void function(const char* name_,  RESULT_TYPE (*fun)(%s), Rcpp::List formals, const char* docstring = 0) {
+    Rcpp::Module* scope = ::getCurrentScope();
+    if (scope) {
+       scope->Add(name_, new CppFunction_WithFormals%d<RESULT_TYPE%s>(fun, formals, docstring));
+    }
+}', 
+                   typename, 
+                   Uu, 
+                   i, 
+                   U, 
+
+                   typename, 
+                   Uu, 
+                   i, 
+                   U
+                   )
+	
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_function.h: -- generated helper code for Modules
+//                                 see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_function_h
+#define Rcpp_Module_generated_function_h
+
+namespace Rcpp {
+
+%s
+
+}
+
+#endif ',
+    paste(sapply( 0:65, fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines(file, "inst/include/Rcpp/module/Module_generated_function.h")

--- a/internal/scripts/generator_Module_method.R
+++ b/internal/scripts/generator_Module_method.R
@@ -1,0 +1,141 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_method.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+
+fun <- function(i) {
+
+    index <- (1:i)-1
+    collapse <- function(x) paste(x, collapse = ", ")
+	
+    typenames <- collapse(sprintf("typename U%d", index))
+    u <- collapse(sprintf("U%d u%d", index, index))
+    as <- collapse(sprintf("Rcpp::as< typename Rcpp::traits::remove_const_and_reference<U%d>::type>(args[%d])",
+                           index, index))  
+    U <- collapse(sprintf("U%d", index))
+    
+txt <- sprintf('
+
+template <typename RESULT_TYPE, %s>
+self& method(const char* name_, RESULT_TYPE (Class::*fun)(%s),
+             const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod( name_, new CppMethod%d<Class,RESULT_TYPE,%s>(fun), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE, %s>
+self& method(const char* name_, RESULT_TYPE (Class::*fun)(%s) const,
+             const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod(name_, new const_CppMethod%d<Class,RESULT_TYPE,%s>(fun), valid, docstring);
+    return *this ;
+}
+
+template <typename RESULT_TYPE, %s>
+self& nonconst_method(const char* name_, RESULT_TYPE (Class::*fun)(%s),
+                      const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod(name_, new CppMethod%d<Class,RESULT_TYPE,%s>( fun ), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE, %s>
+self& const_method(const char* name_, RESULT_TYPE (Class::*fun)(%s) const,
+                   const char* docstring = 0, ValidMethod valid = &yes_arity<%d>) {
+    AddMethod(name_, new const_CppMethod%d<Class,RESULT_TYPE,%s>( fun ), valid, docstring);
+    return *this;
+}',
+               typenames,   # typename U0, ...
+               u,           # U0 u0, ...
+               i, 
+               i,
+               U,           # U0, ...
+
+               typenames,   # typename U0, ...
+               u,           # U0 u0, ...
+               i, 
+               i,
+               U,            # U0, ...
+
+               typenames,   # typename U0, ...
+               u,           # U0 u0, ...
+               i,
+               i,
+               U,           # U0, ...
+
+               typenames,   # typename U0, ...
+               u,           # U0 u0, ...
+               i,
+               i,
+               U            # U0, ...
+)   
+
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_method.h: -- generated helper code for Modules
+//                               see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_method_h
+#define Rcpp_Module_generated_method_h
+
+template <typename RESULT_TYPE>
+self& method(const char* name_, RESULT_TYPE (Class::*fun)(void),
+             const char* docstring = 0, ValidMethod valid = &yes) {
+    AddMethod(name_, new CppMethod0<Class,RESULT_TYPE>(fun), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE>
+self& method(const char* name_, RESULT_TYPE (Class::*fun)(void) const,
+             const char* docstring = 0, ValidMethod valid = &yes) {
+    AddMethod( name_, new const_CppMethod0<Class,RESULT_TYPE>(fun), valid, docstring);
+    return *this;
+}
+
+template <typename RESULT_TYPE>
+self& nonconst_method(const char* name_, RESULT_TYPE (Class::*fun)(void),
+                      const char* docstring = 0, ValidMethod valid = &yes ){
+    AddMethod( name_, new CppMethod0<Class,RESULT_TYPE>( fun ) , valid, docstring ) ;
+    return *this ;
+}
+
+template <typename RESULT_TYPE>
+self& const_method(const char* name_, RESULT_TYPE (Class::*fun)(void) const,
+                   const char* docstring = 0, ValidMethod valid = &yes ){
+    AddMethod( name_, new const_CppMethod0<Class,RESULT_TYPE>( fun ), valid, docstring ) ;
+    return *this ;
+}
+
+%s
+
+#endif
+', paste( sapply( 1:65, fun), collapse = "\n" ) 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines( file, "inst/include/Rcpp/module/Module_generated_method.h" )
+
+
+
+
+

--- a/internal/scripts/generator_Module_signature.R
+++ b/internal/scripts/generator_Module_signature.R
@@ -1,0 +1,91 @@
+#!/usr/bin/Rscript
+#
+# Generator for inst/include/Rcpp/module/Module_generated_get_signature.h
+#
+# Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+
+fun <- function(i) {
+
+    index <- 0:i
+    collapse <- function(x) paste(x, collapse = ", ")
+	
+    typenames <- collapse(sprintf("typename U%d", index))
+    demangles <- paste(sprintf('    s += ", "; s+= get_return_type<U%d>();', 1:i), collapse = "\n")
+    
+    txt <- sprintf('
+
+template <typename RESULT_TYPE,%s>
+inline void signature(std::string& s, const char* name) {
+    s.clear();
+    s += get_return_type<RESULT_TYPE>();
+    s += " ";
+    s += name;
+    s += "(";
+    s += get_return_type<U0>();
+%s
+    s += ")";
+}
+
+',
+                   typenames,   # typename U0, ...
+                   demangles)   
+    txt
+}
+
+file <- sprintf( 
+'// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// Module_generated_get_signature.h: -- generated helper code for Modules
+//                                      see rcpp-scripts repo for generator script
+//
+// Copyright (C) 2010 - 2014  Doug Bates, Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp_Module_generated_get_signature_h
+#define Rcpp_Module_generated_get_signature_h
+
+namespace Rcpp {
+
+template <typename RESULT_TYPE>
+inline void signature(std::string& s, const char* name) {
+    s.clear();
+    s += get_return_type<RESULT_TYPE>();
+    s += " ";
+    s += name;
+    s += "()";
+}
+
+template <typename RESULT_TYPE,typename U0>
+inline void signature(std::string& s, const char* name) {
+    s.clear();
+    s += get_return_type<RESULT_TYPE>();
+    s += " ";
+    s += name;
+    s += "(";
+    s += get_return_type<U0>();
+    s += ")";
+}
+
+%s
+
+}
+
+#endif', paste(sapply(1:65, fun), collapse = "\n") 
+)
+
+stopifnot(file.exists("inst/include/Rcpp/module/"))
+writeLines(file, "inst/include/Rcpp/module/Module_generated_get_signature.h")

--- a/internal/scripts/lmBench.R
+++ b/internal/scripts/lmBench.R
@@ -1,0 +1,27 @@
+#!/usr/bin/r
+
+suppressMessages({
+    library(utils)
+    library(methods)
+    library(RcppEigen)
+    library(RcppArmadillo)
+    library(RcppGSL)
+    library(rbenchmark)
+})
+
+set.seed(1)
+N <- 100
+p <- 9
+mm <- cbind(1, matrix(rnorm(N * p), nc = p))
+y <- rnorm(N)
+res <- benchmark(RRchol = .Call("fastLmChol2", mm, y, PACKAGE="RcppEigen"),
+                 NRchol = .Call("fastLmChol1", mm, y, PACKAGE="RcppEigen"),
+                 NReigen = .Call("fastLmBench", mm, y, PACKAGE="RcppEigen"),
+                 RReigen = .Call("fastLm", mm, y, PACKAGE="RcppEigen"),
+                 NRarma = .Call("fastLm", mm, y, PACKAGE="RcppArmadillo"),
+                 lmFit = lm.fit(mm, y),
+                 NRGSL = .Call("fastLm", mm, y, PACKAGE="RcppGSL"),
+                 columns=c("test", "elapsed", "relative", "user.self", "sys.self"),
+                 order="elapsed",
+                 replications=1000)
+print(res)

--- a/internal/scripts/osxinstall_RcppGsl
+++ b/internal/scripts/osxinstall_RcppGsl
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd RcppGSL
+./cleanup
+cd ..
+R --arch=i386 CMD INSTALL RcppGSL
+cd RcppGSL
+./cleanup
+cd ..
+R --arch=x86_64 CMD INSTALL --libs-only RcppGSL
+

--- a/internal/scripts/preprocessor.R
+++ b/internal/scripts/preprocessor.R
@@ -1,0 +1,221 @@
+# 
+# run this from the directory that contains Rcpp
+#
+# Rscript ../scripts/preprocessor.R
+#
+
+rcpp_function <- sapply( 0:65, function(i){
+	txt <- sprintf( '
+#define RCPP_FUNCTION_%d(__OUT__,__NAME__%s)        \\
+extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)( ){         \\
+    using Rcpp::_ ;                                 \\
+	Rcpp::List info = Rcpp::List::create(           \\
+        _["n"]   = %d ,                             \\
+        _["output"] = #__OUT__ ,                       \\
+        _["input"]  = Rcpp::CharacterVector::create(   \\
+        	%s                                       \\
+        	) ) ;                                    \\
+    info.attr( "class" ) = "rcppfunctioninfo" ;      \\
+    return info ;                                   \\
+}                                                   \\
+__OUT__ RCPP_DECORATE(__NAME__)(%s) ;               \\
+extern "C" SEXP __NAME__(%s){                       \\
+SEXP res = R_NilValue ;                             \\
+BEGIN_RCPP                                          \\
+REprintf("  RCPP_FUNCTION_%d is deprecated, it will be removed permanently in july 2014\\n" ) ;     \\
+res = ::Rcpp::wrap( RCPP_DECORATE(__NAME__)(%s) ) ; \\
+return res ;                                        \\
+END_RCPP                                            \\
+}                                                   \\
+__OUT__ RCPP_DECORATE(__NAME__)(%s)', 
+	i,
+	if( i == 0 ) "" else paste( ",", paste( sprintf( "___%d", 0:(i-1)), collapse=", ") ),
+	i, 
+	if( i == 0 ) "" else paste( sprintf( "#___%d", 0:(i-1)), collapse=", "),
+	if( i == 0 ) "" else paste( sprintf( "___%d", 0:(i-1)), collapse=", "),
+	if( i == 0 ) "" else paste( sprintf( "SEXP x%d", 0:(i-1) ), collapse = ", " ), 
+	i,
+	if( i == 0 ) "" else paste( sprintf( "::Rcpp::internal::converter( x%d )", 0:(i-1) ), collapse = ", " ), 
+	if( i == 0 ) "" else paste( sprintf( "___%d", 0:(i-1)), collapse=", ")
+	)
+})
+
+
+rcpp_function_void <- sapply( 0:65, function(i){
+	txt <- sprintf( '
+#define RCPP_FUNCTION_VOID_%d(__NAME__%s)           \\
+void RCPP_DECORATE(__NAME__)(%s) ;                  \\
+extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)( ){         \\
+    using Rcpp::_ ;                                 \\
+	Rcpp::List info = Rcpp::List::create(           \\
+        _["n"]   = %d ,                             \\
+        _["output"] = R_NilValue ,                     \\
+        _["input"]  = Rcpp::CharacterVector::create(   \\
+        	%s                                       \\
+        	) );                                      \\
+    info.attr( "class" ) = "rcppfunctionvoidinfo";  \\
+    return info ;                                   \\
+}                                                   \\
+extern "C" SEXP __NAME__(%s){                       \\
+BEGIN_RCPP                                          \\
+REprintf("  RCPP_FUNCTION_VOID_%d is deprecated, it will be removed permanently in july 2014\\n" ) ;     \\
+RCPP_DECORATE(__NAME__)(%s) ;                       \\
+END_RCPP                                            \\
+}                                                   \\
+void RCPP_DECORATE(__NAME__)(%s)', 
+	i,
+	if( i == 0 ) "" else paste( ",", paste( sprintf( "___%d", 0:(i-1)), collapse=", ") ),
+	if( i == 0 ) "" else paste( sprintf( "___%d", 0:(i-1)), collapse=", "),
+	i, 
+	if( i == 0 ) "" else paste( sprintf( "#___%d", 0:(i-1)), collapse=", "),
+	if( i == 0 ) "" else paste( sprintf( "SEXP x%d", 0:(i-1) ), collapse = ", " ), 
+	i, 
+	if( i == 0 ) "" else paste( sprintf( "::Rcpp::internal::converter( x%d )", 0:(i-1) ), collapse = ", " ), 
+	if( i == 0 ) "" else paste( sprintf( "___%d", 0:(i-1)), collapse=", ")
+	)
+})
+
+rcpp_xp_method <- sapply( 0:65, function(i){
+	txt <- sprintf( '
+#define RCPP_XP_METHOD_%d(__NAME__,__CLASS__,__METHOD__ )   \\
+extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)( ){                 \\
+    using Rcpp::_ ;                                         \\
+	Rcpp::List info = Rcpp::List::create(                    \\
+        _["n"]      = %d ,                                  \\
+        _["class"]  = #__CLASS__   ,                        \\
+        _["method"] = #__METHOD__                           \\
+        ) ;                                              \\
+    info.attr( "class" ) = "rcppxpmethodinfo" ;             \\
+    return info   ;                                         \\
+}                                                           \\
+extern "C" SEXP __NAME__( SEXP xp %s ){                     \\
+BEGIN_RCPP                                                  \\
+    REprintf("  RCPP_XP_METHOD_%d is deprecated, it will be removed permanently in july 2014\\n" ) ;     \\
+	::Rcpp::XPtr< __CLASS__ > ptr(xp) ;                       \\
+	return ::Rcpp::wrap( ptr->__METHOD__( %s ) ) ;           \\
+END_RCPP                                                    \\
+}
+', 
+	i, 
+	i, 
+	if( i == 0 ) "" else paste( ", ", paste( sprintf( "SEXP x%d", 0:(i-1) ), collapse = ", " ) ), 
+	i,
+	if( i == 0 ) "" else paste( sprintf( "::Rcpp::internal::converter( x%d )", 0:(i-1)), collapse=", ")
+)
+
+})
+
+rcpp_xp_method_cast <- sapply( 0:65, function(i){
+	txt <- sprintf( '
+#define RCPP_XP_METHOD_CAST_%d(__NAME__,__CLASS__,__METHOD__,__CAST__)   \\
+extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)( ){                 \\
+    using Rcpp::_ ;                                         \\
+	Rcpp::List info = Rcpp::List::create(                    \\
+        _["n"]      = %d ,                                  \\
+        _["class"]  = #__CLASS__  ,                         \\
+        _["method"] = #__METHOD__ ,                          \\
+        _["cast"]   = #__CAST__                             \\
+        )   ;                                              \\
+    info.attr( "class" ) = "rcppxpmethodcastinfo" ;         \\
+    return info   ;                                         \\
+}                                                           \\
+extern "C" SEXP __NAME__( SEXP xp %s ){                      \\
+BEGIN_RCPP                                                   \\
+	REprintf("  RCPP_XP_METHOD_CAST_%d is deprecated, it will be removed permanently in july 2014\\n" ) ;     \\
+	::Rcpp::XPtr< __CLASS__ > ptr(xp) ;                        \\
+	return ::Rcpp::wrap( __CAST__( ptr->__METHOD__( %s ) ) ) ;\\
+END_RCPP                                                     \\
+}
+', 
+	i, 
+	i, 
+	if( i == 0 ) "" else paste( ", ", paste( sprintf( "SEXP x%d", 0:(i-1) ), collapse = ", " ) ), 
+	i, 
+	if( i == 0 ) "" else paste( sprintf( "::Rcpp::internal::converter( x%d )", 0:(i-1)), collapse=", ")
+)
+
+})
+
+
+
+rcpp_xp_method_void <- sapply( 0:65, function(i){
+	txt <- sprintf( '
+#define RCPP_XP_METHOD_VOID_%d(__NAME__,__CLASS__,__METHOD__)    \\
+extern "C" SEXP RCPP_PP_CAT(__NAME__,__rcpp_info__)( ){                 \\
+    using Rcpp::_ ;                                         \\
+	Rcpp::List info = Rcpp::List::create(                    \\
+        _["n"]      = %d ,                                  \\
+        _["class"]  = #__CLASS__  ,                         \\
+        _["method"] = #__METHOD__                           \\
+        ) ;                                                 \\
+    info.attr( "class" ) = "rcppxpmethodvoidinfo" ;         \\
+    return info   ;                                         \\
+}                                                           \\
+extern "C" SEXP __NAME__( SEXP xp %s ){                            \\
+BEGIN_RCPP                                                         \\
+REprintf("  RCPP_XP_METHOD_VOID_%d is deprecated, it will be removed permanently in july 2014\\n" ) ;     \\
+::Rcpp::XPtr< __CLASS__ > ptr(xp) ;                                  \\
+ptr->__METHOD__( %s ) ;                                            \\
+END_RCPP                                                           \\
+}
+', 
+	i, 
+	i, 
+	if( i == 0 ) "" else paste( ", ", paste( sprintf( "SEXP x%d", 0:(i-1) ), collapse = ", " ) ), 
+	i, 
+	if( i == 0 ) "" else paste( sprintf( "::Rcpp::internal::converter( x%d )", 0:(i-1)), collapse=", ")
+)
+
+})
+
+
+res <- c( 
+"// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// :tabSize=4:indentSize=4:noTabs=true:folding=explicit:collapseFolds=1:
+// preprocessor_generated.h: Rcpp R/C++ interface class library -- pre processor help
+//
+// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef RCPP__PREPROCESSOR_GENERATED_H
+#define RCPP__PREPROCESSOR_GENERATED_H
+
+// {{{ RCPP_FUNCTION 
+", rcpp_function, "
+// }}}
+
+// {{{ RCPP_FUNCTION_VOID 
+", rcpp_function_void, "
+// }}}
+
+// {{{ RCPP_XP_METHOD
+", rcpp_xp_method, "
+// }}}
+
+// {{{ RCPP_XP_METHOD_VOID
+", rcpp_xp_method_void, "
+// }}}
+
+// {{{ RCPP_XP_METHOD_CAST
+", rcpp_xp_method_cast, "
+// }}}
+
+#endif
+" )
+
+writeLines( res, "Rcpp/inst/include/Rcpp/macros/preprocessor_generated.h" )
+

--- a/internal/scripts/runBuild.sh
+++ b/internal/scripts/runBuild.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+#
+# Rebuilds all vignettes
+# Builds tarball
+# Runs checks based on tarball
+# Copies tarball in place for Debian package builds from SVN dir
+# Copies tarball to web directory too
+
+set -e 
+set -u 
+
+progname=`basename $0`
+options='lnh?'
+ 
+usage_and_exit()
+{
+    echo ""
+    echo "Usage: $progname [-n] [-?|-h]"
+    echo "  Run build and tests for Rcpp package"
+    echo ""
+    echo "Options:"
+    echo "  -n,-l    no copy, only local build tests"
+    echo "  -h       show this help"
+    echo ""
+    exit 0
+}
+
+copy=1
+while getopts "$options" i 
+do 
+    case "$i" in
+	n)
+	    copy=0
+	    shift
+	    ;;
+	l)
+	    copy=0
+	    shift
+	    ;;
+	h|?)
+	    usage_and_exit
+	    ;;
+    esac
+done
+
+if [ ! -d Rcpp ]; then
+    echo "Not above Rcpp/"
+    exit -1
+fi
+
+version=$(r -e'cat(as.character(read.dcf("Rcpp/DESCRIPTION")[,"Version"]))')
+encodedversion=$(grep RCPP_VERSION Rcpp/inst/include/Rcpp/config.h | awk '{print $3}')
+echo "Working on:  $encodedversion -- $version"
+
+#export RCPP_CXX0X="yes"
+export RCPP_CXX0X="no"
+
+export RunAllRcppTests="yes"
+
+## remove old pdf vignettes and make fresh ones -- no longer needed with vignette scheme
+## cd Rcpp/inst/doc && make pdfclean && make pdfall && cd - 
+
+R CMD build --force Rcpp
+
+R CMD check --as-cran Rcpp_${version}.tar.gz
+
+if [ ${copy} -eq 1 ]; then
+    test -d tarballs   && cp -vax Rcpp_${version}.tar.gz tarballs/rcpp_${version}.orig.tar.gz
+    test -d build-area && cp -vax Rcpp_${version}.tar.gz build-area/rcpp_${version}.orig.tar.gz
+    test -d ~/www/code/rcpp && cp -vax Rcpp_${version}.tar.gz ~/www/code/rcpp
+fi
+
+echo "Done with $encodedversion -- $version"

--- a/internal/scripts/runDoxygenAndZip.sh
+++ b/internal/scripts/runDoxygenAndZip.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -e 
+
+if [ ! -d Rcpp ]; then
+    echo "Not above Rcpp/"
+    exit -1
+fi
+
+cwd=$(pwd)
+
+version=$(r -e'cat(as.character(read.dcf("Rcpp/DESCRIPTION")[,"Version"]))')
+echo "Working on version $version"
+
+
+if [ -x /usr/bin/doxygen ]; then 
+    cd Rcpp/inst/doc
+    rm -rf html/ latex/ man/
+    cd ${cwd}
+    cd Rcpp
+
+    ## see FAQ 17 for doxygen
+    ( cat doxyfile ; echo PROJECT_NAME="\"Rcpp Version ${version}\"" ) | doxygen -
+
+    cd ${cwd}
+    pwd
+
+    cd Rcpp/inst/doc
+    zip -9r rcpp-doc-html.zip html/
+    zip -9r rcpp-doc-man.zip man
+    zip -9r rcpp-doc-latex.zip latex
+    if [ -d ~/www/code/rcpp/ ]; then
+	mv -v rcpp-doc-*.zip ~/www/code/rcpp/
+	rsync --delete -avu html ~/www/code/rcpp/
+    fi
+    cd ${cwd}
+
+    cd Rcpp/inst/doc/latex
+    ## as release 0.8.3 this now requires increasing pool_size in /etc/texmf/texmf.conf
+    pdflatex refman
+    pdflatex refman
+    if [ -d ~/www/code/rcpp/ ]; then
+	cp -vax refman.pdf ~/www/code/rcpp/Rcpp_refman.pdf
+    fi
+    cd ${cwd}
+
+    if [ -d ~/www/code/rcpp/ ]; then
+        cd ~/www/code/rcpp/
+        tarball=`ls -1tr Rcpp_*.tar.gz|tail -1`
+    	#cp -vax Rcpp/inst/doc/Rcpp-*.pdf ~/www/code/rcpp
+        tar xvzf ${tarball} "Rcpp/inst/doc/"
+        mv -v Rcpp/inst/doc/*.pdf .
+        rm -rf Rcpp/
+    fi
+    cd ${cwd}
+
+fi

--- a/internal/scripts/runExamples.sh
+++ b/internal/scripts/runExamples.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e 
+
+function runConvolveBennchmark {
+    cd Rcpp/inst/examples/ConvolveBenchmarks
+    ./buildAndRun.sh
+    cd -
+}
+
+function runFastLM {
+    cd Rcpp/inst/examples/FastLM
+    Rscript ./benchmark.r
+    cd -
+}
+
+function runFunctionCallback {
+    cd Rcpp/inst/examples/functionCallback
+    Rscript ./newApiExample.r
+    cd -
+}
+
+function runRcppInline {
+    cd Rcpp/inst/examples/RcppInline
+    Rscript ./external_pointer.r
+    Rscript ./RcppInlineExample.r
+    Rscript ./RcppInlineWithLibsExamples.r
+    Rscript ./RcppSimpleExample.r
+    Rscript ./RObject.r
+    Rscript ./UncaughtExceptions.r
+    cd -
+}
+
+
+function runSugarPerformance {
+    cd Rcpp/inst/examples/SugarPerformance
+    Rscript ./sugarBenchmarks.R
+    cd -
+}
+
+function runRInsideExamples {
+    cd ../../rinside/pkg/inst/examples/standard
+    make clean
+    make
+    ./rinside_sample0
+    ./rinside_sample1
+    ./rinside_sample2
+    ./rinside_sample3
+    ./rinside_sample4
+    ./rinside_sample5
+    ./rinside_sample6
+    ./rinside_sample7
+    ./rinside_sample8
+    ./rinside_sample9
+    ./rinside_sample10
+    ./rinside_sample11
+    ./rinside_module_sample0
+    ./rinside_callbacks0
+    echo "DONE RInside standard examples"
+    cd -
+}
+
+runConvolveBennchmark
+runFastLM
+runFunctionCallback
+runRcppInline
+runSugarPerformance
+runRInsideExamples

--- a/internal/scripts/runRcppArmadilloDepends.r
+++ b/internal/scripts/runRcppArmadilloDepends.r
@@ -1,0 +1,35 @@
+#!/usr/bin/r
+
+cat("Started at ", format(Sys.time()), "\n")
+pkg <- "RcppArmadillo"
+
+setwd("/tmp/RcppDepends")
+
+AP <- available.packages(contrib.url("http://cran.r-project.org"), filter=list())	# available package at CRAN
+rcpparmaset <- sort(unname(AP[unique(c(grep(pkg, as.character(AP[,"Depends"])),
+                                       grep(pkg, as.character(AP[,"LinkingTo"])),
+                                       grep(pkg, as.character(AP[,"Imports"])))),"Package"]))
+print( rcpparmaset )
+
+res <- data.frame(pkg=rcpparmaset, res=NA)
+
+#for (pi in 1:nrow(res)) {
+#lres <- mclapply(1:nrow(res), mc.cores = 4, FUN=function(pi) {
+lres <- lapply(1:nrow(res), FUN=function(pi) {
+    p <- rcpparmaset[pi]
+    i <- which(AP[,"Package"]==p)
+    pkg <- paste(AP[i,"Package"], "_", AP[i,"Version"], ".tar.gz", sep="")
+    pathpkg <- paste(AP[i,"Repository"], "/", pkg, sep="")
+    #print(pathpkg)
+    if (!file.exists(pkg)) download.file(pathpkg, pkg, quiet=TRUE)
+    rc <- system(paste("R CMD check --no-manual --no-vignettes ", pkg, " > ", pkg, ".log", sep=""))
+    res[pi, "res"] <- rc
+    cat(rc, ":", pkg, "\n")
+    res[pi, ]
+})
+
+res <- do.call(rbind, lres)
+print(res)
+write.table(res, file=paste("result-", strftime(Sys.time(), "%Y%m%d-%H%M%S"), ".txt", sep=""), sep=",")
+save(res, file=paste("result-", strftime(Sys.time(), "%Y%m%d-%H%M%S"), ".RData", sep=""))
+cat("Ended at ", format(Sys.time()), "\n")

--- a/internal/scripts/runRcppDepends.r
+++ b/internal/scripts/runRcppDepends.r
@@ -1,0 +1,55 @@
+#!/usr/bin/r
+
+cat("Started at ", format(Sys.time()), "\n")
+#library(parallel)
+
+## use a test-local directory, install Rcpp, RcppArmadillo, ... there
+## this will work for sub-shells such as the ones started by system() below
+Sys.setenv("R_LIBS_USER"="/tmp/RcppDepends/lib")
+
+## for the borked src/Makevars of ExactNumCI
+Sys.setenv("BOOSTLIB"="/usr/include")
+
+setwd("/tmp/RcppDepends")
+
+AP <- available.packages(contrib.url("http://cran.r-project.org"),filter=list())	# available package at CRAN
+rcppset <- sort(unname(AP[unique(c(grep("Rcpp", as.character(AP[,"Depends"])),
+                                   grep("Rcpp", as.character(AP[,"LinkingTo"])),
+                                   grep("Rcpp", as.character(AP[,"Imports"])))),"Package"]))
+#if (grep("transnet", rcppset)) {        ## not really an Rcpp user
+#    rcppset <- rcppset[ ! grepl("transnet", rcppset) ]
+#}
+if (grep("BioGeoBEARS", rcppset)) {     ## indirect match, no need to test
+    rcppset <- rcppset[ ! grepl("BioGeoBEARS", rcppset) ]
+}
+if (grep("quadrupen", rcppset)) {       ## takes hours, skipping
+    rcppset <- rcppset[ ! grepl("quadrupen", rcppset) ]
+}
+if (grep("roxygen2", rcppset)) {       ## seems to hang for reasons that are unclear
+    rcppset <- rcppset[ ! grepl("roxygen2", rcppset) ]
+}
+
+print( rcppset )
+
+res <- data.frame(pkg=rcppset, res=NA)
+
+#for (pi in 1:nrow(res)) {
+#lres <- mclapply(1:nrow(res), mc.cores = 4, FUN=function(pi) {
+lres <- lapply(1:nrow(res), FUN=function(pi) {
+    p <- rcppset[pi]
+    i <- which(AP[,"Package"]==p)
+    pkg <- paste(AP[i,"Package"], "_", AP[i,"Version"], ".tar.gz", sep="")
+    pathpkg <- paste(AP[i,"Repository"], "/", pkg, sep="")
+    #print(pathpkg)
+    if (!file.exists(pkg)) download.file(pathpkg, pkg, quiet=TRUE)
+    rc <- system(paste("R CMD check --no-manual --no-vignettes ", pkg, " > ", pkg, ".log", sep=""))
+    res[pi, "res"] <- rc
+    cat(rc, ":", pkg, "\n")
+    res[pi, ]
+})
+
+res <- do.call(rbind, lres)
+print(res)
+write.table(res, file=paste("result-", strftime(Sys.time(), "%Y%m%d-%H%M%S"), ".txt", sep=""), sep=",")
+save(res, file=paste("result-", strftime(Sys.time(), "%Y%m%d-%H%M%S"), ".RData", sep=""))
+cat("Ended at ", format(Sys.time()), "\n")

--- a/internal/scripts/stats.R
+++ b/internal/scripts/stats.R
@@ -1,0 +1,252 @@
+
+
+cook <- function( 
+	dist = "norm", 
+	params = list( 
+		mu = list( type = "double", default = "0.0" ),
+		sigma = list( type = "double", default = "1.0" ) 
+	), 
+	input = c("double", "integer"), 
+	output = sprintf("Rcpp/inst/include/Rcpp/stats/%s.h", dist)
+	){
+
+	input <- match.arg( input )	
+	
+	udist <- dist
+	substring( udist, 1, 1 ) <- toupper( substring( udist, 1, 1 ) )
+	
+	param_def  <- paste( sapply(params, "[[", "type"), " ", names(params), "; ", sep = "" )
+	param_def  <- paste( param_def, collapse = "" )
+
+	param_decl <- paste( sapply(params, "[[", "type"), " ", names(params), "_" , sep = "" )
+	for( i in seq_along(params) ){
+		if( "default" %in% names(params[[i]]) ){
+			param_decl[i] <- paste( param_decl[i], " = ", params[[i]][["default"]], sep = "" )
+		}
+	}
+	param_decl <- paste( param_decl, collapse = ", " )
+	
+	param_init <- paste( names(params), "(", names(params), "_)", sep = "" )
+	param_init <- paste( param_init, collapse = ", ")
+	
+	param_list  <- paste( names(params), collapse = ", " )
+	param_ulist <- paste( paste( names(params), "_", sep = "" ),  collapse = ", " )
+	
+	
+code <- '
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+//
+// auto generated file (from script/stats.R) 
+//
+// __DIST__.h: Rcpp R/C++ interface class library -- 
+//
+// Copyright (C) 2010 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__stats____DIST___h
+#define Rcpp__stats____DIST___h
+
+namespace Rcpp {
+namespace stats {
+
+	template <bool NA, typename T>
+	class D__UDIST__ : public Rcpp::VectorBase< REALSXP, NA, D__UDIST__<NA,T> >{
+	public:
+		typedef typename Rcpp::VectorBase<REALSXP,NA,T> VEC_TYPE;
+	
+		D__UDIST__( const VEC_TYPE& vec_, __PARAM_DECL__ , bool log_ = false ) : 
+			vec(vec_), __PARAM_INIT__ , log(log_) {}
+		
+		inline double operator[]( int i) const {
+			return ::d__DIST__( vec[i], __PARAM_LIST__ , log );
+		}
+		
+		inline int size() const { return vec.size(); }
+		
+	private:
+		const VEC_TYPE& vec;
+		__PARAM_DEF__
+		int log;
+	
+	};
+
+	template <bool NA, typename T>
+	class P__UDIST__ : public Rcpp::VectorBase< REALSXP, NA, P__UDIST__<NA,T> >{
+	public:
+		typedef typename Rcpp::VectorBase<REALSXP,NA,T> VEC_TYPE;
+	
+		P__UDIST__( const VEC_TYPE& vec_, __PARAM_DECL__ ,
+			   bool lower_tail = true, bool log_ = false ) : 
+			vec(vec_), __PARAM_INIT__ , lower(lower_tail), log(log_) {}
+		
+		inline double operator[]( int i) const {
+			return ::p__DIST__( vec[i], __PARAM_LIST__, lower, log );
+		}
+		
+		inline int size() const { return vec.size(); }
+		
+	private:
+		const VEC_TYPE& vec;
+		__PARAM_DEF__
+		int lower, log;
+	
+	};
+
+	template <bool NA, typename T>
+	class Q__UDIST__ : public Rcpp::VectorBase< REALSXP, NA, Q__UDIST__<NA,T> >{
+	public:
+		typedef typename Rcpp::VectorBase<REALSXP,NA,T> VEC_TYPE;
+	
+		Q__UDIST__( const VEC_TYPE& vec_, __PARAM_DECL__ ,
+			   bool lower_tail = true, bool log_ = false ) : 
+			vec(vec_), __PARAM_INIT__, lower(lower_tail), log(log_) {}
+		
+		inline double operator[]( int i) const {
+			return ::q__DIST__( vec[i], __PARAM_LIST__, lower, log );
+		}
+		
+		inline int size() const { return vec.size(); }
+		
+	private:
+		const VEC_TYPE& vec;
+		__PARAM_DEF__
+		int lower, log;
+	
+	};
+	
+} // stats
+
+template <bool NA, typename T>
+inline stats::D__UDIST__<NA,T> d__DIST__( const VectorBase<REALSXP,NA,T>& x, __PARAM_DECL__, bool log = false ) {
+	return stats::D__UDIST__<NA,T>( x, __PARAM_ULIST__, log ); 
+}
+
+template <bool NA, typename T>
+inline stats::P__UDIST__<NA,T> p__DIST__( const VectorBase<REALSXP,NA,T>& x, __PARAM_DECL__, bool lower = true, bool log = false ) {
+	return stats::P__UDIST__<NA,T>( x, __PARAM_ULIST__, lower, log ); 
+}
+
+template <bool NA, typename T>
+inline stats::Q__UDIST__<NA,T> q__DIST__( const VectorBase<REALSXP,NA,T>& x, __PARAM_DECL__, bool lower = true, bool log = false ) {
+	return stats::Q__UDIST__<NA,T>( x, __PARAM_ULIST__, lower, log ); 
+}
+	
+} // Rcpp
+
+#endif
+'
+code <- gsub( "__DIST__" , dist, code, fixed = TRUE )
+code <- gsub( "__UDIST__", udist, code, fixed = TRUE )
+code <- gsub( "__PARAM_INIT__", param_init, code, fixed = TRUE )
+code <- gsub( "__PARAM_LIST__", param_list, code, fixed = TRUE )
+code <- gsub( "__PARAM_ULIST__", param_ulist, code, fixed = TRUE )
+code <- gsub( "__PARAM_DECL__", param_decl, code, fixed = TRUE )
+code <- gsub( "__PARAM_DEF__", param_def, code, fixed = TRUE )
+
+writeLines( code, output )
+
+}
+
+# cook( "unif", params = list( 
+# 	"min" = list( type = "double", default = "0.0" ), 
+# 	"max" = list( type = "double", default = "1.0" )
+# 	) )
+#                                   
+# cook( "gamma", params = list( 
+# 	"shape" = list( type = "double" ), 
+# 	"scale" = list( type = "double", default = "1.0" )
+# 	) )
+# 
+# cook( "chisq", params = list( 
+# 	"df" = list( type = "double" ) 
+# 	) )
+#
+# cook( "lnorm", params = list( 
+#	"meanlog" = list( type = "double", default = "0.0" ), 
+#	"sdlog" = list( type = "double", default = "1.0" )
+#	) )
+# 
+# cook( "weibull", params = list(
+# 		"shape" = list( type = "double" ), 
+# 		"scale" = list( type = "double", default = "1.0" )
+#  	)  )
+# 
+# cook( "logis", params = list(
+# 		"location" = list( type = "double", default = "0.0" ), 
+# 		"scale" = list( type = "double", default = "1.0" )
+#  	)  )
+# 
+# cook( "f", params = list(
+# 	"df1" = list( type = "double" ), 
+# 	"df2" = list( type = "double" )
+#  	)  )
+#
+
+# # manual editing needed so that the dexp, qexp, etc ...
+# # are parameterized by shape instead of rate
+# cook( "exp", params = list( 
+# 	"rate" = list( type = "double", default = "1.0" )
+# ) )
+# 
+
+# cook( "cauchy", params = list( 
+# 	"location" = list( type = "double", default = "0.0" ), 
+# 	"scale" = list( type = "double", default = "1.0" )
+# ) )
+
+# cook( "geom", params = list( 
+# 	prob = list( type = "double" ) 
+# 	) )
+
+# cook( "hyper", params = list( 
+# 	mm = list( type = "double" ), 
+# 	nn = list( type = "double" ),
+# 	kk = list( type = "double" )
+# 	) )
+
+# cook( "nt", params = list(
+# 	"df" = list( type = "double" ), 
+# 	"ncp" = list( type = "double" )
+# ) )
+
+# cook( "nchisq", params = list(
+# 	"df" = list( type = "double" ), 
+# 	"ncp" = list( type = "double" )                  
+# ) )
+ 
+# cook( "nbeta", params = list( 
+# 	"shape1" = list( type = "double" ), 
+# 	"shape2" = list( type = "double" ), 
+# 	"ncp" = list( type = "double" ) 
+# ) )
+
+# cook( "nf", params = list(
+# 	"df1" = list( type = "double" ), 
+# 	"df2" = list( type = "double" ), 
+# 	"ncp" = list( type = "double" )
+#  	)  )
+
+# cook( "nbinom", params = list(
+# 	"size" = list( type = "int" ),
+# 	"prob" = list( type = "double" )
+#  	)  )
+# 
+# cook( "nbinom_mu", params = list(
+# 	"size" = list( type = "int" ),
+# 	"mu"   = list( type = "double" )
+#  	)  )
+


### PR DESCRIPTION
This PR brings the `rcpp-scripts` repository into `Rcpp`.

IMO it's preferable to keep Rcpp and its tools in one place; otherwise it's easy to 'lose' them or let them get out of sync.

@eddelbuettel, if you agree with bringing `rcpp-scripts` would you mind merging this? Otherwise feel free to close the PR.