### PR TITLE
const support for Nullable<>

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,17 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
+\section{Changes in Rcpp version 0.12.4 (2016-01-XX)}{
+  \itemize{
+    \item Changes in Rcpp API:
+    \itemize{
+      \item \code{Nullable<>::operator SEXP()} and
+      \code{Nullable<>::get()} now also work for \code{const} objects
+      (PR \ghpr{417}).
+    }
+  }
+}
+
 \section{Changes in Rcpp version 0.12.3 (2016-01-10)}{
   \itemize{
     \item Changes in Rcpp API:

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -77,7 +77,8 @@ namespace Rcpp {
          * @throw 'not initialized' if object has not been set
          */
         inline operator SEXP() const {
-            return get();
+            checkIfSet();
+            return m_sexp;
         }
 
         /**

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -76,7 +76,7 @@ namespace Rcpp {
          *
          * @throw 'not initialized' if object has not been set
          */
-        inline operator SEXP() {
+        inline operator SEXP() const {
             checkIfSet();
             return m_sexp;
         }
@@ -86,7 +86,7 @@ namespace Rcpp {
          *
          * @throw 'not initialized' if object has not been set
          */
-        inline SEXP get() {
+        inline SEXP get() const {
             checkIfSet();
             return m_sexp;
         }

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -77,8 +77,7 @@ namespace Rcpp {
          * @throw 'not initialized' if object has not been set
          */
         inline operator SEXP() const {
-            checkIfSet();
-            return m_sexp;
+            return get();
         }
 
         /**

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -179,22 +179,22 @@ void test_stop_variadic() {
 }
 
 // [[Rcpp::export]]
-bool testNullableForNull(Nullable<NumericMatrix> M) {
+bool testNullableForNull(const Nullable<NumericMatrix>& M) {
     return M.isNull();
 }
 
 // [[Rcpp::export]]
-bool testNullableForNotNull(Nullable<NumericMatrix> M) {
+bool testNullableForNotNull(const Nullable<NumericMatrix>& M) {
     return M.isNotNull();
 }
 
 // [[Rcpp::export]]
-SEXP testNullableOperator(Nullable<NumericMatrix> M) {
+SEXP testNullableOperator(const Nullable<NumericMatrix>& M) {
     return M;
 }
 
 // [[Rcpp::export]]
-SEXP testNullableGet(Nullable<NumericMatrix> M) {
+SEXP testNullableGet(const Nullable<NumericMatrix>& M) {
     return M.get();
 }
 


### PR DESCRIPTION
cargo-culted from many other implementations of `operator SEXP() const`

This came up when trying to use `const Nullable<...>&` in https://github.com/rstats-db/RMySQL/pull/90/files#r49576837

Seemed too minor to open an issue first. What would a test for this look like?

CC @peternowee