### PR TITLE
Add extra checks to demangler_one

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -42,10 +42,13 @@ using namespace Rcpp;
         static std::string demangler_one(const char* input) {
             static std::string buffer;
             buffer = input;
-            buffer = buffer.substr(0, buffer.find_last_of('+'));
+            const auto last_plus =  buffer.find_last_of('+');
+            if (last_plus != std::string::npos) {
+                buffer.resize(last_plus - 1);
+            }
             const auto last_space = buffer.find_last_of(' ');
             if (last_space != std::string::npos) {
-                buffer = buffer.substr(last_space + 1);
+                buffer.erase(buffer.begin(), buffer.begin() + last_space + 1);
             }
             return demangle(buffer);
         }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -42,11 +42,11 @@ using namespace Rcpp;
         static std::string demangler_one(const char* input) {
             static std::string buffer;
             buffer = input;
-            buffer.resize(buffer.find_last_of('+') - 1);
-            buffer.erase(
-                buffer.begin(),
-                buffer.begin() + buffer.find_last_of(' ') + 1
-            );
+            buffer = buffer.substr(0, buffer.find_last_of('+'));
+            const auto last_space = buffer.find_last_of(' ');
+            if (last_space != std::string::npos) {
+                buffer = buffer.substr(last_space + 1);
+            }
             return demangle(buffer);
         }
 


### PR DESCRIPTION
Be more defensive about the output of backtrace_symbols, passed to demangler_one: don't assume the string would always have plus sign and space (e.g. the symbol may be unavailable) to prevent against crashes (e.g. resize would throw std::length_error for std::string::npos - 1).