### PR TITLE
add 'updateChangeLog' utility function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2015-07-21  Kevin Ushey  <kevinushey@gmail.com>
 
+        * R/tools.R: add 'updateChangeLog()' utility function
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: don't use 'CDDDR'
 
 2015-07-20  Dirk Eddelbuettel  <edd@debian.org>

--- a/R/tools.R
+++ b/R/tools.R
@@ -48,3 +48,55 @@ asBuildPath <- function(path) {
     
     return(path)
 }
+
+updateChangeLog <- function(dir = getwd(), text = "") {
+    
+    clPath <- file.path(dir, "ChangeLog")
+    if (is.null(clPath))
+        return()
+    
+    if (!file.exists(clPath))
+        file.create(clPath)
+    
+    on.exit(file.edit(clPath))
+    
+    git <- Sys.which("git")
+    stopifnot(git != "")
+    
+    gitOutput <- system("git status --porcelain", intern = TRUE)
+    if (!length(gitOutput))
+        return()
+    
+    changedFiles <- sort(substr(gitOutput, 4, nchar(gitOutput)))
+    
+    userName <- getOption("devtools.name", default = Sys.getenv("USER"))
+    descOpt <- getOption("devtools.desc")
+    if (length(descOpt)) {
+        maintainer <- descOpt$Maintainer
+        if (length(maintainer))
+            mail <- sub(".*<\\s*(.*)\\s*>", "<\\1>", maintainer, perl = TRUE)
+    } else {
+        mail <- Sys.getenv("MAIL")
+    }
+    
+    date <- as.character(Sys.Date())
+    
+    header <- paste(date, userName, mail, sep = "  ")
+    body <- if (length(changedFiles)) {
+        paste(
+            sep = "", collapse = "\n",
+            "        * ", changedFiles, ": ", text
+        )
+    }
+    
+    all <- paste(header, "", body, sep = "\n")
+    
+    contents <- if (file.exists(clPath))
+        paste(readLines(clPath), collapse = "\n")
+    
+    amended <- paste(all, "", contents, sep = "\n")
+    amended <- sub("\\s*$", "", amended, perl = TRUE)
+    
+    cat(amended, file = clPath, sep = "\n")
+    
+}


### PR DESCRIPTION
This PR adds an (unexported) function to Rcpp, `updateChangeLog()`, which can be used to take the set of modified files (based on a `git status --porcelain` call) and insert a `ChangeLog` skeleton.

Primarily intended for those of us who might be working on Rcpp without Emacs at a particular point in time...

The user name field is either pulled from a devtools option if it exists, or (as a default) uses `Sys.getenv("USER")`. A similar scheme is used for email (falling back to `Sys.getenv("MAIL")`).