### PR TITLE
Feature/issue383 -- closes #383

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-11-08  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/vector/Matrix.h (Rcpp): Matrix transpose is now a
+        free function for both INTSXP and REALSXP
+
 2015-11-08  Daniel C. Dillon  <dcdillon@gmail.com>
 
         * inst/include/Rcpp/Nullable.h: No longer prevent assignment of

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-11-11  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/vector/Matrix.h: Further simplification
+
 2015-11-11  Qiang Kou <qkou@umail.iu.edu>
 
         * include/Rcpp/complex.h: operator<< for Rcomplex

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-11-07  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/vector/Matrix.h (Rcpp): Beginnings of a Matrix
+        transpose operator
+
 2015-11-06  Kevin Ushey <kevinushey@gmailcom>
 
         * inst/include/Rcpp/vector/Subsetter.h: Add sugar math operators

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2015-11-10  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/vector/Matrix.h: Added transpose for character
+        matrices as well
+
+        * inst/unitTests/runit.Matrix.R: New unit tests
+        * inst/unitTests/cpp/Matrix.cpp: Ditto
+
 2015-11-08  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/vector/Matrix.h: Matrix transpose is now a free

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
         * inst/include/Rcpp/vector/Matrix.h (Rcpp): Matrix transpose is now a
         free function for both INTSXP and REALSXP
 
+        * inst/unitTests/runit.Matrix.R: New unit tests
+        * inst/unitTests/cpp/Matrix.cpp: Ditto
+
 2015-11-08  Daniel C. Dillon  <dcdillon@gmail.com>
 
         * inst/include/Rcpp/Nullable.h: No longer prevent assignment of

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2015-11-08  Dirk Eddelbuettel  <edd@debian.org>
 
-        * inst/include/Rcpp/vector/Matrix.h (Rcpp): Matrix transpose is now a
-        free function for both INTSXP and REALSXP
+        * inst/include/Rcpp/vector/Matrix.h: Matrix transpose is now a free
+        function for both INTSXP and REALSXP
 
         * inst/unitTests/runit.Matrix.R: New unit tests
         * inst/unitTests/cpp/Matrix.cpp: Ditto
@@ -11,10 +11,11 @@
         * inst/include/Rcpp/Nullable.h: No longer prevent assignment of
         R_NilValue to Nullable<> in function signatures
 
+        * inst/include/Rcpp/vector/Matrix.h: Use showpoint in operator<<()
+
 2015-11-07  Dirk Eddelbuettel  <edd@debian.org>
 
-        * inst/include/Rcpp/vector/Matrix.h (Rcpp): Beginnings of a Matrix
-        transpose operator
+        * inst/include/Rcpp/vector/Matrix.h: Beginnings of a Matrix transpose
 
 2015-11-06  Kevin Ushey <kevinushey@gmailcom>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.1.4
-Date: 2015-11-01
+Version: 0.12.1.5
+Date: 2015-11-08
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
  Qiang Kou, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,6 +15,8 @@
       by Tianqi, fixing \ghit{380})
       \item An overflow in Matrix column indexing was corrected (PR \ghpr{390}
       by Qiang, fixing a bug reported by Allessandro on the list)
+      \item Matrix classes now have a \code{transpose()} function (fixing
+      \ghit{383}) 
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -19,6 +19,8 @@
       \ghit{383}) 
       \item \code{Nullable} types can now be assigned \code{R_NilValue} in
       function signatures. (PR \ghpr{395} by Dan, fixing issue \ghit{394})
+      \item \code{operator<<()} now always shows decimal points (PR \ghpr{396}
+      by Dan) 
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -360,20 +360,20 @@ inline std::ostream &operator<<(std::ostream & s, const Matrix<RTYPE, StoragePol
     return s;
 }
 
-template<template <class> class StoragePolicy>
-Matrix<REALSXP, StoragePolicy> transpose(const Matrix<REALSXP, StoragePolicy> & x) {
-    typedef Matrix<REALSXP, StoragePolicy> MATRIX;
-    typedef Vector<REALSXP, StoragePolicy> VECTOR;
+template<int RTYPE, template <class> class StoragePolicy >
+Matrix<RTYPE, StoragePolicy> tranpose_impl(const Matrix<RTYPE, StoragePolicy> & x) {
+    typedef Matrix<RTYPE, StoragePolicy> MATRIX;
+    typedef Vector<RTYPE, StoragePolicy> VECTOR;
 
     Vector<INTSXP, StoragePolicy> dims = ::Rf_getAttrib(x, R_DimSymbol);
     int nrow = dims[0], ncol = dims[1];
     MATRIX r(Dimension(ncol, nrow)); 	// new Matrix with reversed dimension
-    R_xlen_t len = XLENGTH(x), l_1 = XLENGTH(x)-1;
+    R_xlen_t len = XLENGTH(x), len2 = XLENGTH(x)-1;
 
     // similar approach as in R: fill by in column, "accessing row-wise"
     VECTOR s = VECTOR(r.get__());
     for (R_xlen_t i = 0, j = 0; i < len; i++, j += nrow) {
-        if (j > l_1) j -= l_1;
+        if (j > len2) j -= len2;
         s[i] = x[j];
     }
 
@@ -387,64 +387,21 @@ Matrix<REALSXP, StoragePolicy> transpose(const Matrix<REALSXP, StoragePolicy> & 
         Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
     }
     return r;
+}
+
+template<template <class> class StoragePolicy>
+Matrix<REALSXP, StoragePolicy> transpose(const Matrix<REALSXP, StoragePolicy> & x) {
+    return tranpose_impl<REALSXP, StoragePolicy>(x);
 }
 
 template<template <class> class StoragePolicy>
 Matrix<INTSXP, StoragePolicy> transpose(const Matrix<INTSXP, StoragePolicy> & x) {
-    typedef Matrix<INTSXP, StoragePolicy> MATRIX;
-    typedef Vector<INTSXP, StoragePolicy> VECTOR;
-
-    Vector<INTSXP, StoragePolicy> dims = ::Rf_getAttrib(x, R_DimSymbol);
-    int nrow = dims[0], ncol = dims[1];
-    MATRIX r(Dimension(ncol, nrow)); 	// new Matrix with reversed dimension
-    R_xlen_t len = XLENGTH(x), l_1 = XLENGTH(x)-1;
-
-    // similar approach as in R: fill by in column, "accessing row-wise"
-    VECTOR s = VECTOR(r.get__());
-    for (R_xlen_t i = 0, j = 0; i < len; i++, j += nrow) {
-        if (j > l_1) j -= l_1;
-        s[i] = x[j];
-    }
-
-    // there must be a simpler, more C++-ish way for this ...
-    SEXP dimNames = Rf_getAttrib(x, R_DimNamesSymbol);
-    if (!Rf_isNull(dimNames)) {
-        // do we need dimnamesnames ?
-        Shield<SEXP> newDimNames(Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(newDimNames, 0, VECTOR_ELT(dimNames, 1));
-        SET_VECTOR_ELT(newDimNames, 1, VECTOR_ELT(dimNames, 0));
-        Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
-    }
-    return r;
+    return tranpose_impl<INTSXP, StoragePolicy>(x);
 }
 
 template<template <class> class StoragePolicy>
 Matrix<STRSXP, StoragePolicy> transpose(const Matrix<STRSXP, StoragePolicy> & x) {
-    typedef Matrix<STRSXP, StoragePolicy> MATRIX;
-    typedef Vector<STRSXP, StoragePolicy> VECTOR;
-
-    Vector<INTSXP, StoragePolicy> dims = ::Rf_getAttrib(x, R_DimSymbol);
-    int nrow = dims[0], ncol = dims[1];
-    MATRIX r(Dimension(ncol, nrow)); 	// new Matrix with reversed dimension
-    R_xlen_t len = XLENGTH(x), l_1 = XLENGTH(x)-1;
-
-    // similar approach as in R: fill by in column, "accessing row-wise"
-    VECTOR s = VECTOR(r.get__());
-    for (R_xlen_t i = 0, j = 0; i < len; i++, j += nrow) {
-        if (j > l_1) j -= l_1;
-        s[i] = x[j];
-    }
-
-    // there must be a simpler, more C++-ish way for this ...
-    SEXP dimNames = Rf_getAttrib(x, R_DimNamesSymbol);
-    if (!Rf_isNull(dimNames)) {
-        // do we need dimnamesnames ?
-        Shield<SEXP> newDimNames(Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(newDimNames, 0, VECTOR_ELT(dimNames, 1));
-        SET_VECTOR_ELT(newDimNames, 1, VECTOR_ELT(dimNames, 0));
-        Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
-    }
-    return r;
+    return tranpose_impl<STRSXP, StoragePolicy>(x);
 }
 
 }

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -161,6 +161,36 @@ public:
       return Sub( const_cast<Matrix&>(*this), row_range, Range(0,ncol()-1) ) ;
     }
 
+    Matrix transpose() {
+        typedef Vector<CHARSXP, StoragePolicy> CHARVECTOR;
+        int nrow = VECTOR::dims()[0], ncol = VECTOR::dims()[1];
+        R_xlen_t len = XLENGTH(*this);
+
+        Matrix r(Dimension(ncol, nrow));
+        R_xlen_t i, j, l_1 = len-1;
+
+        // similar approach as in R: fill by in column, "accessing row-wise"
+        VECTOR s = VECTOR(r.get__());
+        for (i = 0, j = 0; i < len; i++, j += nrow) {
+            if (j > l_1) j -= l_1;
+            s[i] = (*this)[j];
+        }
+
+        Rf_copyMostAttrib((*this), r);
+
+        // there must be a simpler, more C++-ish way for this ...
+        SEXP rnames = internal::DimNameProxy((*this), 0);
+        SEXP cnames = internal::DimNameProxy((*this), 1);
+        SEXP dimnames;
+        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(dimnames, 0, cnames);
+        SET_VECTOR_ELT(dimnames, 1, rnames);
+        // do we need dimnamesnames ?
+        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
+        UNPROTECT(1); /* dimnames */
+
+        return r;
+    }
 
 private:
     inline R_xlen_t offset(const int i, const int j) const { return i + static_cast<R_xlen_t>(nrows) * j ; }

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -378,16 +378,13 @@ Matrix<REALSXP, StoragePolicy> transpose(const Matrix<REALSXP, StoragePolicy> & 
     }
 
     // there must be a simpler, more C++-ish way for this ...
-    SEXP rnames = internal::DimNameProxy(x, 0);
-    SEXP cnames = internal::DimNameProxy(x, 1);
-    if (!Rf_isNull(rnames) || !Rf_isNull(cnames)) {
-        SEXP dimnames;
-        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(dimnames, 0, cnames);
-        SET_VECTOR_ELT(dimnames, 1, rnames);
+    SEXP dimNames = Rf_getAttrib(x, R_DimNamesSymbol);
+    if (!Rf_isNull(dimNames)) {
         // do we need dimnamesnames ?
-        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
-        UNPROTECT(1); /* dimnames */
+        Shield<SEXP> newDimNames(Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(newDimNames, 0, VECTOR_ELT(dimNames, 1));
+        SET_VECTOR_ELT(newDimNames, 1, VECTOR_ELT(dimNames, 0));
+        Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
     }
     return r;
 }
@@ -410,16 +407,13 @@ Matrix<INTSXP, StoragePolicy> transpose(const Matrix<INTSXP, StoragePolicy> & x)
     }
 
     // there must be a simpler, more C++-ish way for this ...
-    SEXP rnames = internal::DimNameProxy(x, 0);
-    SEXP cnames = internal::DimNameProxy(x, 1);
-    if (!Rf_isNull(rnames) || !Rf_isNull(cnames)) {
-        SEXP dimnames;
-        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(dimnames, 0, cnames);
-        SET_VECTOR_ELT(dimnames, 1, rnames);
+    SEXP dimNames = Rf_getAttrib(x, R_DimNamesSymbol);
+    if (!Rf_isNull(dimNames)) {
         // do we need dimnamesnames ?
-        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
-        UNPROTECT(1); /* dimnames */
+        Shield<SEXP> newDimNames(Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(newDimNames, 0, VECTOR_ELT(dimNames, 1));
+        SET_VECTOR_ELT(newDimNames, 1, VECTOR_ELT(dimNames, 0));
+        Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
     }
     return r;
 }
@@ -442,16 +436,13 @@ Matrix<STRSXP, StoragePolicy> transpose(const Matrix<STRSXP, StoragePolicy> & x)
     }
 
     // there must be a simpler, more C++-ish way for this ...
-    SEXP rnames = internal::DimNameProxy(x, 0);
-    SEXP cnames = internal::DimNameProxy(x, 1);
-    if (!Rf_isNull(rnames) || !Rf_isNull(cnames)) {
-        SEXP dimnames;
-        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(dimnames, 0, cnames);
-        SET_VECTOR_ELT(dimnames, 1, rnames);
+    SEXP dimNames = Rf_getAttrib(x, R_DimNamesSymbol);
+    if (!Rf_isNull(dimNames)) {
         // do we need dimnamesnames ?
-        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
-        UNPROTECT(1); /* dimnames */
+        Shield<SEXP> newDimNames(Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(newDimNames, 0, VECTOR_ELT(dimNames, 1));
+        SET_VECTOR_ELT(newDimNames, 1, VECTOR_ELT(dimNames, 0));
+        Rf_setAttrib(r, R_DimNamesSymbol, newDimNames);
     }
     return r;
 }

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -161,37 +161,6 @@ public:
       return Sub( const_cast<Matrix&>(*this), row_range, Range(0,ncol()-1) ) ;
     }
 
-    Matrix transpose() {
-        typedef Vector<CHARSXP, StoragePolicy> CHARVECTOR;
-        int nrow = VECTOR::dims()[0], ncol = VECTOR::dims()[1];
-        R_xlen_t len = XLENGTH(*this);
-
-        Matrix r(Dimension(ncol, nrow));
-        R_xlen_t i, j, l_1 = len-1;
-
-        // similar approach as in R: fill by in column, "accessing row-wise"
-        VECTOR s = VECTOR(r.get__());
-        for (i = 0, j = 0; i < len; i++, j += nrow) {
-            if (j > l_1) j -= l_1;
-            s[i] = (*this)[j];
-        }
-
-        Rf_copyMostAttrib((*this), r);
-
-        // there must be a simpler, more C++-ish way for this ...
-        SEXP rnames = internal::DimNameProxy((*this), 0);
-        SEXP cnames = internal::DimNameProxy((*this), 1);
-        SEXP dimnames;
-        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(dimnames, 0, cnames);
-        SET_VECTOR_ELT(dimnames, 1, rnames);
-        // do we need dimnamesnames ?
-        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
-        UNPROTECT(1); /* dimnames */
-
-        return r;
-    }
-
 private:
     inline R_xlen_t offset(const int i, const int j) const { return i + static_cast<R_xlen_t>(nrows) * j ; }
 
@@ -390,6 +359,73 @@ inline std::ostream &operator<<(std::ostream & s, const Matrix<RTYPE, StoragePol
 
     return s;
 }
+
+template<template <class> class StoragePolicy>
+Matrix<REALSXP, StoragePolicy> transpose(const Matrix<REALSXP, StoragePolicy> & x) {
+    typedef Matrix<REALSXP, StoragePolicy> MATRIX;
+    typedef Vector<REALSXP, StoragePolicy> VECTOR;
+
+    Vector<INTSXP, StoragePolicy> dims = ::Rf_getAttrib(x, R_DimSymbol);
+    int nrow = dims[0], ncol = dims[1];
+    MATRIX r(Dimension(ncol, nrow)); 	// new Matrix with reversed dimension
+    R_xlen_t len = XLENGTH(x), l_1 = XLENGTH(x)-1;
+
+    // similar approach as in R: fill by in column, "accessing row-wise"
+    VECTOR s = VECTOR(r.get__());
+    for (R_xlen_t i = 0, j = 0; i < len; i++, j += nrow) {
+        if (j > l_1) j -= l_1;
+        s[i] = x[j];
+    }
+    //Rf_copyMostAttrib((*this), r);
+
+    // there must be a simpler, more C++-ish way for this ...
+    SEXP rnames = internal::DimNameProxy(x, 0);
+    SEXP cnames = internal::DimNameProxy(x, 1);
+    if (!Rf_isNull(rnames) || !Rf_isNull(cnames)) {
+        SEXP dimnames;
+        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(dimnames, 0, cnames);
+        SET_VECTOR_ELT(dimnames, 1, rnames);
+        // do we need dimnamesnames ?
+        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
+        UNPROTECT(1); /* dimnames */
+    }
+    return r;
+}
+
+template<template <class> class StoragePolicy>
+Matrix<INTSXP, StoragePolicy> transpose(const Matrix<INTSXP, StoragePolicy> & x) {
+    typedef Matrix<INTSXP, StoragePolicy> MATRIX;
+    typedef Vector<INTSXP, StoragePolicy> VECTOR;
+
+    Vector<INTSXP, StoragePolicy> dims = ::Rf_getAttrib(x, R_DimSymbol);
+    int nrow = dims[0], ncol = dims[1];
+    MATRIX r(Dimension(ncol, nrow)); 	// new Matrix with reversed dimension
+    R_xlen_t len = XLENGTH(x), l_1 = XLENGTH(x)-1;
+
+    // similar approach as in R: fill by in column, "accessing row-wise"
+    VECTOR s = VECTOR(r.get__());
+    for (R_xlen_t i = 0, j = 0; i < len; i++, j += nrow) {
+        if (j > l_1) j -= l_1;
+        s[i] = x[j];
+    }
+    //Rf_copyMostAttrib((*this), r);
+
+    // there must be a simpler, more C++-ish way for this ...
+    SEXP rnames = internal::DimNameProxy(x, 0);
+    SEXP cnames = internal::DimNameProxy(x, 1);
+    if (!Rf_isNull(rnames) || !Rf_isNull(cnames)) {
+        SEXP dimnames;
+        PROTECT(dimnames = Rf_allocVector(VECSXP, 2));
+        SET_VECTOR_ELT(dimnames, 0, cnames);
+        SET_VECTOR_ELT(dimnames, 1, rnames);
+        // do we need dimnamesnames ?
+        Rf_setAttrib(r, R_DimNamesSymbol, dimnames);
+        UNPROTECT(1); /* dimnames */
+    }
+    return r;
+}
+
 
 }
 

--- a/inst/unitTests/cpp/Matrix.cpp
+++ b/inst/unitTests/cpp/Matrix.cpp
@@ -242,3 +242,14 @@ NumericVector runit_const_Matrix_column( const NumericMatrix& m ){
 int mat_access_with_bounds_checking(const IntegerMatrix m, int i, int j) {
     return m.at(i, j);
 }
+
+
+// [[Rcpp::export]]
+IntegerMatrix transposeInteger(const IntegerMatrix & x) {
+    return transpose(x);
+}
+
+// [[Rcpp::export]]
+NumericMatrix transposeNumeric(const NumericMatrix & x) {
+    return transpose(x);
+}

--- a/inst/unitTests/cpp/Matrix.cpp
+++ b/inst/unitTests/cpp/Matrix.cpp
@@ -253,3 +253,8 @@ IntegerMatrix transposeInteger(const IntegerMatrix & x) {
 NumericMatrix transposeNumeric(const NumericMatrix & x) {
     return transpose(x);
 }
+
+// [[Rcpp::export]]
+CharacterMatrix transposeCharacter(const CharacterMatrix & x) {
+    return transpose(x);
+}

--- a/inst/unitTests/runit.Matrix.R
+++ b/inst/unitTests/runit.Matrix.R
@@ -183,4 +183,22 @@ if (.runThisTest) {
         checkException(mat_access_with_bounds_checking(m, -1, -1) , msg = "index out of bounds not detected" )
     }
 
+    test.IntegerMatrix.transpose <- function() {
+        M <- matrix(1:12, 3, 4)
+        checkEquals(transposeInteger(M), t(M), msg="integer transpose")
+        rownames(M) <- letters[1:nrow(M)]
+        checkEquals(transposeInteger(M), t(M), msg="integer transpose with rownames")
+        colnames(M) <- LETTERS[1:ncol(M)]
+        checkEquals(transposeInteger(M), t(M), msg="integer transpose with row and colnames")
+    }
+
+    test.NumericMatrix.transpose <- function() {
+        M <- matrix(1.0 * (1:12), 3, 4)
+        checkEquals(transposeNumeric(M), t(M), msg="numeric transpose")
+        rownames(M) <- letters[1:nrow(M)]
+        checkEquals(transposeNumeric(M), t(M), msg="numeric transpose with rownames")
+        colnames(M) <- LETTERS[1:ncol(M)]
+        checkEquals(transposeNumeric(M), t(M), msg="numeric transpose with row and colnames")
+    }
+    
 }

--- a/inst/unitTests/runit.Matrix.R
+++ b/inst/unitTests/runit.Matrix.R
@@ -200,5 +200,14 @@ if (.runThisTest) {
         colnames(M) <- LETTERS[1:ncol(M)]
         checkEquals(transposeNumeric(M), t(M), msg="numeric transpose with row and colnames")
     }
+
+    test.CharacterMatrix.transpose <- function() {
+        M <- matrix(as.character(1:12), 3, 4)
+        checkEquals(transposeCharacter(M), t(M), msg="character transpose")
+        rownames(M) <- letters[1:nrow(M)]
+        checkEquals(transposeCharacter(M), t(M), msg="character transpose with rownames")
+        colnames(M) <- LETTERS[1:ncol(M)]
+        checkEquals(transposeCharacter(M), t(M), msg="character transpose with row and colnames")
+    }
     
 }


### PR DESCRIPTION
this should close #383:
- works on square and non-square integer and real matrices
- deals with `dimnames`
- will add one for strings as well, not sure I can be bothered for complex