### PR TITLE
initialize underlying SEXP when construct String from char*/std::string

### DIFF
--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -108,6 +108,7 @@ namespace Rcpp {
 
         /** from a std::string */
         String( const std::string& s) : buffer(s), valid(false), buffer_ready(true), enc(CE_NATIVE) {
+            data = R_NilValue ;
             RCPP_STRING_DEBUG( "String(const std::string& )" ) ;
         }
 
@@ -118,6 +119,7 @@ namespace Rcpp {
 
         /** from a const char* */
         String( const char* s) : buffer(s), valid(false), buffer_ready(true), enc(CE_NATIVE){
+            data = R_NilValue ;
             RCPP_STRING_DEBUG( "String(const char*)" ) ;
         }
 

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -47,6 +47,13 @@ CharacterVector test_sapply_string( CharacterVector text, CharacterVector old , 
 }
 
 // [[Rcpp::export]]
+String test_ctor(String x) {
+    String test = "test";
+    test = x;
+    return test;
+}
+
+// [[Rcpp::export]]
 List test_compare_Strings( String aa, String bb ){
     return List::create(
         _["a  < b" ] = aa < bb,

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -19,7 +19,6 @@
 # along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
 .runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
-
 if (.runThisTest) {
 
     .setUp <- Rcpp:::unitTestSetup("String.cpp")
@@ -48,6 +47,11 @@ if (.runThisTest) {
             "a == a" = TRUE
             )
         checkEquals( res, target )
+    }
+
+    test.String.ctor <- function() {
+        res <- test_ctor("abc")
+        checkIdentical(res, "abc")
     }
 
     test.push.front <- function() {


### PR DESCRIPTION
This should fix cccp bugs.

String class should be rewritten using Storage meta class.