### PR TITLE
Added explicit (const_)string_proxy/SEXP comparisons to resolve ambiguity

### DIFF
--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -110,6 +110,13 @@ namespace internal{
 			return strcmp( begin(), other.begin() ) != 0 ;
 		}
 
+                bool operator==( SEXP other ) const {
+                    return get() == other;
+                }
+
+                bool operator!=( SEXP other ) const {
+                    return get() != other;
+                }
 
 		private:
 			static std::string buffer ;

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -192,6 +192,14 @@ namespace internal{
 			return strcmp( begin(), other.begin() ) != 0 ;
 		}
 
+                bool operator==( SEXP other ) const {
+                    return get() == other;
+                }
+
+                bool operator!=( SEXP other ) const {
+                    return get() != other;
+                }
+
 
 		private:
 			static std::string buffer ;


### PR DESCRIPTION
This fixes compile failures in readr, readxl, and rpg