### PR TITLE
rework Rcpp try-catch macros for new toolchain

### DIFF
--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -27,32 +27,30 @@
 #define RCPP_GET_CLASS(x) Rf_getAttrib(x, R_ClassSymbol)
 
 #ifndef BEGIN_RCPP
-#define BEGIN_RCPP                                                                               \
-    int rcpp_output_type = 0 ;                                                                   \
-    SEXP rcpp_output_condition = R_NilValue ;                                                    \
+#define BEGIN_RCPP                                                             \
+    int rcpp_output_type = 0 ;                                                 \
+    char rcpp_output_message[1024] = "c++ exception (unknown reason)";         \
     try {
 #endif
 
 #ifndef VOID_END_RCPP
-#define VOID_END_RCPP                                                                            \
-    }                                                                                            \
-    catch( Rcpp::internal::InterruptedException &__ex__) {                                       \
-        rcpp_output_type = 1 ;                                                                   \
-    }                                                                                            \
-    catch( std::exception& __ex__ ){                                                             \
-       rcpp_output_type = 2 ;                                                                    \
-       rcpp_output_condition = PROTECT(exception_to_r_condition(__ex__)) ;                       \
-    } catch( ... ){                                                                              \
-       rcpp_output_type = 2 ;                                                                    \
-       rcpp_output_condition = PROTECT(string_to_try_error("c++ exception (unknown reason)")) ;  \
-    }                                                                                            \
-    if( rcpp_output_type == 1 ){                                                                 \
-       Rf_onintr() ;                                                                             \
-    }                                                                                            \
-    if( rcpp_output_type == 2 ){                                                                 \
-       SEXP stop_sym  = Rf_install( "stop" ) ;                                                   \
-       SEXP expr = PROTECT( Rf_lang2( stop_sym , rcpp_output_condition ) ) ;                     \
-       Rf_eval( expr, R_GlobalEnv ) ;                                                            \
+#define VOID_END_RCPP                                                          \
+    }                                                                          \
+    catch(Rcpp::internal::InterruptedException &__ex__) {                      \
+        rcpp_output_type = 1 ;                                                 \
+    }                                                                          \
+    catch( std::exception& __ex__ ){                                           \
+        rcpp_output_type = 2 ;                                                 \
+        const char* msg = __ex__.what();                                       \
+        strncpy(rcpp_output_message, msg, sizeof(rcpp_output_message) - 1);    \
+    } catch( ... ){                                                            \
+       rcpp_output_type = 2 ;                                                  \
+    }                                                                          \
+    if( rcpp_output_type == 1 ){                                               \
+       Rf_onintr() ;                                                           \
+    }                                                                          \
+    if( rcpp_output_type == 2 ){                                               \
+       Rf_error(rcpp_output_message);                                          \
     }
 #endif
 


### PR DESCRIPTION
This PR is yet another iteration around the 'call `Rf_error()` safely and don't blow up windows' theme. The goal here is to fix unit tests where modules throwing exceptions cause the R session to crash (after a failed `longjmp`):

https://github.com/RcppCore/Rcpp/blob/7d556daf295e279edea7990e7b7c19f58e1f9d8f/inst/unitTests/runit.Module.R#L69

https://github.com/RcppCore/Rcpp/blob/7d556daf295e279edea7990e7b7c19f58e1f9d8f/inst/unitTests/runit.Module.R#L80

The main idea here is that, within our `BEGIN_RCPP` and `END_RCPP` blocks, we:

1) Avoid touching anything related to R within a `catch` block (e.g. potential allocation, GC),
2) Ensure only plain C objects are on the stack (no destructors),
3) Call `Rf_error()` directly rather than through `stop()`.

This PR isn't quite ready (more testing needed) but I'd appreciate any thoughts on what we think of this approach.