### PR TITLE
Enable e.g. 'a[b > 3] = b[b > 3]'

### DIFF
--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -100,8 +100,24 @@ public:
     template <int RTYPE_OTHER, template <class> class StoragePolicyOther,int RHS_RTYPE_OTHER, bool RHS_NA_OTHER, typename RHS_T_OTHER>
     SubsetProxy& operator=(const SubsetProxy<RTYPE_OTHER, StoragePolicyOther, RHS_RTYPE_OTHER, RHS_NA_OTHER, RHS_T_OTHER>& other) {
 
-        Vector<RTYPE, StoragePolicyOther> other_vec = other;
+        Vector<RTYPE_OTHER, StoragePolicyOther> other_vec = other;
         *this = other_vec;
+        return *this;
+    }
+
+    SubsetProxy& operator=(const SubsetProxy& other) {
+        if (other.indices_n == 1) {
+            for (int i=0; i < indices_n; ++i) {
+                lhs[ indices[i] ] = other.lhs[other.indices[0]];
+            }
+        }
+        else if (indices_n == other.indices_n) {
+            for (int i=0; i < indices_n; ++i)
+                lhs[ indices[i] ] = other.lhs[other.indices[i]];
+            }
+        else {
+            stop("index error");
+        }
         return *this;
     }
 

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -97,6 +97,14 @@ public:
         return *this;
     }
 
+    template <int RTYPE_OTHER, template <class> class StoragePolicyOther,int RHS_RTYPE_OTHER, bool RHS_NA_OTHER, typename RHS_T_OTHER>
+    SubsetProxy& operator=(const SubsetProxy<RTYPE_OTHER, StoragePolicyOther, RHS_RTYPE_OTHER, RHS_NA_OTHER, RHS_T_OTHER>& other) {
+
+        Vector<RTYPE, StoragePolicyOther> other_vec = other;
+        *this = other_vec;
+        return *this;
+    }
+
     operator Vector<RTYPE, StoragePolicy>() const {
         return get_vec();
     }

--- a/inst/unitTests/cpp/Subset.cpp
+++ b/inst/unitTests/cpp/Subset.cpp
@@ -70,3 +70,25 @@ NumericVector subset_assign_subset2(NumericVector x) {
     y[x <= 3] = x[x > 3];
     return y;
 }
+
+// [[Rcpp::export]]
+NumericVector subset_assign_subset3(NumericVector x) {
+    NumericVector y(x.size());
+    y[x <= 3] = x[3];
+    return y;
+}
+
+// [[Rcpp::export]]
+IntegerVector subset_assign_subset4(NumericVector x) {
+    IntegerVector y(x.size());
+    y[x <= 3] = x[x <= 3];
+    return y;
+}
+
+// [[Rcpp::export]]
+NumericVector subset_assign_subset5(NumericVector x) {
+    NumericVector y(x.size());
+    y[x < 3] = x[x >= 4];
+    return y;
+}
+

--- a/inst/unitTests/cpp/Subset.cpp
+++ b/inst/unitTests/cpp/Subset.cpp
@@ -56,3 +56,17 @@ NumericVector subset_test_assign(NumericVector x) {
 NumericVector subset_test_constref(NumericVector const& x, IntegerVector const& y) {
     return x[y];
 }
+
+// [[Rcpp::export]]
+NumericVector subset_assign_subset(NumericVector x) {
+    NumericVector y(x.size());
+    y[x > 3] = x[x > 3];
+    return y;
+}
+
+// [[Rcpp::export]]
+NumericVector subset_assign_subset2(NumericVector x) {
+    NumericVector y(x.size());
+    y[x <= 3] = x[x > 3];
+    return y;
+}

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -78,7 +78,12 @@ if (.runThisTest) {
         checkIdentical(subset_assign_subset(1:6), c(0,0,0,4,5,6))
         
         checkIdentical(subset_assign_subset2(1:6), c(4,5,6,0,0,0))
+
+        checkIdentical(subset_assign_subset3(1:6), c(4,4,4,0,0,0))
+
+        checkIdentical(subset_assign_subset4(seq(2, 4, 0.2)), c(2L,2L,2L,2L,2L,3L,0L,0L,0L,0L,0L))
         
+        checkException(subset_assign_subset5(1:6), msg = "index error")
     }
 
 }

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -75,6 +75,10 @@ if (.runThisTest) {
         y <- subset_test_int(x, 0L)
         checkIdentical( attr(y, "foo"), "bar" )
         
+        checkIdentical(subset_assign_subset(1:6), c(0,0,0,4,5,6))
+        
+        checkIdentical(subset_assign_subset2(1:6), c(4,5,6,0,0,0))
+        
     }
 
 }


### PR DESCRIPTION
This for #345 .

It is just a combination of code from @kevinushey and @fabian-s .

I think converting to `Vector` is better than defining `length()` and `get()` for `SubsetProxy`.