### PR TITLE
fix overflow in MatrixColumn ctor

### DIFF
--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -36,16 +36,16 @@ public:
 
     MatrixColumn( MATRIX& parent, int i ) :
         n(parent.nrow()),
-        start(parent.begin() + i * n ),
-        const_start(const_cast<const MATRIX&>(parent).begin() + i *n)
+        start(parent.begin() + static_cast<R_xlen_t>(i) * n ),
+        const_start(const_cast<const MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n)
     {
         if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
     }
 
     MatrixColumn( const MATRIX& parent, int i ) :
         n(parent.nrow()),
-        start( const_cast<MATRIX&>(parent).begin() + i * n ),
-        const_start(parent.begin() + i *n)
+        start( const_cast<MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n ),
+        const_start(parent.begin() + static_cast<R_xlen_t>(i) * n)
     {
         if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
     }


### PR DESCRIPTION
This is for the error reported in mailing list: https://www.mail-archive.com/rcpp-devel@lists.r-forge.r-project.org/msg08582.html

```c
#include <Rcpp.h>

// [[Rcpp::export]]
Rcpp::IntegerMatrix makeMat(int nrow=18, int ncol=136633572){
  Rcpp::IntegerMatrix mat(nrow, ncol);
  for (int i = 0; i < ncol; ++i) {
    Rcpp::MatrixColumn<INTSXP> col = mat.column(i);
    for (int j = 0; j < nrow; ++j){
      col[j] = 1;
    }
  }
  return mat;
}
/*
> Rcpp::sourceCpp("test.cpp")
> mat <- makeMat()

 *** caught segfault ***
address 0x7f9d542ee088, cause 'memory not mapped'

Traceback:
 1: .Primitive(".Call")(<pointer: 0x7fa1b368b2a0>, nrow, ncol)
 2: makeMat()
*/
```

In `MatrixColumn `'s ctor, even `i` and `n` are both `int`, `i * n` can still cause an overflow, which will lead to a segfault.