### PR TITLE
-pedantic does not like that (`R_xlen_t` vs `size_t)

### DIFF
--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -110,7 +110,7 @@ namespace Rcpp{
         }
 
         operator SEXP() const {
-            R_xlen_t n = data.size();
+            size_t n = data.size();
             NumericVector out(n);
             CharacterVector names(n);
             for (size_t i=0; i<n; i++) {


### PR DESCRIPTION
`data` is a `std::vector` anyway, so I don't see the point of using `R_xlen_t`.