### PR TITLE
Attributes.R: allow findPlugin to getInlinePlugin

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -552,6 +552,11 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
 .findPlugin <- function(pluginName) {
 
     plugin <- .plugins[[pluginName]]
+    if (is.null(plugin)) {
+        plugin <- .getInlinePlugin(pluginName)
+        if (!is.null(plugin))
+            registerPlugin(pluginName, plugin)
+    }
     if (is.null(plugin))
         stop("Inline plugin '", pluginName, "' could not be found ",
              "within the Rcpp package. You should be ",


### PR DESCRIPTION
- Reduce need of registering plugins for sourceCpp when the plugin_name
  of //Rcpp::plugins(plugin_name) matches a package name that provides
  an inlineCxxPlugin.

Signed-off-by: Thell Fowler <thell@tbfowler.name>

--->8---

Instead of complaining that `foo` isn't registered and forcing a manual call to `registerPlugin(foo, Rcpp:::.getInlinePlugin(foo))` just do it...

I wasn't sure of what a good test would be or where it would go, so let me know if you want one.