### PR TITLE
Resolve misleading-indentation warnings from gcc 6

### DIFF
--- a/inst/include/Rcpp/stats/exp.h
+++ b/inst/include/Rcpp/stats/exp.h
@@ -27,46 +27,45 @@
 
 namespace Rcpp {
 namespace stats {
-	inline double d_exp_0( double x, int give_log){
+	inline double d_exp_0(double x, int give_log) {
 
 		#ifdef IEEE_754
-		    /* NaNs propagated correctly */
-		    if (ISNAN(x) ) return x + 1.0 ;
+		/* NaNs propagated correctly */
+		if (ISNAN(x)) return x + 1.0;
 		#endif
 
-    	if (x < 0.)
-		return R_D__0;
+		if (x < 0.)
+			return R_D__0;
 		return give_log ? (-x) : ::exp(-x);
 	}
-	inline double q_exp_0( double p, int lower_tail, int log_p){
+	inline double q_exp_0(double p, int lower_tail, int log_p) {
 		#ifdef IEEE_754
 		if (ISNAN(p)) return p + 1.0;
 		#endif
 
-		if ((log_p	&& p > 0) || (!log_p && (p < 0 || p > 1)) ) return R_NaN ;
+		if ((log_p && p > 0) || (!log_p && (p < 0 || p > 1))) return R_NaN;
 		if (p == R_DT_0)
-		return 0;
+			return 0;
 
 		return - R_DT_Clog(p);
 	}
 	inline double p_exp_0(double x, int lower_tail, int log_p) {
-#ifdef IEEE_754
-    if (ISNAN(x) )
-	return x + 1.0 ;
-#endif
+		#ifdef IEEE_754
+		if (ISNAN(x)) return x + 1.0;
+		#endif
 
-    if (x <= 0.)
-	return R_DT_0;
-    /* same as weibull( shape = 1): */
-    x = -x;
-    if (lower_tail)
-	return (log_p
-		/* log(1 - exp(x))  for x < 0 : */
-		? (x > -M_LN2 ? ::log(-::expm1(x)) : ::log1p(-::exp(x)))
-		: -::expm1(x));
-    /* else:  !lower_tail */
-    return R_D_exp(x);
-}
+		if (x <= 0.)
+			return R_DT_0;
+		/* same as weibull(shape = 1): */
+		x = -x;
+		if (lower_tail)
+			return (log_p
+				/* log(1 - exp(x))  for x < 0 : */
+				? (x > -M_LN2 ? ::log(-::expm1(x)) : ::log1p(-::exp(x)))
+				: -::expm1(x));
+		/* else:  !lower_tail */
+		return R_D_exp(x);
+	}
 
 } // stats
 } // Rcpp

--- a/inst/include/Rcpp/stats/lnorm.h
+++ b/inst/include/Rcpp/stats/lnorm.h
@@ -33,15 +33,15 @@ inline double dlnorm_0(double x, int log_p){
 
 #ifdef IEEE_754
     if (ISNAN(x))
-	return x + 1.0 ;
+        return x + 1.0;
 #endif
 
-    if(x <= 0) return R_D__0;
+    if (x <= 0) return R_D__0;
 
-    y = ::log(x) ;
+    y = ::log(x);
     return (log_p ?
-	    -(M_LN_SQRT_2PI   + 0.5 * y * y + ::log(x)) :
-	    M_1_SQRT_2PI * ::exp(-0.5 * y * y)  / x );
+            -(M_LN_SQRT_2PI + 0.5 * y * y + ::log(x)) :
+            M_1_SQRT_2PI * ::exp(-0.5 * y * y) / x);
     /* M_1_SQRT_2PI = 1 / sqrt(2 * pi) */
 
 }
@@ -50,16 +50,16 @@ inline double dlnorm_1(double x, double meanlog, int log_p){
     double y;
 
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(meanlog) )
-	return x + meanlog + 1.0 ;
+    if (ISNAN(x) || ISNAN(meanlog))
+        return x + meanlog + 1.0;
 #endif
 
-    if(x <= 0) return R_D__0;
+    if (x <= 0) return R_D__0;
 
     y = (::log(x) - meanlog);
     return (log_p ?
-	    -(M_LN_SQRT_2PI   + 0.5 * y * y + ::log(x)) :
-	    M_1_SQRT_2PI * ::exp(-0.5 * y * y)  / x );
+            -(M_LN_SQRT_2PI + 0.5 * y * y + ::log(x)) :
+            M_1_SQRT_2PI * ::exp(-0.5 * y * y) / x);
     /* M_1_SQRT_2PI = 1 / sqrt(2 * pi) */
 
 }
@@ -67,30 +67,30 @@ inline double dlnorm_1(double x, double meanlog, int log_p){
 
 inline double plnorm_0(double x, int lower_tail, int log_p){
 #ifdef IEEE_754
-    if (ISNAN(x)  )
-	return x + 1.0 ;
+    if (ISNAN(x))
+        return x + 1.0;
 #endif
 
     if (x > 0)
-    	return Rcpp::stats::pnorm_0(::log(x), lower_tail, log_p);
+        return Rcpp::stats::pnorm_0(::log(x), lower_tail, log_p);
     return R_DT_0;
 }
 
 inline double plnorm_1(double x, double meanlog, int lower_tail, int log_p) {
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(meanlog) )
-	return x + meanlog + 1.0 ;
+    if (ISNAN(x) || ISNAN(meanlog))
+        return x + meanlog + 1.0;
 #endif
 
-	if (x > 0)
-    	return Rcpp::stats::pnorm_1(::log(x), meanlog, lower_tail, log_p);
+    if (x > 0)
+        return Rcpp::stats::pnorm_1(::log(x), meanlog, lower_tail, log_p);
     return R_DT_0;
 }
 
 inline double qlnorm_0(double p, int lower_tail, int log_p){
 #ifdef IEEE_754
-    if (ISNAN(p) )
-	return p + 1.0 ;
+    if (ISNAN(p))
+        return p + 1.0;
 #endif
     R_Q_P01_boundaries(p, 0, ML_POSINF);
 
@@ -100,7 +100,7 @@ inline double qlnorm_0(double p, int lower_tail, int log_p){
 inline double qlnorm_1(double p, double meanlog, int lower_tail, int log_p){
 #ifdef IEEE_754
     if (ISNAN(p) || ISNAN(meanlog))
-	return p + meanlog + 1.0 ;
+        return p + meanlog + 1.0;
 #endif
     R_Q_P01_boundaries(p, 0, ML_POSINF);
 

--- a/inst/include/Rcpp/stats/logis.h
+++ b/inst/include/Rcpp/stats/logis.h
@@ -29,11 +29,11 @@ inline double dlogis_0(double x /*, double location [=0.0], double scale [=1.0] 
     double e, f;
 #ifdef IEEE_754
     if (ISNAN(x))
-	return x + 1.0 ;
+        return x + 1.0;
 #endif
 
-	e = ::exp(-::fabs(x));
-    f = 1.0 + e ;
+    e = ::exp(-::fabs(x));
+    f = 1.0 + e;
     return give_log ? -(x + ::log(f * f)) : e / (f * f);
 }
 
@@ -41,10 +41,10 @@ inline double dlogis_1(double x, double location /*, double scale [=1.0] */, int
     double e, f;
 #ifdef IEEE_754
     if (ISNAN(x) || ISNAN(location))
-	return x + location + 1.0;
+        return x + location + 1.0;
 #endif
 
-    x = ::fabs((x - location) );
+    x = ::fabs((x - location));
     e = ::exp(-x);
     f = 1.0 + e;
     return give_log ? -(x + ::log(f * f)) : e / (f * f);
@@ -52,13 +52,13 @@ inline double dlogis_1(double x, double location /*, double scale [=1.0] */, int
 
 
 inline double plogis_0(double x /*, double location [=0.0] , double scale [=1.0] */,
-	      int lower_tail, int log_p) {
+                       int lower_tail, int log_p) {
 #ifdef IEEE_754
-    if (ISNAN(x) )
-	return x + 1.0 ;
+    if (ISNAN(x))
+        return x + 1.0;
 #endif
 
-    if (ISNAN(x))	return R_NaN ;
+    if (ISNAN(x)) return R_NaN;
     R_P_bounds_Inf_01(x);
 
     x = ::exp(lower_tail ? -x : x);
@@ -67,14 +67,14 @@ inline double plogis_0(double x /*, double location [=0.0] , double scale [=1.0]
 
 
 inline double plogis_1(double x, double location /*, double scale [=1.0] */,
-	      int lower_tail, int log_p) {
+                       int lower_tail, int log_p) {
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(location) )
-	return x + location + 1.0 ;
+    if (ISNAN(x) || ISNAN(location))
+        return x + location + 1.0;
 #endif
 
-    x = (x - location) ;
-    if (ISNAN(x))	return R_NaN ;
+    x = (x - location);
+    if (ISNAN(x)) return R_NaN;
     R_P_bounds_Inf_01(x);
 
     x = ::exp(lower_tail ? -x : x);
@@ -86,19 +86,19 @@ inline double qlogis_0(double p /*, double location [=0.0], double scale [=1.0] 
 {
 #ifdef IEEE_754
     if (ISNAN(p))
-	return p + 1.0 ;
+        return p + 1.0;
 #endif
     R_Q_P01_boundaries(p, ML_NEGINF, ML_POSINF);
 
-    /* p := logit(p) = log( p / (1-p) )	 : */
-    if(log_p) {
-	if(lower_tail)
-	    p = p - ::log1p(- ::exp(p));
-	else
-	    p = ::log1p(- ::exp(p)) - p;
+    /* p := logit(p) = log(p / (1. - p))         : */
+    if (log_p) {
+        if (lower_tail)
+            p = p - ::log1p(- ::exp(p));
+        else
+            p = ::log1p(- ::exp(p)) - p;
     }
     else
-    	p = ::log(lower_tail ? (p / (1. - p)) : ((1. - p) / p));
+        p = ::log(lower_tail ? (p / (1. - p)) : ((1. - p) / p));
 
     return p;
 }
@@ -108,19 +108,19 @@ inline double qlogis_1(double p, double location /*, double scale [=1.0] */, int
 {
 #ifdef IEEE_754
     if (ISNAN(p) || ISNAN(location))
-	return p + location + 1.0 ;
+        return p + location + 1.0;
 #endif
     R_Q_P01_boundaries(p, ML_NEGINF, ML_POSINF);
 
-    /* p := logit(p) = log( p / (1-p) )	 : */
-    if(log_p) {
-	if(lower_tail)
-	    p = p - ::log1p(- ::exp(p));
-	else
-	    p = ::log1p(- ::exp(p)) - p;
+    /* p := logit(p) = log(p / (1. - p))         : */
+    if (log_p) {
+        if (lower_tail)
+            p = p - ::log1p(- ::exp(p));
+        else
+            p = ::log1p(- ::exp(p)) - p;
     }
     else
-    	p = ::log(lower_tail ? (p / (1. - p)) : ((1. - p) / p));
+        p = ::log(lower_tail ? (p / (1. - p)) : ((1. - p) / p));
 
     return location + p;
 }

--- a/inst/include/Rcpp/stats/norm.h
+++ b/inst/include/Rcpp/stats/norm.h
@@ -27,28 +27,28 @@ namespace stats {
 
 inline double dnorm_1(double x, double mu /*, double sigma [=1.0]*/ , int give_log) {
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(mu) )
-	return x + mu + 1.0 ;
+    if (ISNAN(x) || ISNAN(mu))
+        return x + mu + 1.0;
 #endif
-    if(!R_FINITE(x) && mu == x) return ML_NAN;/* x-mu is NaN */
-    x = (x - mu) ;
+    if (!R_FINITE(x) && mu == x) return ML_NAN; /* x-mu is NaN */
+    x = (x - mu);
 
-    if(!R_FINITE(x)) return R_D__0;
+    if (!R_FINITE(x)) return R_D__0;
     return (give_log ?
-	    -(M_LN_SQRT_2PI  +	0.5 * x * x ) :
-	    M_1_SQRT_2PI * ::exp(-0.5 * x * x) );
+            -(M_LN_SQRT_2PI + 0.5 * x * x) :
+            M_1_SQRT_2PI * ::exp(-0.5 * x * x));
     /* M_1_SQRT_2PI = 1 / sqrt(2 * pi) */
 }
 
 inline double dnorm_0(double x /*, double mu [=0.0], double sigma [=1.0]*/ , int give_log) {
 #ifdef IEEE_754
-    if (ISNAN(x) )
-	return x + 1.0 ;
+    if (ISNAN(x))
+        return x + 1.0;
 #endif
-   	if(!R_FINITE(x)) return R_D__0;
+    if (!R_FINITE(x)) return R_D__0;
     return (give_log ?
-	    -(M_LN_SQRT_2PI  +	0.5 * x * x ) :
-	    M_1_SQRT_2PI * ::exp(-0.5 * x * x) );
+            -(M_LN_SQRT_2PI + 0.5 * x * x) :
+            M_1_SQRT_2PI * ::exp(-0.5 * x * x));
     /* M_1_SQRT_2PI = 1 / sqrt(2 * pi) */
 }
 
@@ -59,13 +59,13 @@ inline double pnorm_1(double x, double mu /*, double sigma [=1.]*/ , int lower_t
      * For example, if x == mu and sigma == 0, we get the correct answer 1.
      */
 #ifdef IEEE_754
-    if(ISNAN(x) || ISNAN(mu) )
-	return x + mu + 1.0 ;
+    if (ISNAN(x) || ISNAN(mu))
+        return x + mu + 1.0;
 #endif
-    if(!R_FINITE(x) && mu == x) return ML_NAN;/* x-mu is NaN */
-    p = (x - mu) ;
-    if(!R_FINITE(p))
-	return (x < mu) ? R_DT_0 : R_DT_1;
+    if (!R_FINITE(x) && mu == x) return ML_NAN; /* x-mu is NaN */
+    p = (x - mu);
+    if (!R_FINITE(p))
+        return (x < mu) ? R_DT_0 : R_DT_1;
     x = p;
 
     ::Rf_pnorm_both(x, &p, &cp, (lower_tail ? 0 : 1), log_p);
@@ -80,12 +80,12 @@ inline double pnorm_0(double x /*, double mu [=0.] , double sigma [=1.]*/ , int 
      * For example, if x == mu and sigma == 0, we get the correct answer 1.
      */
 #ifdef IEEE_754
-    if(ISNAN(x)  )
-	return x + 1.0 ;
+    if (ISNAN(x))
+        return x + 1.0;
 #endif
-    p = x ;
-    if(!R_FINITE(p))
-	return (x < 0.0 ) ? R_DT_0 : R_DT_1;
+    p = x;
+    if (!R_FINITE(p))
+        return (x < 0.0) ? R_DT_0 : R_DT_1;
     x = p;
 
     ::Rf_pnorm_both(x, &p, &cp, (lower_tail ? 0 : 1), log_p);
@@ -94,17 +94,17 @@ inline double pnorm_0(double x /*, double mu [=0.] , double sigma [=1.]*/ , int 
 }
 
 inline double qnorm_1(double p, double mu /*, double sigma [=1.] */, int lower_tail, int log_p){
-	return ::Rf_qnorm5(p, mu, 1.0, lower_tail, log_p ) ;
+    return ::Rf_qnorm5(p, mu, 1.0, lower_tail, log_p);
 }
 inline double qnorm_0(double p /*, double mu [=0.], double sigma [=1.] */, int lower_tail, int log_p){
-	return ::Rf_qnorm5(p, 0.0, 1.0, lower_tail, log_p ) ;
+    return ::Rf_qnorm5(p, 0.0, 1.0, lower_tail, log_p);
 }
 
 } // stats
 } // Rcpp
 
-RCPP_DPQ_0(norm, Rcpp::stats::dnorm_0, Rcpp::stats::pnorm_0, Rcpp::stats::qnorm_0 )
-RCPP_DPQ_1(norm, Rcpp::stats::dnorm_1, Rcpp::stats::pnorm_1, Rcpp::stats::qnorm_1 )
-RCPP_DPQ_2(norm, ::Rf_dnorm4, ::Rf_pnorm5, ::Rf_qnorm5 )
+RCPP_DPQ_0(norm, Rcpp::stats::dnorm_0, Rcpp::stats::pnorm_0, Rcpp::stats::qnorm_0)
+RCPP_DPQ_1(norm, Rcpp::stats::dnorm_1, Rcpp::stats::pnorm_1, Rcpp::stats::qnorm_1)
+RCPP_DPQ_2(norm, ::Rf_dnorm4, ::Rf_pnorm5, ::Rf_qnorm5)
 
 #endif

--- a/inst/include/Rcpp/stats/weibull.h
+++ b/inst/include/Rcpp/stats/weibull.h
@@ -31,50 +31,50 @@ namespace stats {
 inline double dweibull_1(double x, double shape /*, double scale [=1.0] */ , int give_log){
     double tmp1, tmp2;
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(shape) )
-	return x + shape + 1.0;
+    if (ISNAN(x) || ISNAN(shape))
+        return x + shape + 1.0;
 #endif
-    if (shape <= 0 ) return R_NaN ;
+    if (shape <= 0) return R_NaN;
 
     if (x < 0) return R_D__0;
     if (!R_FINITE(x)) return R_D__0;
     /* need to handle x == 0 separately */
-    if(x == 0 && shape < 1) return ML_POSINF;
+    if (x == 0 && shape < 1) return ML_POSINF;
     tmp1 = ::pow(x, shape - 1);
     tmp2 = tmp1 * x;
     /* These are incorrect if tmp1 == 0 */
     return  give_log ?
-	-tmp2 + ::log(shape * tmp1 ) :
-	shape * tmp1 * ::exp(-tmp2) ;
+        -tmp2 + ::log(shape * tmp1) :
+        shape * tmp1 * ::exp(-tmp2);
 }
 inline double pweibull_1(double x, double shape /*, double scale [=1.0] */, int lower_tail, int log_p) {
 #ifdef IEEE_754
-    if (ISNAN(x) || ISNAN(shape) )
-	return x + shape + 1.0;
+    if (ISNAN(x) || ISNAN(shape))
+        return x + shape + 1.0;
 #endif
-    if(shape <= 0) return R_NaN;
+    if (shape <= 0) return R_NaN;
 
     if (x <= 0)
-	return R_DT_0;
-	x = -::pow(x , shape);
+        return R_DT_0;
+    x = -::pow(x , shape);
     if (lower_tail)
-	return (log_p
-		/* log(1 - exp(x))  for x < 0 : */
-		? (x > -M_LN2 ? ::log(-::expm1(x)) : ::log1p(-::exp(x)))
-		: -::expm1(x));
+        return (log_p
+                /* log(1 - exp(x))  for x < 0 : */
+                ? (x > -M_LN2 ? ::log(-::expm1(x)) : ::log1p(-::exp(x)))
+                : -::expm1(x));
     /* else:  !lower_tail */
     return R_D_exp(x);
 }
 inline double qweibull_1(double p, double shape /*, double scale [=1.0] */, int lower_tail, int log_p){
 #ifdef IEEE_754
     if (ISNAN(p) || ISNAN(shape))
-	return p + shape + 1.0;
+        return p + shape + 1.0;
 #endif
-    if (shape <= 0 ) return R_NaN ;
+    if (shape <= 0) return R_NaN;
 
     R_Q_P01_boundaries(p, 0, ML_POSINF);
 
-    return ::pow(- R_DT_Clog(p), 1./shape) ;
+    return ::pow(- R_DT_Clog(p), 1./shape);
 }
 
 } // stats


### PR DESCRIPTION
This pull request resolves the warnings about misleading indentation issued by gcc 6.
~~~
In file included from ../inst/include/Rcpp/stats/stats.h:32:0,
                 from ../inst/include/Rcpp.h:71,
                 from Date.cpp:31:
../inst/include/Rcpp/stats/norm.h: In function 'double Rcpp::stats::dnorm_0(double, int)':
../inst/include/Rcpp/stats/norm.h:48:5: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
     if(!R_FINITE(x)) return R_D__0;
     ^~
../inst/include/Rcpp/stats/norm.h:45:5: note: ...this 'if' clause, but it is not
     if (ISNAN(x) )
     ^~
In file included from ../inst/include/Rcpp/stats/stats.h:37:0,
                 from ../inst/include/Rcpp.h:71,
                 from Date.cpp:31:
../inst/include/Rcpp/stats/lnorm.h: In function 'double Rcpp::stats::plnorm_1(double, double, int, int)':
../inst/include/Rcpp/stats/lnorm.h:85:2: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
  if (x > 0)
  ^~
../inst/include/Rcpp/stats/lnorm.h:81:5: note: ...this 'if' clause, but it is not
     if (ISNAN(x) || ISNAN(meanlog) )
     ^~
In file included from ../inst/include/Rcpp/stats/stats.h:38:0,
                 from ../inst/include/Rcpp.h:71,
                 from Date.cpp:31:
../inst/include/Rcpp/stats/weibull.h: In function 'double Rcpp::stats::pweibull_1(double, double, int, int)':
../inst/include/Rcpp/stats/weibull.h:59:2: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
  x = -::pow(x , shape);
  ^
../inst/include/Rcpp/stats/weibull.h:57:5: note: ...this 'if' clause, but it is not
     if (x <= 0)
     ^~
In file included from ../inst/include/Rcpp/stats/stats.h:39:0,
                 from ../inst/include/Rcpp.h:71,
                 from Date.cpp:31:
../inst/include/Rcpp/stats/logis.h: In function 'double Rcpp::stats::dlogis_0(double, int)':
../inst/include/Rcpp/stats/logis.h:35:2: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
  e = ::exp(-::fabs(x));
  ^
../inst/include/Rcpp/stats/logis.h:31:5: note: ...this 'if' clause, but it is not
     if (ISNAN(x))
     ^~
In file included from ../inst/include/Rcpp/stats/stats.h:41:0,
                 from ../inst/include/Rcpp.h:71,
                 from Date.cpp:31:
../inst/include/Rcpp/stats/exp.h: In function 'double Rcpp::stats::d_exp_0(double, int)':
../inst/include/Rcpp/stats/exp.h:39:3: warning: statement is indented as if it were guarded by... [-Wmisleading-indentation]
   return give_log ? (-x) : ::exp(-x);
   ^~~~~~
../inst/include/Rcpp/stats/exp.h:37:6: note: ...this 'if' clause, but it is not
      if (x < 0.)
      ^~

~~~