### PR TITLE
const_iterators for CharacterVector now work analogously to iterators

### DIFF
--- a/inst/include/Rcpp/vector/const_generic_proxy.h
+++ b/inst/include/Rcpp/vector/const_generic_proxy.h
@@ -47,6 +47,8 @@ namespace internal{
 			operator bool() const { return ::Rcpp::as<bool>(get()) ; }
 			operator int() const { return ::Rcpp::as<int>(get()) ; }
 
+			inline void move(R_xlen_t n) { index += n ; }
+			
 			const VECTOR* parent;
 			R_xlen_t index ;
 

--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -40,7 +40,7 @@ namespace internal{
 		 * @param v reference to the associated character vector
 		 * @param index index
 		 */
-		const_string_proxy( VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
+		const_string_proxy( const VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
 
         const_string_proxy(SEXP x): parent(0), index(0) {
             Vector<RTYPE> tmp(x);

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -249,6 +249,13 @@ namespace traits {
 	template<> struct r_vector_iterator<VECSXP> : proxy_based_iterator<VECSXP>{} ;
 	template<> struct r_vector_iterator<EXPRSXP> : proxy_based_iterator<EXPRSXP>{} ;
 	template<> struct r_vector_iterator<STRSXP> : proxy_based_iterator<STRSXP>{} ;
+	
+	template <int RTYPE> struct proxy_based_const_iterator{
+		typedef ::Rcpp::internal::Proxy_Iterator< typename r_vector_const_proxy<RTYPE>::type > type ;
+	} ;
+	template<> struct r_vector_const_iterator<VECSXP> : proxy_based_const_iterator<VECSXP>{} ;
+	template<> struct r_vector_const_iterator<EXPRSXP> : proxy_based_const_iterator<EXPRSXP>{} ;
+	template<> struct r_vector_const_iterator<STRSXP> : proxy_based_const_iterator<STRSXP>{} ;
 
 }  // traits
 }

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -67,7 +67,7 @@ namespace traits{
 		}
 		inline iterator get() const { return iterator( proxy(*p, 0 ) ) ;}
 		// inline const_iterator get_const() const { return const_iterator( *p ) ;}
-		inline const_iterator get_const() const { return get_vector_ptr(*p) ; }
+		inline const_iterator get_const() const { return const_iterator( const_proxy(*p, 0) ) ; }
 
 		inline proxy ref() { return proxy(*p,0) ; }
 		inline proxy ref(R_xlen_t i) { return proxy(*p,i);}

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -574,9 +574,27 @@ std::string character_iterator1( CharacterVector letters ){
     return res ;
 }
 
+// [[Rcpp::export]]
+std::string character_const_iterator1( const CharacterVector letters ){
+    std::string res ;
+    CharacterVector::const_iterator first = letters.begin() ;
+    CharacterVector::const_iterator last = letters.end() ;
+    while( first != last ){
+        res += *first ;
+        ++first ;
+    }
+    return res ;
+}
+
 
 // [[Rcpp::export]]
 std::string character_iterator2( CharacterVector letters ){
+    std::string res(std::accumulate(letters.begin(), letters.end(), std::string()));
+    return res ;
+}
+
+// [[Rcpp::export]]
+std::string character_const_iterator2( const CharacterVector letters ){
     std::string res(std::accumulate(letters.begin(), letters.end(), std::string()));
     return res ;
 }

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -499,6 +499,18 @@ if (.runThisTest) {
                     paste(letters, collapse=""),
                     msg = "CharacterVector::iterator using std::accumulate" )
     }
+    
+    test.CharacterVector.iterator <- function(){
+        fun <- character_const_iterator1
+        checkEquals(fun(letters),
+                    paste(letters, collapse=""),
+                    msg = "CharacterVector::iterator explicit looping" )
+
+        fun <- character_const_iterator2
+        checkEquals(fun(letters),
+                    paste(letters, collapse=""),
+                    msg = "CharacterVector::iterator using std::accumulate" )
+    }
 
     test.CharacterVector.reverse <- function(){
         fun <- character_reverse


### PR DESCRIPTION
Happy Thanksgiving.

Been holding on to this one for a while and since we're between releases, now seemed like a good time.

This basically just makes `const_iterators` for `CharacterVector` work just like their non-const counterparts.