### PR TITLE
more verbose use of seq(along.with=

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2016-02-07  Dirk Eddelbuettel  <edd@debian.org>
 
+        * R/Attributes.R (sourceCppFunction): Use fully matched seq(along.with=...)
+
         * vignettes/Rcpp-FAQ.Rnw: Added a table of contents
 
 2016-02-06  James J Balamuta  <balamut2@illinois.edu>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -461,7 +461,7 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
 
     body <- quote( CALL_PLACEHOLDER ( EXTERNALNAME, ARG ) )[ c(1:2, rep(3, length(args))) ]
 
-    for (i in seq(along = args))
+    for (i in seq(along.with = args))
         body[[i+2]] <- as.symbol(args[i])
 
     body[[1L]] <- .Call


### PR DESCRIPTION
Mostly for @jjallaire:

Following a moment of madenss, I now use
```r
    options(#
            # ...
            warnPartialMatchAttr=TRUE,
            warnPartialMatchDollar=TRUE,
            warnPartialMatchArgs=TRUE,
            # ...
    ) 
```

which tickled some warnings from `seq(along=...)` and this PR fixes one.  There may be others, but this is a start.