### PR TITLE
String and (const_)string_proxy are now comparable

### DIFF
--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -417,6 +417,22 @@ namespace Rcpp {
         bool operator!=( const Rcpp::String& other) const {
             return get_sexp() != other.get_sexp() ;
         }
+        
+        bool operator==( const StringProxy& other) const {
+            return get_sexp() == other.get();
+        }
+        
+        bool operator!=( const StringProxy& other) const {
+            return get_sexp() != other.get();
+        }
+        
+        bool operator==( const const_StringProxy& other) const {
+            return get_sexp() == other.get();
+        }
+        
+        bool operator!=( const const_StringProxy& other) const {
+            return get_sexp() != other.get();
+        }
 
         bool operator>( const Rcpp::String& other ) const {
             return strcmp( get_cstring(), other.get_cstring() ) > 0;
@@ -501,7 +517,22 @@ namespace Rcpp {
         SET_STRING_ELT( res, 0, data ) ;
         return res ;
     }
-
+    
+    inline bool operator==(const String::StringProxy& lhs, const String& rhs) {
+        return rhs == lhs;
+    }
+    
+    inline bool operator!=(const String::StringProxy& lhs, const String& rhs) {
+        return rhs != lhs;
+    }
+    
+    inline bool operator==(const String::const_StringProxy& lhs, const String& rhs) {
+        return rhs == lhs;
+    }
+    
+    inline bool operator!=(const String::const_StringProxy& lhs, const String& rhs) {
+        return rhs != lhs;
+    }
 
 } // Rcpp
 

--- a/inst/unitTests/cpp/String.cpp
+++ b/inst/unitTests/cpp/String.cpp
@@ -64,6 +64,26 @@ List test_compare_Strings( String aa, String bb ){
 }
 
 // [[Rcpp::export]]
+List test_compare_String_string_proxy( String aa, CharacterVector bb ){
+    return List::create(
+        _["a == b"]  = aa == bb[0],
+        _["a != b"]  = aa != bb[0],
+        _["b == a"]  = bb[0] == aa,
+        _["b != a"]  = bb[0] != aa
+        ) ;
+}
+
+// [[Rcpp::export]]
+List test_compare_String_const_string_proxy( String aa, const CharacterVector bb ){
+    return List::create(
+        _["a == b"]  = aa == bb[0],
+        _["a != b"]  = aa != bb[0],
+        _["b == a"]  = bb[0] == aa,
+        _["b != a"]  = bb[0] != aa
+        ) ;
+}
+
+// [[Rcpp::export]]
 String test_push_front(String x) {
     x.push_front("abc");
     return x;

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -48,6 +48,30 @@ if (.runThisTest) {
             )
         checkEquals( res, target )
     }
+    
+    test.compare.String.string_proxy <- function(){
+        v <- c("aab")
+        res <- test_compare_String_string_proxy( "aaa", v )
+        target <- list( 
+            "a == b" = FALSE, 
+            "a != b" = TRUE,  
+            "b == a" = FALSE,
+            "b != a" = TRUE
+            )
+        checkEquals( res, target )
+    }
+    
+    test.compare.String.const_string_proxy <- function(){
+        v <- c("aab")
+        res <- test_compare_String_const_string_proxy( "aaa", v )
+        target <- list( 
+            "a == b" = FALSE, 
+            "a != b" = TRUE,  
+            "b == a" = FALSE,
+            "b != a" = TRUE
+            )
+        checkEquals( res, target )
+    }
 
     test.String.ctor <- function() {
         res <- test_ctor("abc")


### PR DESCRIPTION
I had an open PR for this that got auto-closed when I reorganized my repo.  This is a feature requested in the discussion of #191.

In the previous PR discussion @thirdwing mentioned that due to #251 we ought not to implement `>, <, >=, <=` operators so they are not present.

Unit tests are present and pass.

Sorry for the confusion with the multiple PRs.