### PR TITLE
Allow assignment of size 1 with Subsetter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-09-01  Florian Plaza Onate <florian.plaza@jouy.inra.fr>
+        * inst/include/Rcpp/vector/Subsetter.h: Allow logical subsets to be
+       	assigned to a vector of size 1 
+		(pull request #349, discussed in issue #345)
+        * inst/unitTests/cpp/Subset.cpp: Add unit test for above
+        * inst/unitTests/runit.subset.R: Ditto
+
 2015-08-31  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll Version and Date

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2015-09-01  Florian Plaza Onate <florian.plaza@jouy.inra.fr>
         * inst/include/Rcpp/vector/Subsetter.h: Allow logical subsets to be
-       	assigned to a vector of size 1 
-		(pull request #349, discussed in issue #345)
+        assigned to a vector of size 1 
+        (pull request #349, discussed in issue #345)
         * inst/unitTests/cpp/Subset.cpp: Add unit test for above
         * inst/unitTests/runit.subset.R: Ditto
 

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -52,9 +52,9 @@ public:
     template <int OtherRTYPE, template <class> class OtherStoragePolicy>
     SubsetProxy& operator=(const Vector<OtherRTYPE, OtherStoragePolicy>& other) {
         int n = other.size();
-        if (indices_n != n) stop("index error");
+
         if (n == 1) {
-            for (int i=0; i < n; ++i) {
+            for (int i=0; i < indices_n; ++i) {
                 lhs[ indices[i] ] = other[0];
             }
         } else if (n == indices_n) {
@@ -65,7 +65,7 @@ public:
             stop("index error");
         }
         return *this;
-    }
+    }  
 
     // Enable e.g. x[y] = 1;
     // TODO: std::enable_if<primitive> with C++11

--- a/inst/unitTests/cpp/Subset.cpp
+++ b/inst/unitTests/cpp/Subset.cpp
@@ -92,3 +92,13 @@ NumericVector subset_assign_subset5(NumericVector x) {
     return y;
 }
 
+// [[Rcpp::export]]
+NumericVector subset_assign_vector_size_1(NumericVector x, int i) {
+    NumericVector y(1);
+    y[0]=i;
+
+    x[x < 4] = y;
+
+    return x;
+}
+

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -84,6 +84,8 @@ if (.runThisTest) {
         checkIdentical(subset_assign_subset4(seq(2, 4, 0.2)), c(2L,2L,2L,2L,2L,3L,0L,0L,0L,0L,0L))
         
         checkException(subset_assign_subset5(1:6), msg = "index error")
+
+        checkIdentical(subset_assign_vector_size_1(1:6,7), c(7,7,7,4,5,6))
     }
 
 }


### PR DESCRIPTION
R allows singleton vectors to be assigned to vectors subsets with more than one element.

Here is an example:
```R
> v1=c(1,2,3)
> v2=c(4)
> v1[v1<4]=v2
> v1
[1] 4 4 4
```

This feature is currently not available in Rcpp as previously discussed in #345 

Code:
```c++
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
IntegerVector test()
{
  IntegerVector v1 = IntegerVector::create(1,2,3);
  IntegerVector v2 = IntegerVector::create(4);
  v1[v1<4] = v2;
  
  return v1;
}

/*** R
test()
*/
```

Result:
```
test()
Error in eval(expr, envir, enclos) : index error
```

This PR fixes this issue by returning the same result as R:
```
test()
[1] 4 4 4
```
