### PR TITLE
incorporate @thirdwing's suggestion for sugar ops (closes #392)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/*.o
 src/*.so
 src/*.dll
 .Rhistory
+.RData
 
 ## QtCreator
 Rcpp.pro

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-11-06  Kevin Ushey <kevinushey@gmailcom>
+
+        * inst/include/Rcpp/vector/Subsetter.h: Add sugar math operators
+        * inst/unitTests/runit.subset.R: Unit tests
+        * inst/unitTests/cpp/Subset.cpp: Unit tests
+        * inst/NEWS.Rd: NEWS entry
+
 2015-11-01  Qiang Kou <qkou@umail.iu.edu>
 
         * inst/include/Rcpp/vector/MatrixColumn.h: Fix overflow

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -24,6 +24,8 @@
     \itemize{
       \item Added new Sugar function \code{cummin()}, \code{cummax()},
       \code{cumprod()} (PR \ghpr{389} by Nathan Russell fixing \ghit{388})
+      \item Enabled sugar math operations for subsets; e.g. x[y] + x[z].
+      (PR \ghpr{393}, implementing \ghit{392})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -228,22 +228,23 @@ private:
 
 public:
 
-#define RCPP_GENERATE_SUBSET_PROXY_OPERATOR(__OPERATOR__)                      \
-    template <int RTYPE_OTHER, template <class> class StoragePolicyOther,      \
-              int RHS_RTYPE_OTHER, bool RHS_NA_OTHER, typename RHS_T_OTHER>    \
-    SubsetProxy& operator __OPERATOR__ (                                       \
-        const SubsetProxy<RTYPE_OTHER, StoragePolicyOther, RHS_RTYPE_OTHER,    \
-                          RHS_NA_OTHER, RHS_T_OTHER>& other) {                 \
-        if (other.indices_n == 1) {                                            \
-            for (int i = 0; i < indices_n; ++i)                                \
-                lhs[indices[i]] __OPERATOR__ ## = other.lhs[other.indices[0]]; \
-        } else if (indices_n == other.indices_n) {                             \
-            for (int i = 0; i < indices_n; ++i)                                \
-                lhs[indices[i]] __OPERATOR__ ## = other.lhs[other.indices[i]]; \
-        } else {                                                               \
-            stop("index error");                                               \
-        }                                                                      \
-        return *this;                                                          \
+#define RCPP_GENERATE_SUBSET_PROXY_OPERATOR(__OPERATOR__)                             \
+    template <int RTYPE_OTHER, template <class> class StoragePolicyOther,             \
+              int RHS_RTYPE_OTHER, bool RHS_NA_OTHER, typename RHS_T_OTHER>           \
+    Vector<RTYPE, StoragePolicy> operator __OPERATOR__ (                              \
+        const SubsetProxy<RTYPE_OTHER, StoragePolicyOther, RHS_RTYPE_OTHER,           \
+                          RHS_NA_OTHER, RHS_T_OTHER>& other) {                        \
+        Vector<RTYPE, StoragePolicy> result(indices_n);                               \
+        if (other.indices_n == 1) {                                                   \
+            for (int i = 0; i < indices_n; ++i)                                       \
+                result[i] = lhs[indices[i]] __OPERATOR__ other.lhs[other.indices[0]]; \
+        } else if (indices_n == other.indices_n) {                                    \
+            for (int i = 0; i < indices_n; ++i)                                       \
+                result[i] = lhs[indices[i]] __OPERATOR__ other.lhs[other.indices[i]]; \
+        } else {                                                                      \
+            stop("index error");                                                      \
+        }                                                                             \
+        return result;                                                                \
     }
 
 RCPP_GENERATE_SUBSET_PROXY_OPERATOR(+)

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -226,6 +226,33 @@ private:
     // because of the above, we keep track of the size
     int indices_n;
 
+public:
+
+#define RCPP_GENERATE_SUBSET_PROXY_OPERATOR(__OPERATOR__)                      \
+    template <int RTYPE_OTHER, template <class> class StoragePolicyOther,      \
+              int RHS_RTYPE_OTHER, bool RHS_NA_OTHER, typename RHS_T_OTHER>    \
+    SubsetProxy& operator __OPERATOR__ (                                       \
+        const SubsetProxy<RTYPE_OTHER, StoragePolicyOther, RHS_RTYPE_OTHER,    \
+                          RHS_NA_OTHER, RHS_T_OTHER>& other) {                 \
+        if (other.indices_n == 1) {                                            \
+            for (int i = 0; i < indices_n; ++i)                                \
+                lhs[indices[i]] __OPERATOR__ ## = other.lhs[other.indices[0]]; \
+        } else if (indices_n == other.indices_n) {                             \
+            for (int i = 0; i < indices_n; ++i)                                \
+                lhs[indices[i]] __OPERATOR__ ## = other.lhs[other.indices[i]]; \
+        } else {                                                               \
+            stop("index error");                                               \
+        }                                                                      \
+        return *this;                                                          \
+    }
+
+RCPP_GENERATE_SUBSET_PROXY_OPERATOR(+)
+RCPP_GENERATE_SUBSET_PROXY_OPERATOR(-)
+RCPP_GENERATE_SUBSET_PROXY_OPERATOR(*)
+RCPP_GENERATE_SUBSET_PROXY_OPERATOR(/)
+
+#undef RCPP_GENERATE_SUBSET_PROXY_OPERATOR
+
 };
 
 }

--- a/inst/unitTests/cpp/Subset.cpp
+++ b/inst/unitTests/cpp/Subset.cpp
@@ -102,3 +102,10 @@ NumericVector subset_assign_vector_size_1(NumericVector x, int i) {
     return x;
 }
 
+// [[Rcpp::export]]
+NumericVector subset_sugar_add(NumericVector x, IntegerVector y)
+{
+    NumericVector result = x[y] + x[y];
+    return result;
+}
+

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -86,6 +86,10 @@ if (.runThisTest) {
         checkException(subset_assign_subset5(1:6), msg = "index error")
 
         checkIdentical(subset_assign_vector_size_1(1:6,7), c(7,7,7,4,5,6))
+
+        x <- rnorm(10)
+        y <- sample(10, 5)
+        checkIdentical(subset_sugar_add(x, y - 1L), x[y] + x[y])
     }
 
 }


### PR DESCRIPTION
Enables e.g. `x[y]` + `x[z]`.

Should we add other binary operators to the list? (I just grabbed the four main arithmetic ones)