### PR TITLE
Added operator<<() and print() functions to Vector

### DIFF
--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -210,6 +210,158 @@ inline internal::DimNameProxy colnames(SEXP x) {
     return internal::DimNameProxy(x, 1);
 }
 
+template<template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Matrix<REALSXP, StoragePolicy> & rhs) {
+    typedef Matrix<REALSXP, StoragePolicy> MATRIX;
+
+    std::ios::fmtflags flags = s.flags();
+    s.unsetf(std::ios::floatfield);
+    std::streamsize precision = s.precision();
+
+    const int rows = rhs.rows();
+
+    for (int i = 0; i < rows; ++i) {
+        typename MATRIX::Row row = const_cast<MATRIX &>(rhs).row(i);
+
+        typename MATRIX::Row::iterator j = row.begin();
+        typename MATRIX::Row::iterator jend = row.end();
+
+        if (j != jend) {
+            s << std::setw(precision + 1) << (*j);
+            j++;
+
+            for ( ; j != jend; j++) {
+                s << " " << std::setw(precision + 1) << (*j);
+            }
+        }
+
+        s << std::endl;
+    }
+
+    s.flags(flags);
+    return s;
+}
+
+template<template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Matrix<INTSXP, StoragePolicy> & rhs) {
+    typedef Matrix<INTSXP, StoragePolicy> MATRIX;
+    typedef Vector<INTSXP, StoragePolicy> VECTOR;
+
+    std::ios::fmtflags flags = s.flags();
+
+    s << std::dec;
+
+    int min = std::numeric_limits<int>::max();
+    int max = std::numeric_limits<int>::min();
+
+    typename VECTOR::iterator j = static_cast<VECTOR &>(const_cast<MATRIX &>(rhs)).begin();
+    typename VECTOR::iterator jend = static_cast<VECTOR &>(const_cast<MATRIX &>(rhs)).end();
+
+    for ( ; j != jend; ++j) {
+        if (*j < min) {
+            min = *j;
+        }
+
+        if (*j > max) {
+            max = *j;
+        }
+    }
+
+    int digitsMax = (max >= 0) ? 0 : 1;
+    int digitsMin = (min >= 0) ? 0 : 1;
+
+    while (min != 0)
+    {
+        ++digitsMin;
+        min /= 10;
+    }
+
+    while (max != 0)
+    {
+        ++digitsMax;
+        max /= 10;
+    }
+
+    int digits = std::max(digitsMin, digitsMax);
+
+    const int rows = rhs.rows();
+
+    for (int i = 0; i < rows; ++i) {
+        typename MATRIX::Row row = const_cast<MATRIX &>(rhs).row(i);
+
+        typename MATRIX::Row::iterator j = row.begin();
+        typename MATRIX::Row::iterator jend = row.end();
+
+        if (j != jend) {
+            s << std::setw(digits) << (*j);
+            ++j;
+
+            for ( ; j != jend; ++j) {
+                s << " " << std::setw(digits) << (*j);
+            }
+        }
+
+        s << std::endl;
+    }
+
+    s.flags(flags);
+    return s;
+}
+
+template<template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Matrix<STRSXP, StoragePolicy> & rhs) {
+    typedef Matrix<STRSXP, StoragePolicy> MATRIX;
+
+    const int rows = rhs.rows();
+
+    for (int i = 0; i < rows; ++i) {
+        typename MATRIX::Row row = const_cast<MATRIX &>(rhs).row(i);
+
+        typename MATRIX::Row::iterator j = row.begin();
+        typename MATRIX::Row::iterator jend = row.end();
+
+        if (j != jend) {
+            s << "\"" << (*j) << "\"";
+            j++;
+
+            for ( ; j != jend; j++) {
+                s << " \"" << (*j) << "\"";
+            }
+        }
+
+        s << std::endl;
+    }
+
+    return s;
+}
+
+template<int RTYPE, template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Matrix<RTYPE, StoragePolicy> & rhs) {
+    typedef Matrix<RTYPE, StoragePolicy> MATRIX;
+
+    const int rows = rhs.rows();
+
+    for (int i = 0; i < rows; ++i) {
+        typename MATRIX::Row row = const_cast<MATRIX &>(rhs).row(i);
+
+        typename MATRIX::Row::iterator j = row.begin();
+        typename MATRIX::Row::iterator jend = row.end();
+
+        if (j != jend) {
+            s << (*j);
+            j++;
+
+            for ( ; j != jend; j++) {
+                s << (*j);
+            }
+        }
+
+        s << std::endl;
+    }
+
+    return s;
+}
+
 }
 
 #endif

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -582,15 +582,6 @@ public:
         return -1;
     }
 
-    inline void print(const std::string & comment = "", std::ostream & stream = Rcout) const {
-        if (comment.length() > 0) {
-            stream << comment << std::endl;
-        }
-
-        stream << (*this);
-    }
-
-
 protected:
     inline int* dims() const {
         if( !::Rf_isMatrix(Storage::get__()) ) throw not_a_matrix() ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -582,6 +582,14 @@ public:
         return -1;
     }
 
+    inline void print(const std::string & comment = "", std::ostream & stream = Rcout) const {
+        if (comment.length() > 0) {
+            stream << comment << std::endl;
+        }
+
+        stream << (*this);
+    }
+
 
 protected:
     inline int* dims() const {
@@ -1079,6 +1087,44 @@ public:
 
 
 } ; /* Vector */
+
+template <int RTYPE, template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Vector<RTYPE, StoragePolicy> & rhs) {
+    typedef Vector<RTYPE, StoragePolicy> VECTOR;
+
+    typename VECTOR::iterator i = const_cast<VECTOR &>(rhs).begin();
+    typename VECTOR::iterator iend = const_cast<VECTOR &>(rhs).end();
+
+    if (i != iend) {
+        s << (*i);
+        ++i;
+
+        for ( ; i != iend; ++i) {
+            s << " " << (*i);
+        }
+    }
+
+    return s;
+}
+
+template<template <class> class StoragePolicy >
+inline std::ostream &operator<<(std::ostream & s, const Vector<STRSXP, StoragePolicy> & rhs) {
+    typedef Vector<STRSXP, StoragePolicy> VECTOR;
+
+    typename VECTOR::iterator i = const_cast<VECTOR &>(rhs).begin();
+    typename VECTOR::iterator iend = const_cast<VECTOR &>(rhs).end();
+
+    if (i != iend) {
+        s << "\"" << (*i) << "\"";
+        ++i;
+
+        for ( ; i != iend; ++i) {
+            s << " \"" << (*i) << "\"";
+        }
+    }
+
+    return s;
+}
 
 }
 

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -49,6 +49,7 @@ namespace Rcpp {
 #include <iterator>
 #include <exception>
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <list>

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -793,23 +793,9 @@ String vec_print_numeric(NumericVector v) {
 }
 
 // [[Rcpp::export]]
-String vec_print_numeric_member(NumericVector v) {
-    std::ostringstream buf;
-    v.print("", buf);
-    return buf.str();
-}
-
-// [[Rcpp::export]]
 String vec_print_character(CharacterVector v) {
     std::ostringstream buf;
     buf << v;
-    return buf.str();
-}
-
-// [[Rcpp::export]]
-String vec_print_character_member(CharacterVector v) {
-    std::ostringstream buf;
-    v.print("", buf);
     return buf.str();
 }
 
@@ -819,11 +805,3 @@ String vec_print_integer(IntegerVector v) {
     buf << v;
     return buf.str();
 }
-
-// [[Rcpp::export]]
-String vec_print_integer_member(IntegerVector v) {
-    std::ostringstream buf;
-    v.print("", buf);
-    return buf.str();
-}
-

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -21,6 +21,8 @@
 
 #include <climits>
 #include <Rcpp.h>
+#include <sstream>
+
 using namespace Rcpp ;
 
 inline double square( double x){ return x*x; }
@@ -782,3 +784,46 @@ int noprotect_matrix( Matrix<REALSXP, NoProtectStorage> x){
 int vec_access_with_bounds_checking(const IntegerVector x, int index) {
     return x.at(index);
 }
+
+// [[Rcpp::export]]
+String vec_print_numeric(NumericVector v) {
+    std::ostringstream buf;
+    buf << v;
+    return buf.str();
+}
+
+// [[Rcpp::export]]
+String vec_print_numeric_member(NumericVector v) {
+    std::ostringstream buf;
+    v.print("", buf);
+    return buf.str();
+}
+
+// [[Rcpp::export]]
+String vec_print_character(CharacterVector v) {
+    std::ostringstream buf;
+    buf << v;
+    return buf.str();
+}
+
+// [[Rcpp::export]]
+String vec_print_character_member(CharacterVector v) {
+    std::ostringstream buf;
+    v.print("", buf);
+    return buf.str();
+}
+
+// [[Rcpp::export]]
+String vec_print_integer(IntegerVector v) {
+    std::ostringstream buf;
+    buf << v;
+    return buf.str();
+}
+
+// [[Rcpp::export]]
+String vec_print_integer_member(IntegerVector v) {
+    std::ostringstream buf;
+    v.print("", buf);
+    return buf.str();
+}
+

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -697,33 +697,15 @@ if (.runThisTest) {
         checkEquals(s, "1.1 2.2 3.3 4.4")
     }
 
-    test.NumericVector.print.member <- function() {
-        v <- c(1.1, 2.2, 3.3, 4.4)
-        s <- vec_print_numeric_member(v)
-        checkEquals(s, "1.1 2.2 3.3 4.4")
-    }
-
     test.IntegerVector.print <- function() {
         v <- c(1, 2, 3, 4)
         s <-vec_print_integer(v)
         checkEquals(s, "1 2 3 4")
     }
 
-    test.IntegerVector.print.member <- function() {
-        v <- c(1, 2, 3, 4)
-        s <- vec_print_integer_member(v)
-        checkEquals(s, "1 2 3 4")
-    }
-
     test.CharacterVector.print <- function() {
         v <- c("a", "b", "c", "d")
         s <- vec_print_character(v)
-        checkEquals(s, '"a" "b" "c" "d"')
-    }
-
-    test.CharacterVector.print.member <- function() {
-        v <- c("a", "b", "c", "d")
-        s <- vec_print_character_member(v)
         checkEquals(s, '"a" "b" "c" "d"')
     }
 }

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -690,5 +690,41 @@ if (.runThisTest) {
         checkException(vec_access_with_bounds_checking(x, 5) , msg = "index out of bounds not detected" )
         checkException(vec_access_with_bounds_checking(x, -1) , msg = "index out of bounds not detected" )
     }
+
+    test.NumericVector.print <- function() {
+        v <- c(1.1, 2.2, 3.3, 4.4)
+        s <- vec_print_numeric(v)
+        checkEquals(s, "1.1 2.2 3.3 4.4")
+    }
+
+    test.NumericVector.print.member <- function() {
+        v <- c(1.1, 2.2, 3.3, 4.4)
+        s <- vec_print_numeric_member(v)
+        checkEquals(s, "1.1 2.2 3.3 4.4")
+    }
+
+    test.IntegerVector.print <- function() {
+        v <- c(1, 2, 3, 4)
+        s <-vec_print_integer(v)
+        checkEquals(s, "1 2 3 4")
+    }
+
+    test.IntegerVector.print.member <- function() {
+        v <- c(1, 2, 3, 4)
+        s <- vec_print_integer_member(v)
+        checkEquals(s, "1 2 3 4")
+    }
+
+    test.CharacterVector.print <- function() {
+        v <- c("a", "b", "c", "d")
+        s <- vec_print_character(v)
+        checkEquals(s, '"a" "b" "c" "d"')
+    }
+
+    test.CharacterVector.print.member <- function() {
+        v <- c("a", "b", "c", "d")
+        s <- vec_print_character_member(v)
+        checkEquals(s, '"a" "b" "c" "d"')
+    }
 }
 


### PR DESCRIPTION
For issue #239, added `operator<<()` functions for the `Rcpp::Vector` class.  These print a space delimited list of items.  In the case of a `CharacterVector`, each item is enclosed in `"`.

Additionally added a `Vector::print(const std::string comment, std::ostream &stream)` function at Dirk's behest.  This function prints as follows:

```
My Comment
1 2 3 4 5 6
```

Unit tests are included and pass.