### PR TITLE
Fix R shebangs

### DIFF
--- a/inst/examples/ConvolveBenchmarks/exampleRCode.r
+++ b/inst/examples/ConvolveBenchmarks/exampleRCode.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 suppressMessages(require(Rcpp))
 set.seed(42)

--- a/inst/examples/ConvolveBenchmarks/overhead.r
+++ b/inst/examples/ConvolveBenchmarks/overhead.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 set.seed(42)
 a <- rnorm(100)

--- a/inst/examples/FastLM/benchmark.r
+++ b/inst/examples/FastLM/benchmark.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Comparison benchmark
 #

--- a/inst/examples/FastLM/benchmarkLongley.r
+++ b/inst/examples/FastLM/benchmarkLongley.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Comparison benchmark -- using old and small Longley data set
 #

--- a/inst/examples/FastLM/fastLMviaArmadillo.r
+++ b/inst/examples/FastLM/fastLMviaArmadillo.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # A faster lm() replacement based on Armadillo
 #

--- a/inst/examples/FastLM/fastLMviaGSL.r
+++ b/inst/examples/FastLM/fastLMviaGSL.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # A faster lm() replacement based on GNU GSL
 #

--- a/inst/examples/Misc/fibonacci.r
+++ b/inst/examples/Misc/fibonacci.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 ## this short example was provided in response to this StackOverflow questions:
 ## http://stackoverflow.com/questions/6807068/why-is-my-recursive-function-so-slow-in-r

--- a/inst/examples/Misc/ifelseLooped.r
+++ b/inst/examples/Misc/ifelseLooped.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 ##
 ## This example goes back to the following StackOverflow questions:
 ##   http://stackoverflow.com/questions/7153586/can-i-vectorize-a-calculation-which-depends-on-previous-elements

--- a/inst/examples/Misc/newFib.r
+++ b/inst/examples/Misc/newFib.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 ## New and shorter version of Fibonacci example using Rcpp 0.9.16 or later features
 ## The the sibbling file 'fibonacci.r' for context

--- a/inst/examples/Misc/piBySimulation.r
+++ b/inst/examples/Misc/piBySimulation.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 library(Rcpp)
 library(rbenchmark)

--- a/inst/examples/OpenMP/OpenMPandInline.r
+++ b/inst/examples/OpenMP/OpenMPandInline.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 library(inline)
 library(rbenchmark)

--- a/inst/examples/RcppInline/RObject.r
+++ b/inst/examples/RcppInline/RObject.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2009 - 2010  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/examples/RcppInline/RcppInlineExample.r
+++ b/inst/examples/RcppInline/RcppInlineExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 suppressMessages(library(Rcpp))
 suppressMessages(library(inline))

--- a/inst/examples/RcppInline/RcppInlineWithLibsExamples.r
+++ b/inst/examples/RcppInline/RcppInlineWithLibsExamples.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2009 - 2010	Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/examples/RcppInline/RcppSimpleExample.r
+++ b/inst/examples/RcppInline/RcppSimpleExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/R
 
 
 suppressMessages(library(Rcpp))

--- a/inst/examples/RcppInline/UncaughtExceptions.r
+++ b/inst/examples/RcppInline/UncaughtExceptions.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2009 - 2010  Romain Francois and Dirk Eddelbuettel
 #

--- a/inst/examples/RcppInline/external_pointer.r
+++ b/inst/examples/RcppInline/external_pointer.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2009 - 2010	Romain Francois
 #

--- a/inst/examples/SugarPerformance/sugarBenchmarks.R
+++ b/inst/examples/SugarPerformance/sugarBenchmarks.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 
 suppressMessages(library(inline))
 suppressMessages(library(Rcpp))

--- a/inst/examples/functionCallback/newApiExample.r
+++ b/inst/examples/functionCallback/newApiExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -ti
+#!/usr/bin/R -ti
 
 suppressMessages(library(Rcpp))
 suppressMessages(library(inline))

--- a/inst/unitTests/runit.DataFrame.R
+++ b/inst/unitTests/runit.DataFrame.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Function.R
+++ b/inst/unitTests/runit.Function.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.InternalFunction.R
+++ b/inst/unitTests/runit.InternalFunction.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/runit.InternalFunctionCPP11.R
+++ b/inst/unitTests/runit.InternalFunctionCPP11.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/runit.Language.R
+++ b/inst/unitTests/runit.Language.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Matrix.R
+++ b/inst/unitTests/runit.Matrix.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel, Romain Francois and Kevin Ushey
 #

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Module.client.package.R
+++ b/inst/unitTests/runit.Module.client.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015	 John Chambers, Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.RObject.R
+++ b/inst/unitTests/runit.RObject.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2009 - 2014  Romain Francois and Dirk Eddelbuettel

--- a/inst/unitTests/runit.Reference.R
+++ b/inst/unitTests/runit.Reference.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2013 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.S4.R
+++ b/inst/unitTests/runit.S4.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.XPTr.R
+++ b/inst/unitTests/runit.XPTr.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2009 - 2014	 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.as.R
+++ b/inst/unitTests/runit.as.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.attributes.R
+++ b/inst/unitTests/runit.attributes.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/unitTests/runit.binary.package.R
+++ b/inst/unitTests/runit.binary.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2014  Dirk Eddelbuettel
 #

--- a/inst/unitTests/runit.client.package.R
+++ b/inst/unitTests/runit.client.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.environments.R
+++ b/inst/unitTests/runit.environments.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2009 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.misc.R
+++ b/inst/unitTests/runit.misc.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.modref.R
+++ b/inst/unitTests/runit.modref.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2015  John Chambers, Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.na.R
+++ b/inst/unitTests/runit.na.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Kevin Ushey

--- a/inst/unitTests/runit.rmath.R
+++ b/inst/unitTests/runit.rmath.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; ess-indent-level: 4; tab-width: 4; indent-tabs-mode: nil; -*
 #
 # Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.stats.R
+++ b/inst/unitTests/runit.stats.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #                     -*- mode: R; ess-indent-level: 4; indent-tabs-mode: nil; -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.sugar.var.R
+++ b/inst/unitTests/runit.sugar.var.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #                     -*- mode: R; ess-indent-level: 4; indent-tabs-mode: nil; -*-
 #
 # Copyright (C) 2015 Wush Wu

--- a/inst/unitTests/runit.support.R
+++ b/inst/unitTests/runit.support.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.table.R
+++ b/inst/unitTests/runit.table.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
 #

--- a/inst/unitTests/runit.wrap.R
+++ b/inst/unitTests/runit.wrap.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.wstring.R
+++ b/inst/unitTests/runit.wstring.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/R -t
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2013 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/vignettes/getCurrentVersionsOfCitedPackages.R
+++ b/vignettes/getCurrentVersionsOfCitedPackages.R
@@ -1,4 +1,4 @@
-#/usr/bin/r
+#/usr/bin/R
 
 setwd("~/git/rcpp/vignettes")
 cmd <- "grep package= Rcpp.bib | cut -c27- | sed -e 's/\"$//' | sort | uniq"


### PR DESCRIPTION
I am not sure what this is supposed to be. I assume /usr/bin/r is a misspelt /usr/bin/R since these are all R macros. But many of them say "/usr/bin/R -t" and -t is not a valid option to R.
~~~
$ R -t
WARNING: unknown option '-t'
~~~
So what is this -t flag supposed to do?

The shebang with /usr/bin/r doesn't work
~~~
$ inst/examples/FastLM/benchmark.r
bash: inst/examples/FastLM/benchmark.r: /usr/bin/r: bad interpreter: No such file or directory
~~~
Only a few of the files with an /usr/bin/r shebang (15 of 52) actually have the executable permissions set. Why does some have executable permissions set and some not - is this just a mistake, or is this inconsistency deliberate. A shebang in a file without executable permissions does not make sense, so I would suggest either to set the executable permission or remove the shebang.
