### PR TITLE
Feature/switch to usr bin env r (closes #440)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2016-02-21  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/examples/functionCallback/newApiExample.r (vecfunc): Switched to
+        using '/usr/bin/env r', switch to using 'cxxfunction'
+
+        * inst/examples/Misc/fibonacci.r: Switched to using '/usr/bin/env r',
+        added explicit load of Rcpp package
+
+        * inst/examples/Misc/newFib.r: Switched to using '/usr/bin/env r'
+        * inst/examples/Misc/ifelseLooped.r: Idem
+        * inst/examples/Misc/piBySimulation.r: Idem
+        * inst/examples/SugarPerformance/sugarBenchmarks.r: Idem
+
 2016-02-16  Dirk Eddelbuettel  <edd@debian.org>
 
         * vignettes/Rcpp-FAQ.Rnw: Added answer on fixed-size limit of arguments

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-03-03  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/examples/FastLM/benchmarkLongley.r: Switched to '/usr/bin/env r'
+        * inst/examples/FastLM/fastLMviaArmadillo.r: Idem
+        * inst/examples/FastLM/fastLMviaGSL.r: Idem
+        * inst/examples/FastLM/lmArmadillo.R: Idem
+        * inst/examples/FastLM/lmGSL.R: Idem
+
 2016-02-27  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/RcppInline/RcppInlineWithLibsExamples.r: Switched to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,38 @@
+2016-03-04  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/unitTests/runit.Function.R: Switched to '/usr/bin/env r'
+        * inst/unitTests/runit.table.R: Idem
+        * inst/unitTests/runit.as.R: Idem
+        * inst/unitTests/runit.Date.R: Idem
+        * inst/unitTests/runit.misc.R: Idem
+        * inst/unitTests/runit.Language.R: Idem
+        * inst/unitTests/runit.subset.R: Idem
+        * inst/unitTests/runit.wrap.R: Idem
+        * inst/unitTests/runit.sugar.R: Idem
+        * inst/unitTests/runit.na.R: Idem
+        * inst/unitTests/runit.String.R: Idem
+        * inst/unitTests/runit.Vector.R: Idem
+        * inst/unitTests/runit.environments.R: Idem
+        * inst/unitTests/runit.Reference.R: Idem
+        * inst/unitTests/runit.Matrix.R: Idem
+        * inst/unitTests/runit.client.package.R: Idem
+        * inst/unitTests/runit.binary.package.R: Idem
+        * inst/unitTests/runit.support.R: Idem
+        * inst/unitTests/runit.S4.R: Idem
+        * inst/unitTests/runit.RObject.R: Idem
+        * inst/unitTests/runit.modref.R: Idem
+        * inst/unitTests/runit.InternalFunctionCPP11.R: Idem
+        * inst/unitTests/runit.attributes.R: Idem
+        * inst/unitTests/runit.sugar.var.R: Idem
+        * inst/unitTests/runit.Module.R: Idem
+        * inst/unitTests/runit.XPTr.R: Idem
+        * inst/unitTests/runit.Module.client.package.R: Idem
+        * inst/unitTests/runit.stats.R: Idem
+        * inst/unitTests/runit.rmath.R: Idem
+        * inst/unitTests/runit.DataFrame.R: Idem
+        * inst/unitTests/runit.wstring.R: Idem
+        * inst/unitTests/runit.InternalFunction.R: Idem
+
 2016-03-03  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/FastLM/benchmarkLongley.r: Switched to '/usr/bin/env r'

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
         * inst/examples/FastLM/fastLMviaGSL.r: Idem
         * inst/examples/FastLM/lmArmadillo.R: Idem
         * inst/examples/FastLM/lmGSL.R: Idem
+        * inst/examples/FastLM/benchmark.r: Idem
+        * inst/examples/ConvolveBenchmarks/exampleRCode.r: Idem
 
 2016-02-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2016-02-23  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/examples/OpenMP/OpenMPandInline.r: Switched to '/usr/bin/env r'
+        * inst/examples/RcppInline/RcppSimpleExample.r: Idem
+        * inst/examples/RcppInline/RObject.r: Idem
+        * inst/examples/RcppInline/UncaughtExceptions.r: Idem
+
 2016-02-21  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/functionCallback/newApiExample.r (vecfunc): Switched to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2016-02-27  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/examples/RcppInline/RcppInlineWithLibsExamples.r: Switched to
+        using '/usr/bin/env r', switch to using 'cxxfunction' and RcppGSL plugin
+
+        * inst/examples/RcppInline/external_pointer.r: Switched to '/usr/bin/env r'
+        * inst/examples/RcppInline/RcppInlineExample.r: Idem
+        * inst/examples/ConvolveBenchmarks/overhead.r: Idem
+
+        * inst/include/Rcpp/Fast.h (Rcpp): Undo two const declarations
+
 2016-02-23  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/examples/OpenMP/OpenMPandInline.r: Switched to '/usr/bin/env r'

--- a/inst/examples/ConvolveBenchmarks/exampleRCode.r
+++ b/inst/examples/ConvolveBenchmarks/exampleRCode.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 suppressMessages(require(Rcpp))
 set.seed(42)

--- a/inst/examples/ConvolveBenchmarks/overhead.r
+++ b/inst/examples/ConvolveBenchmarks/overhead.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 set.seed(42)
 a <- rnorm(100)
@@ -17,12 +17,8 @@ overhead_cpp <- function(a,b) .Call( overhead_cpp_symbol, a, b )
 ## load benchmarkin helper function
 suppressMessages(library(rbenchmark))
 
-benchmark(
-
-    overhead_cpp(a,b),
-    overhead_c(a,b),
-    
-            columns=c("test", "replications", "elapsed", "relative", "user.self", "sys.self"),
-                order="relative",
-                replications=10000)
-
+res <- benchmark(overhead_cpp(a,b), overhead_c(a,b),
+                 columns=c("test", "replications", "elapsed", "relative", "user.self", "sys.self"),
+                 order="relative",
+                 replications=10000)
+print(res)

--- a/inst/examples/FastLM/benchmark.r
+++ b/inst/examples/FastLM/benchmark.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Comparison benchmark
 #
@@ -21,6 +21,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+suppressMessages(library(RcppGSL))
+suppressMessages(library(RcppArmadillo))
 
 source("lmArmadillo.R")
 source("lmGSL.R")

--- a/inst/examples/FastLM/benchmarkLongley.r
+++ b/inst/examples/FastLM/benchmarkLongley.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Comparison benchmark -- using old and small Longley data set
 #

--- a/inst/examples/FastLM/fastLMviaArmadillo.r
+++ b/inst/examples/FastLM/fastLMviaArmadillo.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # A faster lm() replacement based on Armadillo
 #

--- a/inst/examples/FastLM/fastLMviaGSL.r
+++ b/inst/examples/FastLM/fastLMviaGSL.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # A faster lm() replacement based on GNU GSL
 #

--- a/inst/examples/FastLM/lmArmadillo.R
+++ b/inst/examples/FastLM/lmArmadillo.R
@@ -49,11 +49,9 @@ lmArmadillo <- function() {
     '
 
     ## turn into a function that R can call
-    fun <- cfunction(signature(Ysexp="numeric", Xsexp="numeric"),
-                     src,
-                     includes="#include <armadillo>",
-                     Rcpp=TRUE,
-                     cppargs="-I/usr/include",
-                     libargs="-larmadillo -llapack")
+    fun <- cxxfunction(signature(Ysexp="numeric", Xsexp="numeric"),
+                       src,
+                       includes="#include <armadillo>",
+                       plugin="RcppArmadillo")
 }
 

--- a/inst/examples/FastLM/lmGSL.R
+++ b/inst/examples/FastLM/lmGSL.R
@@ -62,10 +62,8 @@ lmGSL <- function() {
 
     ## turn into a function that R can call
     ## compileargs redundant on Debian/Ubuntu as gsl headers are found anyway
-    fun <- cfunction(signature(Ysexp="numeric", Xsexp="numeric"),
-                     src,
-                     includes="#include <gsl/gsl_multifit.h>",
-                     Rcpp=TRUE,
-                     cppargs="-I/usr/include",
-                     libargs="-lgsl -lgslcblas")
+    fun <- cxxfunction(signature(Ysexp="numeric", Xsexp="numeric"),
+                       src,
+                       includes="#include <gsl/gsl_multifit.h>",
+                       plugin="RcppGSL")
 }

--- a/inst/examples/Misc/fibonacci.r
+++ b/inst/examples/Misc/fibonacci.r
@@ -1,10 +1,12 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 ## this short example was provided in response to this StackOverflow questions:
 ## http://stackoverflow.com/questions/6807068/why-is-my-recursive-function-so-slow-in-r
 ## and illustrates that recursive function calls are a) really expensive in R and b) not
 ## all expensive in C++ (my machine sees a 700-fold speed increase) and c) the byte
 ## compiler in R does not help here.
+
+suppressMessages(library(Rcpp))
 
 ## byte compiler
 require(compiler)

--- a/inst/examples/Misc/ifelseLooped.r
+++ b/inst/examples/Misc/ifelseLooped.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 ##
 ## This example goes back to the following StackOverflow questions:
 ##   http://stackoverflow.com/questions/7153586/can-i-vectorize-a-calculation-which-depends-on-previous-elements

--- a/inst/examples/Misc/newFib.r
+++ b/inst/examples/Misc/newFib.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 ## New and shorter version of Fibonacci example using Rcpp 0.9.16 or later features
 ## The the sibbling file 'fibonacci.r' for context

--- a/inst/examples/Misc/piBySimulation.r
+++ b/inst/examples/Misc/piBySimulation.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 library(Rcpp)
 library(rbenchmark)

--- a/inst/examples/OpenMP/OpenMPandInline.r
+++ b/inst/examples/OpenMP/OpenMPandInline.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 library(inline)
 library(rbenchmark)

--- a/inst/examples/RcppInline/RObject.r
+++ b/inst/examples/RcppInline/RObject.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2009 - 2010  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/examples/RcppInline/RcppInlineExample.r
+++ b/inst/examples/RcppInline/RcppInlineExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 suppressMessages(library(Rcpp))
 suppressMessages(library(inline))

--- a/inst/examples/RcppInline/RcppSimpleExample.r
+++ b/inst/examples/RcppInline/RcppSimpleExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r
+#!/usr/bin/env r
 
 
 suppressMessages(library(Rcpp))

--- a/inst/examples/RcppInline/UncaughtExceptions.r
+++ b/inst/examples/RcppInline/UncaughtExceptions.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2009 - 2010  Romain Francois and Dirk Eddelbuettel
 #

--- a/inst/examples/RcppInline/external_pointer.r
+++ b/inst/examples/RcppInline/external_pointer.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2009 - 2010	Romain Francois
 #

--- a/inst/examples/SugarPerformance/sugarBenchmarks.R
+++ b/inst/examples/SugarPerformance/sugarBenchmarks.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 
 suppressMessages(library(inline))
 suppressMessages(library(Rcpp))

--- a/inst/examples/functionCallback/newApiExample.r
+++ b/inst/examples/functionCallback/newApiExample.r
@@ -1,4 +1,4 @@
-#!/usr/bin/r -ti
+#!/usr/bin/env r
 
 suppressMessages(library(Rcpp))
 suppressMessages(library(inline))
@@ -24,8 +24,8 @@ cpp <- '
 '
 
 # create a C++ function
-funx <- cfunction(signature(N = "integer" , xvec = "numeric", fun = "function" ),
-                  cpp, , Rcpp = TRUE, include = "using namespace Rcpp; ")
+funx <- cxxfunction(signature(N = "integer" , xvec = "numeric", fun = "function" ),
+                    body=cpp, include = "using namespace Rcpp; ", plugin = "Rcpp")
 
 # create the vector
 xvec <- sqrt(c(1:12, 11:1))
@@ -36,4 +36,3 @@ par(mar=c(3,3,1,1),cex=0.8, pch=19)
 
 # run example
 funx( 10L, xvec, vecfunc )
-

--- a/inst/include/Rcpp/Fast.h
+++ b/inst/include/Rcpp/Fast.h
@@ -2,7 +2,7 @@
 //
 // Fast.h: Rcpp R/C++ interface class library -- faster vectors (less interface)
 //
-// Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -26,19 +26,19 @@ namespace Rcpp {
 template <typename VECTOR>
 class Fast {
 public:
-    typedef typename VECTOR::stored_type value_type ;
+    typedef typename VECTOR::stored_type value_type;
 
-    Fast( const VECTOR& v_) : v(v_), data( v_.begin() ){}
+    Fast( /*const*/ VECTOR& v_) : v(v_), data(v_.begin()) {}
 
-    inline value_type& operator[]( R_xlen_t i){ return data[i] ; }
-    inline const value_type& operator[]( R_xlen_t i) const { return data[i] ; }
-    inline R_xlen_t size() const { return v.size() ; }
+    inline value_type& operator[](R_xlen_t i) { return data[i]; }
+    inline const value_type& operator[](R_xlen_t i) const { return data[i]; }
+    inline R_xlen_t size() const { return v.size(); }
 
 private:
-    const VECTOR& v ;
-    value_type* data ;
+    /*const*/ VECTOR& v;
+    value_type* data;
 
-} ;
+};
 }
 
 #endif

--- a/inst/unitTests/runit.DataFrame.R
+++ b/inst/unitTests/runit.DataFrame.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Function.R
+++ b/inst/unitTests/runit.Function.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.InternalFunction.R
+++ b/inst/unitTests/runit.InternalFunction.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/runit.InternalFunctionCPP11.R
+++ b/inst/unitTests/runit.InternalFunctionCPP11.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/runit.Language.R
+++ b/inst/unitTests/runit.Language.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Matrix.R
+++ b/inst/unitTests/runit.Matrix.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel, Romain Francois and Kevin Ushey
 #

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Module.client.package.R
+++ b/inst/unitTests/runit.Module.client.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015	 John Chambers, Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.RObject.R
+++ b/inst/unitTests/runit.RObject.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2009 - 2014  Romain Francois and Dirk Eddelbuettel

--- a/inst/unitTests/runit.Reference.R
+++ b/inst/unitTests/runit.Reference.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2013 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.S4.R
+++ b/inst/unitTests/runit.S4.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.XPTr.R
+++ b/inst/unitTests/runit.XPTr.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2009 - 2014	 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.as.R
+++ b/inst/unitTests/runit.as.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.attributes.R
+++ b/inst/unitTests/runit.attributes.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/unitTests/runit.binary.package.R
+++ b/inst/unitTests/runit.binary.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2014  Dirk Eddelbuettel
 #

--- a/inst/unitTests/runit.client.package.R
+++ b/inst/unitTests/runit.client.package.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.environments.R
+++ b/inst/unitTests/runit.environments.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
 # Copyright (C) 2009 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.misc.R
+++ b/inst/unitTests/runit.misc.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.modref.R
+++ b/inst/unitTests/runit.modref.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2015  John Chambers, Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.na.R
+++ b/inst/unitTests/runit.na.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Kevin Ushey

--- a/inst/unitTests/runit.rmath.R
+++ b/inst/unitTests/runit.rmath.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; ess-indent-level: 4; tab-width: 4; indent-tabs-mode: nil; -*
 #
 # Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.stats.R
+++ b/inst/unitTests/runit.stats.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2010 - 2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.subset.R
+++ b/inst/unitTests/runit.subset.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #                     -*- mode: R; ess-indent-level: 4; indent-tabs-mode: nil; -*-
 #
 # Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/runit.sugar.var.R
+++ b/inst/unitTests/runit.sugar.var.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #                     -*- mode: R; ess-indent-level: 4; indent-tabs-mode: nil; -*-
 #
 # Copyright (C) 2015 Wush Wu

--- a/inst/unitTests/runit.support.R
+++ b/inst/unitTests/runit.support.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.table.R
+++ b/inst/unitTests/runit.table.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
 #

--- a/inst/unitTests/runit.wrap.R
+++ b/inst/unitTests/runit.wrap.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 #
 # Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
 #

--- a/inst/unitTests/runit.wstring.R
+++ b/inst/unitTests/runit.wstring.R
@@ -1,4 +1,4 @@
-#!/usr/bin/r -t
+#!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
 # Copyright (C) 2013 - 2014  Dirk Eddelbuettel and Romain Francois


### PR DESCRIPTION
This is mostly cleanup along the lines of the earlier (but too large) PR #438 by @ellert

I went over all examples and updated where needed; they now all use `#!/usr/bin/env r`. 