### PR TITLE
Feature/more headers cleanup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,28 @@
+2016-03-07  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/stats/beta.h: Updated Emacs header and copyright
+	* inst/include/Rcpp/stats/binom.h: Idem
+	* inst/include/Rcpp/stats/cauchy.h: Idem
+	* inst/include/Rcpp/stats/chisq.h: Idem
+	* inst/include/Rcpp/stats/f.h: Idem
+	* inst/include/Rcpp/stats/gamma.h: Idem
+	* inst/include/Rcpp/stats/geom.h: Idem
+	* inst/include/Rcpp/stats/hyper.h: Idem
+	* inst/include/Rcpp/stats/nbeta.h: Idem
+	* inst/include/Rcpp/stats/nbinom.h: Idem
+	* inst/include/Rcpp/stats/nbinom_mu.h: Idem
+	* inst/include/Rcpp/stats/nchisq.h: Idem
+	* inst/include/Rcpp/stats/nf.h: Idem
+	* inst/include/Rcpp/stats/nt.h: Idem
+	* inst/include/Rcpp/stats/pois.h: Idem
+	* inst/include/Rcpp/stats/stats.h: Idem
+	* inst/include/Rcpp/stats/t.h: Idem
+	* inst/include/Rcpp/stats/unif.h: Idem
+
 2016-03-05  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/stats/exp.h: Replaced initial Emacs header line with
-        current one, ran M-x untabify and streamlined indentation
+        current one, ran M-x untabify, streamlined indentation, update copyright
         * inst/include/Rcpp/stats/lnorm.h: Idem
         * inst/include/Rcpp/stats/logis.h: Idem
         * inst/include/Rcpp/stats/norm.h: Idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2016-03-09  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/stats/random/rlogis.h: Updated Emacs header and
+        copyright, aligned indentation
+        * inst/include/Rcpp/stats/random/rnbinom.h: Idem
+        * inst/include/Rcpp/stats/random/rnbinom_mu.h: Idem
+        * inst/include/Rcpp/stats/random/rnchisq.h: Idem
+        * inst/include/Rcpp/stats/random/rnorm.h: Idem
+        * inst/include/Rcpp/stats/random/rt.h: Idem
+        * inst/include/Rcpp/stats/random/runif.h: Idem
+        * inst/include/Rcpp/stats/random/rweibull.h: Idem
+        * inst/include/Rcpp/stats/random/random.h: Idem
+
 2016-03-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/stats/beta.h: Updated Emacs header and copyright

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,19 @@
         * inst/include/Rcpp/stats/random/runif.h: Idem
         * inst/include/Rcpp/stats/random/rweibull.h: Idem
         * inst/include/Rcpp/stats/random/random.h: Idem
+        * inst/include/Rcpp/stats/random/rcauchy.h: Idem
+        * inst/include/Rcpp/stats/random/rchisq.h: Idem
+        * inst/include/Rcpp/stats/random/rexp.h: Idem
+        * inst/include/Rcpp/stats/random/rf.h: Idem
+        * inst/include/Rcpp/stats/random/rgeom.h: Idem
+        * inst/include/Rcpp/stats/random/rlnorm.h: Idem
+        * inst/include/Rcpp/stats/random/rbeta.h: Idem
+        * inst/include/Rcpp/stats/random/rbinom.h: Idem
+        * inst/include/Rcpp/stats/random/rgamma.h: Idem
+        * inst/include/Rcpp/stats/random/rhyper.h: Idem
+        * inst/include/Rcpp/stats/random/rpois.h: Idem
+        * inst/include/Rcpp/stats/random/rsignrank.h: Idem
+        * inst/include/Rcpp/stats/random/rwilcox.h: Idem 
 
 2016-03-07  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@
 	* inst/include/Rcpp/stats/stats.h: Idem
 	* inst/include/Rcpp/stats/t.h: Idem
 	* inst/include/Rcpp/stats/unif.h: Idem
+        * inst/include/Rcpp/stats/dpq/dpq.h: Idem
 
 2016-03-05  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/stats/beta.h
+++ b/inst/include/Rcpp/stats/beta.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // beta.h: Rcpp R/C++ interface class library -- beta distribution
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/binom.h
+++ b/inst/include/Rcpp/stats/binom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // binom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/cauchy.h
+++ b/inst/include/Rcpp/stats/cauchy.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // cauchy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,25 +25,27 @@
 namespace Rcpp{
 namespace stats{
 
-inline double dcauchy_0(double x, int give_log){
-	return ::Rf_dcauchy(x,0.0,1.0, give_log) ;
-}
-inline double dcauchy_1(double x, double location, int give_log){
-	return ::Rf_dcauchy(x,location,1.0, give_log) ;
+inline double dcauchy_0(double x, int give_log) {
+    return ::Rf_dcauchy(x,0.0,1.0, give_log) ;
 }
 
-inline double pcauchy_0(double x, int lower_tail, int log_p){
-	return ::Rf_pcauchy(x,0.0,1.0,lower_tail, log_p) ;
-}
-inline double pcauchy_1(double x, double location, int lower_tail, int log_p){
-	return ::Rf_pcauchy(x,location,1.0,lower_tail, log_p) ;
+inline double dcauchy_1(double x, double location, int give_log) {
+    return ::Rf_dcauchy(x,location,1.0, give_log) ;
 }
 
-inline double qcauchy_0(double p, int lower_tail, int log_p){
-	return ::Rf_qcauchy(p, 0.0, 1.0, lower_tail, log_p ) ;
+inline double pcauchy_0(double x, int lower_tail, int log_p) {
+    return ::Rf_pcauchy(x,0.0,1.0,lower_tail, log_p) ;
 }
-inline double qcauchy_1(double p, double location, int lower_tail, int log_p){
-	return ::Rf_qcauchy(p, location, 1.0, lower_tail, log_p ) ;
+
+inline double pcauchy_1(double x, double location, int lower_tail, int log_p) {
+    return ::Rf_pcauchy(x,location,1.0,lower_tail, log_p) ;
+}
+
+inline double qcauchy_0(double p, int lower_tail, int log_p) {
+    return ::Rf_qcauchy(p, 0.0, 1.0, lower_tail, log_p ) ;
+}
+inline double qcauchy_1(double p, double location, int lower_tail, int log_p) {
+    return ::Rf_qcauchy(p, location, 1.0, lower_tail, log_p ) ;
 }
 
 } // stats

--- a/inst/include/Rcpp/stats/chisq.h
+++ b/inst/include/Rcpp/stats/chisq.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // chisq.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/dpq/dpq.h
+++ b/inst/include/Rcpp/stats/dpq/dpq.h
@@ -319,89 +319,89 @@ private:
 namespace Rcpp {                                                                       \
 template <int RTYPE, bool NA, typename T>                                              \
 inline stats::D0<RTYPE,NA,T> d##__NAME__(                                              \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool log = false                          \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool log = false                            \
 ) {                                                                                    \
-    return stats::D0<RTYPE,NA,T>( __D__, x, log );                                           \
+    return stats::D0<RTYPE,NA,T>( __D__, x, log );                                     \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::P0<RTYPE,NA,T> p##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::P0<RTYPE,NA,T> p##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false         \
 ) {                                                                                    \
-    return stats::P0<RTYPE,NA,T>( __P__, x, lower, log );                                    \
+    return stats::P0<RTYPE,NA,T>( __P__, x, lower, log );                              \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::Q0<RTYPE,NA,T> q##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::Q0<RTYPE,NA,T> q##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false         \
 ) {                                                                                    \
-    return stats::Q0<RTYPE,NA,T>( __Q__, x, lower, log );                                    \
+    return stats::Q0<RTYPE,NA,T>( __Q__, x, lower, log );                              \
 } }
 
 
 #define RCPP_DPQ_1(__NAME__,__D__,__P__,__Q__)                                         \
 namespace Rcpp {                                                                       \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::D1<RTYPE,NA,T> d##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool log = false                          \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::D1<RTYPE,NA,T> d##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool log = false                 \
 ) {                                                                                    \
-    return stats::D1<RTYPE,NA,T>( __D__, x, p0, log );                                           \
+    return stats::D1<RTYPE,NA,T>( __D__, x, p0, log );                                 \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::P1<RTYPE,NA,T> p##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::P1<RTYPE,NA,T> p##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false \
 ) {                                                                                    \
-    return stats::P1<RTYPE,NA,T>( __P__, x, p0, lower, log );                                    \
+    return stats::P1<RTYPE,NA,T>( __P__, x, p0, lower, log );                          \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::Q1<RTYPE,NA,T> q##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::Q1<RTYPE,NA,T> q##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false \
 ) {                                                                                    \
-    return stats::Q1<RTYPE,NA,T>( __Q__, x, p0, lower, log );                                    \
+    return stats::Q1<RTYPE,NA,T>( __Q__, x, p0, lower, log );                          \
 } }
 
 
 
 #define RCPP_DPQ_2(__NAME__,__D__,__P__,__Q__)                                         \
 namespace Rcpp {                                                                       \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::D2<RTYPE,NA,T> d##__NAME__(                                                    \
-    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool log = false                          \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::D2<RTYPE,NA,T> d##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool log = false      \
 ) {                                                                                    \
-    return stats::D2<RTYPE,NA,T>( __D__, x, p0, p1, log );                                           \
+    return stats::D2<RTYPE,NA,T>( __D__, x, p0, p1, log );                             \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::P2<RTYPE,NA,T> p##__NAME__(                                                    \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::P2<RTYPE,NA,T> p##__NAME__(                                              \
     const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
 ) {                                                                                    \
-    return stats::P2<RTYPE,NA,T>( __P__, x, p0, p1, lower, log );                                    \
+    return stats::P2<RTYPE,NA,T>( __P__, x, p0, p1, lower, log );                      \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::Q2<RTYPE,NA,T> q##__NAME__(                                                    \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::Q2<RTYPE,NA,T> q##__NAME__(                                              \
     const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
 ) {                                                                                    \
-    return stats::Q2<RTYPE,NA,T>( __Q__, x, p0, p1, lower, log );                                    \
+    return stats::Q2<RTYPE,NA,T>( __Q__, x, p0, p1, lower, log );                      \
 } }
 
 
 
 #define RCPP_DPQ_3(__NAME__,__D__,__P__,__Q__)                                         \
 namespace Rcpp {                                                                       \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::D3<RTYPE,NA,T> d##__NAME__(                                                    \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::D3<RTYPE,NA,T> d##__NAME__(                                              \
     const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool log = false                          \
 ) {                                                                                    \
-    return stats::D3<RTYPE,NA,T>( __D__, x, p0, p1, p2, log );                                           \
+    return stats::D3<RTYPE,NA,T>( __D__, x, p0, p1, p2, log );                         \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::P3<RTYPE,NA,T> p##__NAME__(                                                    \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::P3<RTYPE,NA,T> p##__NAME__(                                              \
     const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
 ) {                                                                                    \
-    return stats::P3<RTYPE,NA,T>( __P__, x, p0, p1, p2, lower, log );                                    \
+    return stats::P3<RTYPE,NA,T>( __P__, x, p0, p1, p2, lower, log );                  \
 }                                                                                      \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::Q3<RTYPE,NA,T> q##__NAME__(                                                    \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::Q3<RTYPE,NA,T> q##__NAME__(                                              \
     const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
 ) {                                                                                    \
-    return stats::Q3<RTYPE,NA,T>( __Q__, x, p0, p1, p2, lower, log );                                    \
+    return stats::Q3<RTYPE,NA,T>( __Q__, x, p0, p1, p2, lower, log );                  \
 } }
 
 

--- a/inst/include/Rcpp/stats/dpq/dpq.h
+++ b/inst/include/Rcpp/stats/dpq/dpq.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // dpq.h: Rcpp R/C++ interface class library -- normal distribution
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -27,292 +27,289 @@
 namespace Rcpp {
 namespace stats {
 
-	// D
-
-	template <int RTYPE, bool NA, typename T>
-	class D0 : public Rcpp::VectorBase< REALSXP, NA, D0<RTYPE,NA,T> > {
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,int) ;
-
-		D0( FunPtr ptr_, const VEC_TYPE& vec_, bool log_ ) :
-			ptr(ptr_), vec(vec_), log(log_) {}
-
-		inline double operator[]( int i) const {
-			return ptr( vec[i], log );
-		}
-
-		inline int size() const { return vec.size(); }
+// D
+
+template <int RTYPE, bool NA, typename T>
+class D0 : public Rcpp::VectorBase< REALSXP, NA, D0<RTYPE,NA,T> > {
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,int) ;
+
+    D0( FunPtr ptr_, const VEC_TYPE& vec_, bool log_ ) :
+        ptr(ptr_), vec(vec_), log(log_) {}
+
+    inline double operator[]( int i) const {
+        return ptr( vec[i], log );
+    }
+
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		int log;
-	} ;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    int log;
+};
 
-	template <int RTYPE, bool NA, typename T>
-	class D1 : public Rcpp::VectorBase< REALSXP, NA, D1<RTYPE,NA,T> > {
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,int) ;
+template <int RTYPE, bool NA, typename T>
+class D1 : public Rcpp::VectorBase< REALSXP, NA, D1<RTYPE,NA,T> > {
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,int) ;
 
-		D1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_ , bool log_) :
-			ptr(ptr_), vec(vec_), p0(p0_), log(log_) {}
+    D1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_ , bool log_) :
+        ptr(ptr_), vec(vec_), p0(p0_), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, log );
+    }
 
-		inline int size() const { return vec.size(); }
-
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0 ;
-		int log;
-	} ;
+    inline int size() const { return vec.size(); }
+
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0 ;
+    int log;
+} ;
 
-	template <int RTYPE, bool NA, typename T>
-	class D2 : public Rcpp::VectorBase< REALSXP, NA, D2<RTYPE,NA,T> > {
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,int) ;
+template <int RTYPE, bool NA, typename T>
+class D2 : public Rcpp::VectorBase< REALSXP, NA, D2<RTYPE,NA,T> > {
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,int) ;
 
-		D2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_ , bool log_) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), log(log_) {}
+    D2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_ , bool log_) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, log );
+    }
 
-		inline int size() const { return vec.size(); }
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1 ;
-		int log;
-	} ;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1 ;
+    int log;
+} ;
 
-	template <int RTYPE, bool NA, typename T>
-	class D3 : public Rcpp::VectorBase< REALSXP, NA, D3<RTYPE,NA,T> > {
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,double,int) ;
+template <int RTYPE, bool NA, typename T>
+class D3 : public Rcpp::VectorBase< REALSXP, NA, D3<RTYPE,NA,T> > {
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,double,int) ;
 
-		D3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_ , bool log_ ) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), log(log_) {}
+    D3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_ , bool log_ ) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, p2, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, p2, log );
+    }
 
-		inline int size() const { return vec.size(); }
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1, p2 ;
-		int log;
-	} ;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1, p2 ;
+    int log;
+} ;
 
-	// P
+// P
 
 
-	template <int RTYPE, bool NA, typename T>
-	class P0 : public Rcpp::VectorBase< REALSXP, NA, P0<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,int,int) ;
+template <int RTYPE, bool NA, typename T>
+class P0 : public Rcpp::VectorBase< REALSXP, NA, P0<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,int,int) ;
 
-		P0( FunPtr ptr_, const VEC_TYPE& vec_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
+    P0( FunPtr ptr_, const VEC_TYPE& vec_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], lower, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], lower, log );
+    }
 
-		inline int size() const { return vec.size(); }
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		int lower, log;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    int lower, log;
 
-	};
+};
 
 
-	template <int RTYPE, bool NA, typename T>
-	class P1 : public Rcpp::VectorBase< REALSXP, NA, P1<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,int,int) ;
+template <int RTYPE, bool NA, typename T>
+class P1 : public Rcpp::VectorBase< REALSXP, NA, P1<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,int,int) ;
 
-		P1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
+    P1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, lower, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, lower, log );
+    }
 
-		inline int size() const { return vec.size(); }
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0 ;
-		int lower, log;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0 ;
+    int lower, log;
 
-	};
+};
 
 
-	template <int RTYPE, bool NA, typename T>
-	class P2 : public Rcpp::VectorBase< REALSXP, NA, P2<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,int,int) ;
+template <int RTYPE, bool NA, typename T>
+class P2 : public Rcpp::VectorBase< REALSXP, NA, P2<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,int,int) ;
 
-		P2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
+    P2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, lower, log );
-		}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, lower, log );
+    }
 
-		inline int size() const { return vec.size(); }
+    inline int size() const { return vec.size(); }
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1 ;
-		int lower, log;
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1 ;
+    int lower, log;
+};
 
-	};
+template <int RTYPE, bool NA, typename T>
+class P3 : public Rcpp::VectorBase< REALSXP, NA, P3<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,double,int,int) ;
 
-	template <int RTYPE, bool NA, typename T>
-	class P3 : public Rcpp::VectorBase< REALSXP, NA, P3<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,double,int,int) ;
+    P3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
 
-		P3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, p2, lower, log );
+    }
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, p2, lower, log );
-		}
+    inline int size() const { return vec.size(); }
 
-		inline int size() const { return vec.size(); }
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1,p2 ;
+    int lower, log;
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1,p2 ;
-		int lower, log;
+};
 
-	};
+// Q
 
-	// Q
+template <int RTYPE, bool NA, typename T>
+class Q0 : public Rcpp::VectorBase< REALSXP, NA, Q0<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,int,int) ;
 
+    Q0( FunPtr ptr_, const VEC_TYPE& vec_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
 
-	template <int RTYPE, bool NA, typename T>
-	class Q0 : public Rcpp::VectorBase< REALSXP, NA, Q0<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,int,int) ;
+    inline double operator[]( int i) const {
+        return ptr( vec[i], lower, log );
+    }
 
-		Q0( FunPtr ptr_, const VEC_TYPE& vec_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
+    inline int size() const { return vec.size(); }
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], lower, log );
-		}
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    int lower, log;
 
-		inline int size() const { return vec.size(); }
+};
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		int lower, log;
+template <int RTYPE, bool NA, typename T>
+class Q1 : public Rcpp::VectorBase< REALSXP, NA, Q1<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,int,int) ;
 
-	};
+    Q1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
 
-	template <int RTYPE, bool NA, typename T>
-	class Q1 : public Rcpp::VectorBase< REALSXP, NA, Q1<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,int,int) ;
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, lower, log );
+    }
 
-		Q1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
+    inline int size() const { return vec.size(); }
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, lower, log );
-		}
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0 ;
+    int lower, log;
 
-		inline int size() const { return vec.size(); }
+};
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0 ;
-		int lower, log;
+template <int RTYPE, bool NA, typename T>
+class Q2 : public Rcpp::VectorBase< REALSXP, NA, Q2<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,int,int) ;
 
-	};
+    Q2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
 
-	template <int RTYPE, bool NA, typename T>
-	class Q2 : public Rcpp::VectorBase< REALSXP, NA, Q2<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,int,int) ;
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, lower, log );
+    }
 
-		Q2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
+    inline int size() const { return vec.size(); }
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, lower, log );
-		}
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1 ;
+    int lower, log;
 
-		inline int size() const { return vec.size(); }
+};
 
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1 ;
-		int lower, log;
+template <int RTYPE, bool NA, typename T>
+class Q3 : public Rcpp::VectorBase< REALSXP, NA, Q3<RTYPE,NA,T> >{
+public:
+    typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
+    typedef double (*FunPtr)(double,double,double,double,int,int) ;
 
-	};
+    Q3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_,
+        bool lower_tail = true, bool log_ = false ) :
+        ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
 
-	template <int RTYPE, bool NA, typename T>
-	class Q3 : public Rcpp::VectorBase< REALSXP, NA, Q3<RTYPE,NA,T> >{
-	public:
-		typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
-		typedef double (*FunPtr)(double,double,double,double,int,int) ;
+    inline double operator[]( int i) const {
+        return ptr( vec[i], p0, p1, p2, lower, log );
+    }
 
-		Q3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_,
-			   bool lower_tail = true, bool log_ = false ) :
-			ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
+    inline int size() const { return vec.size(); }
 
-		inline double operator[]( int i) const {
-			return ptr( vec[i], p0, p1, p2, lower, log );
-		}
-
-		inline int size() const { return vec.size(); }
-
-	private:
-		FunPtr ptr ;
-		const VEC_TYPE& vec;
-		double p0, p1, p2 ;
-		int lower, log;
-
-	};
+private:
+    FunPtr ptr ;
+    const VEC_TYPE& vec;
+    double p0, p1, p2 ;
+    int lower, log;
+};
 
 
 } // stats
@@ -320,23 +317,23 @@ namespace stats {
 
 #define RCPP_DPQ_0(__NAME__,__D__,__P__,__Q__)                                         \
 namespace Rcpp {                                                                       \
-template <int RTYPE, bool NA, typename T>                                                         \
-inline stats::D0<RTYPE,NA,T> d##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, bool log = false                          \
+template <int RTYPE, bool NA, typename T>                                              \
+inline stats::D0<RTYPE,NA,T> d##__NAME__(                                              \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool log = false                          \
 ) {                                                                                    \
-	return stats::D0<RTYPE,NA,T>( __D__, x, log );                                           \
+    return stats::D0<RTYPE,NA,T>( __D__, x, log );                                           \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::P0<RTYPE,NA,T> p##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::P0<RTYPE,NA,T>( __P__, x, lower, log );                                    \
+    return stats::P0<RTYPE,NA,T>( __P__, x, lower, log );                                    \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::Q0<RTYPE,NA,T> q##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::Q0<RTYPE,NA,T>( __Q__, x, lower, log );                                    \
+    return stats::Q0<RTYPE,NA,T>( __Q__, x, lower, log );                                    \
 } }
 
 
@@ -344,21 +341,21 @@ inline stats::Q0<RTYPE,NA,T> q##__NAME__(                                       
 namespace Rcpp {                                                                       \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::D1<RTYPE,NA,T> d##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool log = false                          \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool log = false                          \
 ) {                                                                                    \
-	return stats::D1<RTYPE,NA,T>( __D__, x, p0, log );                                           \
+    return stats::D1<RTYPE,NA,T>( __D__, x, p0, log );                                           \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::P1<RTYPE,NA,T> p##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::P1<RTYPE,NA,T>( __P__, x, p0, lower, log );                                    \
+    return stats::P1<RTYPE,NA,T>( __P__, x, p0, lower, log );                                    \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::Q1<RTYPE,NA,T> q##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::Q1<RTYPE,NA,T>( __Q__, x, p0, lower, log );                                    \
+    return stats::Q1<RTYPE,NA,T>( __Q__, x, p0, lower, log );                                    \
 } }
 
 
@@ -367,21 +364,21 @@ inline stats::Q1<RTYPE,NA,T> q##__NAME__(                                       
 namespace Rcpp {                                                                       \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::D2<RTYPE,NA,T> d##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool log = false                          \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool log = false                          \
 ) {                                                                                    \
-	return stats::D2<RTYPE,NA,T>( __D__, x, p0, p1, log );                                           \
+    return stats::D2<RTYPE,NA,T>( __D__, x, p0, p1, log );                                           \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::P2<RTYPE,NA,T> p##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::P2<RTYPE,NA,T>( __P__, x, p0, p1, lower, log );                                    \
+    return stats::P2<RTYPE,NA,T>( __P__, x, p0, p1, lower, log );                                    \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::Q2<RTYPE,NA,T> q##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::Q2<RTYPE,NA,T>( __Q__, x, p0, p1, lower, log );                                    \
+    return stats::Q2<RTYPE,NA,T>( __Q__, x, p0, p1, lower, log );                                    \
 } }
 
 
@@ -390,21 +387,21 @@ inline stats::Q2<RTYPE,NA,T> q##__NAME__(                                       
 namespace Rcpp {                                                                       \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::D3<RTYPE,NA,T> d##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool log = false                          \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool log = false                          \
 ) {                                                                                    \
-	return stats::D3<RTYPE,NA,T>( __D__, x, p0, p1, p2, log );                                           \
+    return stats::D3<RTYPE,NA,T>( __D__, x, p0, p1, p2, log );                                           \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::P3<RTYPE,NA,T> p##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::P3<RTYPE,NA,T>( __P__, x, p0, p1, p2, lower, log );                                    \
+    return stats::P3<RTYPE,NA,T>( __P__, x, p0, p1, p2, lower, log );                                    \
 }                                                                                      \
 template <int RTYPE, bool NA, typename T>                                                         \
 inline stats::Q3<RTYPE,NA,T> q##__NAME__(                                                    \
-	const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
+    const Rcpp::VectorBase<RTYPE,NA,T>& x, double p0, double p1, double p2, bool lower = true, bool log = false       \
 ) {                                                                                    \
-	return stats::Q3<RTYPE,NA,T>( __Q__, x, p0, p1, p2, lower, log );                                    \
+    return stats::Q3<RTYPE,NA,T>( __Q__, x, p0, p1, p2, lower, log );                                    \
 } }
 
 

--- a/inst/include/Rcpp/stats/f.h
+++ b/inst/include/Rcpp/stats/f.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // f.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/gamma.h
+++ b/inst/include/Rcpp/stats/gamma.h
@@ -1,11 +1,10 @@
-
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // auto generated file (from script/stats.R)
 //
 // gamma.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -36,29 +35,29 @@ inline double dgamma_1(double x, double shape, int log_p){
 #endif
     if (shape < 0) return R_NaN ;
     if (x < 0)
-	return R_D__0;
+        return R_D__0;
     if (shape == 0) /* point mass at 0 */
-	return (x == 0)? ML_POSINF : R_D__0;
+        return (x == 0)? ML_POSINF : R_D__0;
     if (x == 0) {
-	if (shape < 1) return ML_POSINF;
-	if (shape > 1) return R_D__0;
-	/* else */
-	return log_p ? 0.0 : 1.0 ;
+        if (shape < 1) return ML_POSINF;
+        if (shape > 1) return R_D__0;
+        /* else */
+        return log_p ? 0.0 : 1.0 ;
     }
 
     if (shape < 1) {
-    	pr = ::Rf_dpois(shape, x, log_p);
-	return log_p ?  pr + ::log(shape/x) : pr*shape/x;
+        pr = ::Rf_dpois(shape, x, log_p);
+        return log_p ?  pr + ::log(shape/x) : pr*shape/x;
     }
     /* else  shape >= 1 */
     pr = ::Rf_dpois(shape-1, x, log_p);
     return pr;
 }
 inline double pgamma_1(double x, double alph, int lower_tail, int log_p){
-	return ::Rf_pgamma(x, alph, 1.0, lower_tail, log_p) ;
+    return ::Rf_pgamma(x, alph, 1.0, lower_tail, log_p) ;
 }
 inline double qgamma_1(double p, double alpha, int lower_tail, int log_p){
-	return ::Rf_qgamma(p, alpha, 1.0, lower_tail, log_p );
+    return ::Rf_qgamma(p, alpha, 1.0, lower_tail, log_p );
 }
 
 }

--- a/inst/include/Rcpp/stats/geom.h
+++ b/inst/include/Rcpp/stats/geom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // geom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/hyper.h
+++ b/inst/include/Rcpp/stats/hyper.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // hyper.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nbeta.h
+++ b/inst/include/Rcpp/stats/nbeta.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nbeta.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012  Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nbinom.h
+++ b/inst/include/Rcpp/stats/nbinom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nbinom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nbinom_mu.h
+++ b/inst/include/Rcpp/stats/nbinom_mu.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nbinom_mu.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nchisq.h
+++ b/inst/include/Rcpp/stats/nchisq.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nchisq.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nf.h
+++ b/inst/include/Rcpp/stats/nf.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nf.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/nt.h
+++ b/inst/include/Rcpp/stats/nt.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // nt.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/pois.h
+++ b/inst/include/Rcpp/stats/pois.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // pois.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/random/random.h
+++ b/inst/include/Rcpp/stats/random/random.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // random.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -26,15 +26,15 @@ namespace Rcpp{
 
 class RNGScope{
 public:
-	RNGScope(){ internal::enterRNGScope(); }
-	~RNGScope(){ internal::exitRNGScope(); }
-} ;
+    RNGScope(){ internal::enterRNGScope(); }
+    ~RNGScope(){ internal::exitRNGScope(); }
+};
 
 template <typename T>
 class Generator : public RNGScope {
 public:
-	typedef T r_generator ;
-} ;
+    typedef T r_generator ;
+};
 
 }
 #include <Rcpp/stats/random/rnorm.h>
@@ -61,278 +61,278 @@ public:
 
 namespace Rcpp{
 
-    inline NumericVector rnorm( int n, double mean, double sd){
-		if (ISNAN(mean) || !R_FINITE(sd) || sd < 0.){
-			// TODO: R also throws a warning in that case, should we ?
-			return NumericVector( n, R_NaN ) ;
-		}  else if (sd == 0. || !R_FINITE(mean)){
-			return NumericVector( n, mean ) ;
-		} else {
-			bool sd1 = sd == 1.0 ;
-			bool mean0 = mean == 0.0 ;
-			if( sd1 && mean0 ){
-				return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
-			} else if( sd1 ){
-				return NumericVector( n, stats::NormGenerator__sd1( mean ) );
-			} else if( mean0 ){
-				return NumericVector( n, stats::NormGenerator__mean0( sd ) );
-			} else {
-				// general case
-				return NumericVector( n, stats::NormGenerator( mean, sd ) );
-			}
-		}
-	}
-
-	inline NumericVector rnorm( int n, double mean /*, double sd [=1.0] */ ){
-		if (ISNAN(mean) ){
-			// TODO: R also throws a warning in that case, should we ?
-			return NumericVector( n, R_NaN ) ;
-		}  else if ( !R_FINITE(mean)){
-			return NumericVector( n, mean ) ;
-		} else {
-			bool mean0 = mean == 0.0 ;
-			if( mean0 ){
-				return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
-			} else {
-				return NumericVector( n, stats::NormGenerator__sd1( mean ) );
-			}
-		}
-	}
-
-	inline NumericVector rnorm( int n /*, double mean [=0.0], double sd [=1.0] */ ){
-		return NumericVector( n, stats::NormGenerator() ) ;
-	}
-
-	inline NumericVector rbeta( int n, double a, double b ){
-		return NumericVector( n, stats::BetaGenerator(a, b ) ) ;
-	}
-
-    inline NumericVector rbinom( int n, double nin, double pp ){
-		return NumericVector( n, stats::BinomGenerator(nin, pp) ) ;
-	}
-
-	inline NumericVector rcauchy( int n, double location, double scale ){
-        if (ISNAN(location) || !R_FINITE(scale) || scale < 0)
-            return NumericVector( n, R_NaN ) ;
-
-        if (scale == 0. || !R_FINITE(location))
-            return NumericVector( n, location ) ;
-
-        return NumericVector( n, stats::CauchyGenerator( location, scale ) ) ;
+inline NumericVector rnorm( int n, double mean, double sd){
+    if (ISNAN(mean) || !R_FINITE(sd) || sd < 0.){
+        // TODO: R also throws a warning in that case, should we ?
+        return NumericVector( n, R_NaN ) ;
+    }  else if (sd == 0. || !R_FINITE(mean)){
+        return NumericVector( n, mean ) ;
+    } else {
+        bool sd1 = sd == 1.0 ;
+        bool mean0 = mean == 0.0 ;
+        if( sd1 && mean0 ){
+            return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
+        } else if( sd1 ){
+            return NumericVector( n, stats::NormGenerator__sd1( mean ) );
+        } else if( mean0 ){
+            return NumericVector( n, stats::NormGenerator__mean0( sd ) );
+        } else {
+            // general case
+            return NumericVector( n, stats::NormGenerator( mean, sd ) );
+        }
     }
+}
 
-    inline NumericVector rcauchy( int n, double location /* , double scale [=1.0] */ ){
-        if (ISNAN(location))
-            return NumericVector( n, R_NaN ) ;
-
-        if (!R_FINITE(location))
-            return NumericVector( n, location ) ;
-
-        return NumericVector( n, stats::CauchyGenerator_1( location ) ) ;
+inline NumericVector rnorm( int n, double mean /*, double sd [=1.0] */ ){
+    if (ISNAN(mean) ){
+        // TODO: R also throws a warning in that case, should we ?
+        return NumericVector( n, R_NaN ) ;
+    }  else if ( !R_FINITE(mean)){
+        return NumericVector( n, mean ) ;
+    } else {
+        bool mean0 = mean == 0.0 ;
+        if( mean0 ){
+            return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
+        } else {
+            return NumericVector( n, stats::NormGenerator__sd1( mean ) );
+        }
     }
+}
 
-    inline NumericVector rcauchy( int n /*, double location [=0.0] , double scale [=1.0] */ ){
-        return NumericVector( n, stats::CauchyGenerator_0() ) ;
+inline NumericVector rnorm( int n /*, double mean [=0.0], double sd [=1.0] */ ){
+    return NumericVector( n, stats::NormGenerator() ) ;
+}
+
+inline NumericVector rbeta( int n, double a, double b ){
+    return NumericVector( n, stats::BetaGenerator(a, b ) ) ;
+}
+
+inline NumericVector rbinom( int n, double nin, double pp ){
+    return NumericVector( n, stats::BinomGenerator(nin, pp) ) ;
+}
+
+inline NumericVector rcauchy( int n, double location, double scale ){
+    if (ISNAN(location) || !R_FINITE(scale) || scale < 0)
+        return NumericVector( n, R_NaN ) ;
+
+    if (scale == 0. || !R_FINITE(location))
+        return NumericVector( n, location ) ;
+
+    return NumericVector( n, stats::CauchyGenerator( location, scale ) ) ;
+}
+
+inline NumericVector rcauchy( int n, double location /* , double scale [=1.0] */ ){
+    if (ISNAN(location))
+        return NumericVector( n, R_NaN ) ;
+
+    if (!R_FINITE(location))
+        return NumericVector( n, location ) ;
+
+    return NumericVector( n, stats::CauchyGenerator_1( location ) ) ;
+}
+
+inline NumericVector rcauchy( int n /*, double location [=0.0] , double scale [=1.0] */ ){
+    return NumericVector( n, stats::CauchyGenerator_0() ) ;
+}
+
+inline NumericVector rchisq( int n, double df ){
+    if (!R_FINITE(df) || df < 0.0) return NumericVector(n, R_NaN) ;
+    return NumericVector( n, stats::ChisqGenerator( df ) ) ;
+}
+
+inline NumericVector rexp( int n, double rate ){
+    double scale = 1.0 / rate ;
+    if (!R_FINITE(scale) || scale <= 0.0) {
+        if(scale == 0.) return NumericVector( n, 0.0 ) ;
+        /* else */
+        return NumericVector( n, R_NaN ) ;
     }
+    return NumericVector( n, stats::ExpGenerator( scale ) ) ;
+}
 
-    inline NumericVector rchisq( int n, double df ){
-		if (!R_FINITE(df) || df < 0.0) return NumericVector(n, R_NaN) ;
-		return NumericVector( n, stats::ChisqGenerator( df ) ) ;
-	}
+inline NumericVector rexp( int n /* , rate = 1 */ ){
+    return NumericVector( n, stats::ExpGenerator__rate1() ) ;
+}
 
-	inline NumericVector rexp( int n, double rate ){
-		double scale = 1.0 / rate ;
-		if (!R_FINITE(scale) || scale <= 0.0) {
-			if(scale == 0.) return NumericVector( n, 0.0 ) ;
-			/* else */
-			return NumericVector( n, R_NaN ) ;
-		}
-		return NumericVector( n, stats::ExpGenerator( scale ) ) ;
-	}
+inline NumericVector rf( int n, double n1, double n2 ){
+    if (ISNAN(n1) || ISNAN(n2) || n1 <= 0. || n2 <= 0.)
+        return NumericVector( n, R_NaN ) ;
+    if( R_FINITE( n1 ) && R_FINITE( n2 ) ){
+        return NumericVector( n, stats::FGenerator_Finite_Finite( n1, n2 ) ) ;
+    } else if( ! R_FINITE( n1 ) && ! R_FINITE( n2 ) ){
+        return NumericVector( n, 1.0 ) ;
+    } else if( ! R_FINITE( n1 ) ) {
+        return NumericVector( n, stats::FGenerator_NotFinite_Finite( n2 ) ) ;
+    } else {
+        return NumericVector( n, stats::FGenerator_Finite_NotFinite( n1 ) ) ;
+    }
+}
 
-	inline NumericVector rexp( int n /* , rate = 1 */ ){
-		return NumericVector( n, stats::ExpGenerator__rate1() ) ;
-	}
+inline NumericVector rgamma( int n, double a, double scale ){
+    if (!R_FINITE(a) || !R_FINITE(scale) || a < 0.0 || scale <= 0.0) {
+        if(scale == 0.) return NumericVector( n, 0.) ;
+        return NumericVector( n, R_NaN ) ;
+    }
+    if( a == 0. ) return NumericVector(n, 0. ) ;
+    return NumericVector( n, stats::GammaGenerator(a, scale) ) ;
+}
 
-	inline NumericVector rf( int n, double n1, double n2 ){
-		if (ISNAN(n1) || ISNAN(n2) || n1 <= 0. || n2 <= 0.)
-			return NumericVector( n, R_NaN ) ;
-		if( R_FINITE( n1 ) && R_FINITE( n2 ) ){
-			return NumericVector( n, stats::FGenerator_Finite_Finite( n1, n2 ) ) ;
-		} else if( ! R_FINITE( n1 ) && ! R_FINITE( n2 ) ){
-			return NumericVector( n, 1.0 ) ;
-		} else if( ! R_FINITE( n1 ) ) {
-			return NumericVector( n, stats::FGenerator_NotFinite_Finite( n2 ) ) ;
-		} else {
-			return NumericVector( n, stats::FGenerator_Finite_NotFinite( n1 ) ) ;
-		}
-	}
+inline NumericVector rgamma( int n, double a /* scale = 1.0 */ ){
+    if (!R_FINITE(a) || a < 0.0 ) {
+        return NumericVector( n, R_NaN ) ;
+    }
+    if( a == 0. ) return NumericVector(n, 0. ) ;
+    /* TODO: check if we can take advantage of the scale = 1 special case */
+    return NumericVector( n, stats::GammaGenerator(a, 1.0) ) ;
+}
 
-	inline NumericVector rgamma( int n, double a, double scale ){
-		if (!R_FINITE(a) || !R_FINITE(scale) || a < 0.0 || scale <= 0.0) {
-			if(scale == 0.) return NumericVector( n, 0.) ;
-			return NumericVector( n, R_NaN ) ;
-		}
-		if( a == 0. ) return NumericVector(n, 0. ) ;
-		return NumericVector( n, stats::GammaGenerator(a, scale) ) ;
-	}
+inline NumericVector rgeom( int n, double p ){
+    if (!R_FINITE(p) || p <= 0 || p > 1)
+        return NumericVector( n, R_NaN );
+    return NumericVector( n, stats::GeomGenerator( p ) ) ;
+}
 
-	inline NumericVector rgamma( int n, double a /* scale = 1.0 */ ){
-		if (!R_FINITE(a) || a < 0.0 ) {
-			return NumericVector( n, R_NaN ) ;
-		}
-		if( a == 0. ) return NumericVector(n, 0. ) ;
-		/* TODO: check if we can take advantage of the scale = 1 special case */
-		return NumericVector( n, stats::GammaGenerator(a, 1.0) ) ;
-	}
+inline NumericVector rhyper( int n, double nn1, double nn2, double kk ){
+    return NumericVector( n, stats::HyperGenerator( nn1, nn2, kk ) ) ;
+}
 
-	inline NumericVector rgeom( int n, double p ){
-		if (!R_FINITE(p) || p <= 0 || p > 1)
-			return NumericVector( n, R_NaN );
-		return NumericVector( n, stats::GeomGenerator( p ) ) ;
-	}
+inline NumericVector rlnorm( int n, double meanlog, double sdlog ){
+    if (ISNAN(meanlog) || !R_FINITE(sdlog) || sdlog < 0.){
+        // TODO: R also throws a warning in that case, should we ?
+        return NumericVector( n, R_NaN ) ;
+    }  else if (sdlog == 0. || !R_FINITE(meanlog)){
+        return NumericVector( n, ::exp( meanlog ) ) ;
+    } else {
+        return NumericVector( n, stats::LNormGenerator( meanlog, sdlog ) );
+    }
+}
 
-	inline NumericVector rhyper( int n, double nn1, double nn2, double kk ){
-		return NumericVector( n, stats::HyperGenerator( nn1, nn2, kk ) ) ;
-	}
+inline NumericVector rlnorm( int n, double meanlog /*, double sdlog = 1.0 */){
+    if (ISNAN(meanlog) ){
+        // TODO: R also throws a warning in that case, should we ?
+        return NumericVector( n, R_NaN ) ;
+    }  else if ( !R_FINITE(meanlog)){
+        return NumericVector( n, ::exp( meanlog ) ) ;
+    } else {
+        return NumericVector( n, stats::LNormGenerator_1( meanlog ) );
+    }
+}
 
-	inline NumericVector rlnorm( int n, double meanlog, double sdlog ){
-		if (ISNAN(meanlog) || !R_FINITE(sdlog) || sdlog < 0.){
-			// TODO: R also throws a warning in that case, should we ?
-			return NumericVector( n, R_NaN ) ;
-		}  else if (sdlog == 0. || !R_FINITE(meanlog)){
-			return NumericVector( n, ::exp( meanlog ) ) ;
-		} else {
-			return NumericVector( n, stats::LNormGenerator( meanlog, sdlog ) );
-		}
-	}
+inline NumericVector rlnorm( int n /*, double meanlog [=0.], double sdlog = 1.0 */){
+    return NumericVector( n, stats::LNormGenerator_0( ) );
+}
 
-	inline NumericVector rlnorm( int n, double meanlog /*, double sdlog = 1.0 */){
-		if (ISNAN(meanlog) ){
-			// TODO: R also throws a warning in that case, should we ?
-			return NumericVector( n, R_NaN ) ;
-		}  else if ( !R_FINITE(meanlog)){
-			return NumericVector( n, ::exp( meanlog ) ) ;
-		} else {
-			return NumericVector( n, stats::LNormGenerator_1( meanlog ) );
-		}
-	}
+inline NumericVector rlogis( int n, double location, double scale ){
+    if (ISNAN(location) || !R_FINITE(scale))
+        return NumericVector( n, R_NaN ) ;
 
-	inline NumericVector rlnorm( int n /*, double meanlog [=0.], double sdlog = 1.0 */){
-		return NumericVector( n, stats::LNormGenerator_0( ) );
-	}
+    if (scale == 0. || !R_FINITE(location))
+        return NumericVector( n, location );
 
-	inline NumericVector rlogis( int n, double location, double scale ){
-		if (ISNAN(location) || !R_FINITE(scale))
-			return NumericVector( n, R_NaN ) ;
+    return NumericVector( n, stats::LogisGenerator( location, scale ) ) ;
+}
 
-		if (scale == 0. || !R_FINITE(location))
-			return NumericVector( n, location );
+inline NumericVector rlogis( int n, double location /*, double scale =1.0 */ ){
+    if (ISNAN(location) )
+        return NumericVector( n, R_NaN ) ;
 
-		return NumericVector( n, stats::LogisGenerator( location, scale ) ) ;
-	}
+    if (!R_FINITE(location))
+        return NumericVector( n, location );
 
-	inline NumericVector rlogis( int n, double location /*, double scale =1.0 */ ){
-		if (ISNAN(location) )
-			return NumericVector( n, R_NaN ) ;
+    return NumericVector( n, stats::LogisGenerator_1( location ) ) ;
+}
 
-		if (!R_FINITE(location))
-			return NumericVector( n, location );
+inline NumericVector rlogis( int n /*, double location [=0.0], double scale =1.0 */ ){
+    return NumericVector( n, stats::LogisGenerator_0() ) ;
+}
 
-		return NumericVector( n, stats::LogisGenerator_1( location ) ) ;
-	}
+inline NumericVector rnbinom( int n, double siz, double prob ){
+    if(!R_FINITE(siz) || !R_FINITE(prob) || siz <= 0 || prob <= 0 || prob > 1)
+        /* prob = 1 is ok, PR#1218 */
+        return NumericVector( n, R_NaN ) ;
 
-	inline NumericVector rlogis( int n /*, double location [=0.0], double scale =1.0 */ ){
-		return NumericVector( n, stats::LogisGenerator_0() ) ;
-	}
+    return NumericVector( n, stats::NBinomGenerator( siz, prob ) ) ;
+}
 
-	inline NumericVector rnbinom( int n, double siz, double prob ){
-		if(!R_FINITE(siz) || !R_FINITE(prob) || siz <= 0 || prob <= 0 || prob > 1)
-			/* prob = 1 is ok, PR#1218 */
-			return NumericVector( n, R_NaN ) ;
+inline NumericVector rnbinom_mu( int n, double siz, double mu ){
+    if(!R_FINITE(siz) || !R_FINITE(mu) || siz <= 0 || mu < 0)
+        return NumericVector( n, R_NaN ) ;
 
-		return NumericVector( n, stats::NBinomGenerator( siz, prob ) ) ;
-	}
+    return NumericVector( n, stats::NBinomGenerator_Mu( siz, mu ) ) ;
+}
 
-	inline NumericVector rnbinom_mu( int n, double siz, double mu ){
-		if(!R_FINITE(siz) || !R_FINITE(mu) || siz <= 0 || mu < 0)
-			return NumericVector( n, R_NaN ) ;
+inline NumericVector rnchisq( int n, double df, double lambda ){
+    if (!R_FINITE(df) || !R_FINITE(lambda) || df < 0. || lambda < 0.)
+        return NumericVector(n, R_NaN) ;
+    if( lambda == 0.0 ){
+        // using the central generator, see rchisq.h
+        return NumericVector( n, stats::ChisqGenerator( df ) ) ;
+    }
+    return NumericVector( n, stats::NChisqGenerator( df, lambda ) ) ;
+}
 
-		return NumericVector( n, stats::NBinomGenerator_Mu( siz, mu ) ) ;
-	}
+inline NumericVector rnchisq( int n, double df /*, double lambda = 0.0 */ ){
+    if (!R_FINITE(df) || df < 0. )
+        return NumericVector(n, R_NaN) ;
+    return NumericVector( n, stats::ChisqGenerator( df ) ) ;
+}
 
-	inline NumericVector rnchisq( int n, double df, double lambda ){
-		if (!R_FINITE(df) || !R_FINITE(lambda) || df < 0. || lambda < 0.)
-			return NumericVector(n, R_NaN) ;
-		if( lambda == 0.0 ){
-			// using the central generator, see rchisq.h
-			return NumericVector( n, stats::ChisqGenerator( df ) ) ;
-		}
-		return NumericVector( n, stats::NChisqGenerator( df, lambda ) ) ;
-	}
+inline NumericVector rpois( int n, double mu ){
+    return NumericVector( n, stats::PoissonGenerator(mu) ) ;
+}
 
-	inline NumericVector rnchisq( int n, double df /*, double lambda = 0.0 */ ){
-		if (!R_FINITE(df) || df < 0. )
-			return NumericVector(n, R_NaN) ;
-		return NumericVector( n, stats::ChisqGenerator( df ) ) ;
-	}
+inline NumericVector rsignrank( int n, double nn ){
+    return NumericVector( n, stats::SignRankGenerator(nn) ) ;
+}
 
-	inline NumericVector rpois( int n, double mu ){
-		return NumericVector( n, stats::PoissonGenerator(mu) ) ;
-	}
+inline NumericVector rt( int n, double df ){
+    // special case
+    if (ISNAN(df) || df <= 0.0)
+        return NumericVector( n, R_NaN ) ;
 
-    inline NumericVector rsignrank( int n, double nn ){
-		return NumericVector( n, stats::SignRankGenerator(nn) ) ;
-	}
+    // just generating a N(0,1)
+    if(!R_FINITE(df))
+        return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
 
-	inline NumericVector rt( int n, double df ){
-		// special case
-		if (ISNAN(df) || df <= 0.0)
-			return NumericVector( n, R_NaN ) ;
+    // general case
+    return NumericVector( n, stats::TGenerator( df ) ) ;
+}
 
-		// just generating a N(0,1)
-		if(!R_FINITE(df))
-			return NumericVector( n, stats::NormGenerator__mean0__sd1() ) ;
+inline NumericVector runif( int n, double min, double max ){
+    if (!R_FINITE(min) || !R_FINITE(max) || max < min) return NumericVector( n, R_NaN ) ;
+    if( min == max ) return NumericVector( n, min ) ;
+    return NumericVector( n, stats::UnifGenerator( min, max ) ) ;
+}
 
-		// general case
-		return NumericVector( n, stats::TGenerator( df ) ) ;
-	}
+inline NumericVector runif( int n, double min /*, double max = 1.0 */ ){
+    if (!R_FINITE(min) || 1.0 < min) return NumericVector( n, R_NaN ) ;
+    if( min == 1.0 ) return NumericVector( n, 1.0 ) ;
+    return NumericVector( n, stats::UnifGenerator( min, 1.0 ) ) ;
+}
 
-	inline NumericVector runif( int n, double min, double max ){
-		if (!R_FINITE(min) || !R_FINITE(max) || max < min) return NumericVector( n, R_NaN ) ;
-		if( min == max ) return NumericVector( n, min ) ;
-		return NumericVector( n, stats::UnifGenerator( min, max ) ) ;
-	}
+inline NumericVector runif( int n /*, double min = 0.0, double max = 1.0 */ ){
+    return NumericVector( n, stats::UnifGenerator__0__1() ) ;
+}
 
-	inline NumericVector runif( int n, double min /*, double max = 1.0 */ ){
-		if (!R_FINITE(min) || 1.0 < min) return NumericVector( n, R_NaN ) ;
-		if( min == 1.0 ) return NumericVector( n, 1.0 ) ;
-		return NumericVector( n, stats::UnifGenerator( min, 1.0 ) ) ;
-	}
+inline NumericVector rweibull( int n, double shape, double scale ){
+    if (!R_FINITE(shape) || !R_FINITE(scale) || shape <= 0. || scale <= 0.) {
+        if(scale == 0.) return NumericVector(n, 0.);
+        /* else */
+        return NumericVector(n, R_NaN);
+    }
+    return NumericVector( n, stats::WeibullGenerator( shape, scale ) ) ;
+}
 
-	inline NumericVector runif( int n /*, double min = 0.0, double max = 1.0 */ ){
-		return NumericVector( n, stats::UnifGenerator__0__1() ) ;
-	}
+inline NumericVector rweibull( int n, double shape /* scale = 1 */ ){
+    if (!R_FINITE(shape) || shape <= 0. ) {
+        return NumericVector(n, R_NaN);
+    }
+    return NumericVector( n, stats::WeibullGenerator__scale1( shape ) ) ;
+}
 
-	inline NumericVector rweibull( int n, double shape, double scale ){
-		if (!R_FINITE(shape) || !R_FINITE(scale) || shape <= 0. || scale <= 0.) {
-			if(scale == 0.) return NumericVector(n, 0.);
-			/* else */
-			return NumericVector(n, R_NaN);
-		}
-		return NumericVector( n, stats::WeibullGenerator( shape, scale ) ) ;
-	}
-
-	inline NumericVector rweibull( int n, double shape /* scale = 1 */ ){
-		if (!R_FINITE(shape) || shape <= 0. ) {
-			return NumericVector(n, R_NaN);
-		}
-		return NumericVector( n, stats::WeibullGenerator__scale1( shape ) ) ;
-	}
-
-	inline NumericVector rwilcox( int n, double mm, double nn ){
-		return NumericVector( n, stats::WilcoxGenerator(mm, nn) ) ;
-	}
+inline NumericVector rwilcox( int n, double mm, double nn ){
+    return NumericVector( n, stats::WilcoxGenerator(mm, nn) ) ;
+}
 }
 
 #endif

--- a/inst/include/Rcpp/stats/random/rbeta.h
+++ b/inst/include/Rcpp/stats/random/rbeta.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rbeta.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,19 +25,18 @@
 namespace Rcpp {
 namespace stats{
 
-    class BetaGenerator : public Generator<double>{
-    public:
-        BetaGenerator(double a_, double b_) : a(a_), b(b_){}
+class BetaGenerator : public Generator<double>{
+public:
+    BetaGenerator(double a_, double b_) : a(a_), b(b_){}
 
-        inline double operator()() const {
-            return ::Rf_rbeta(a, b) ;
-        }
-    private:
-        double a, b ;
-    } ;
+    inline double operator()() const {
+        return ::Rf_rbeta(a, b) ;
+    }
+private:
+    double a, b ;
+};
 
 } // namespace stats
-
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rbinom.h
+++ b/inst/include/Rcpp/stats/random/rbinom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rbinom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,18 +25,17 @@
 namespace Rcpp {
 namespace stats {
 
-    class BinomGenerator : public Generator<double>{
-    public:
-        BinomGenerator( double nin_, double pp_ ) : nin(nin_), pp(pp_){}
-        inline double operator()() const{
-            return ::Rf_rbinom( nin, pp ) ;
-        }
-    private:
-        double nin, pp ;
-    } ;
+class BinomGenerator : public Generator<double>{
+public:
+    BinomGenerator( double nin_, double pp_ ) : nin(nin_), pp(pp_){}
+    inline double operator()() const{
+        return ::Rf_rbinom( nin, pp ) ;
+    }
+private:
+    double nin, pp ;
+};
 
 }  // stats
-
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rcauchy.h
+++ b/inst/include/Rcpp/stats/random/rcauchy.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rcauchy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -28,44 +28,43 @@ namespace stats {
 class CauchyGenerator : public ::Rcpp::Generator<double> {
 public:
 
-	CauchyGenerator( double location_, double scale_) :
-		location(location_) , scale(scale_) {}
+    CauchyGenerator( double location_, double scale_) :
+        location(location_) , scale(scale_) {}
 
-	inline double operator()() const {
-		return location + scale * ::tan(M_PI * unif_rand()) ;
-	}
+    inline double operator()() const {
+        return location + scale * ::tan(M_PI * unif_rand()) ;
+    }
 
 private:
-	double location, scale ;
-} ;
+    double location, scale ;
+};
 
 class CauchyGenerator_1 : public ::Rcpp::Generator<double> {
 public:
 
-	CauchyGenerator_1( double location_) :
-		location(location_){}
+    CauchyGenerator_1( double location_) :
+        location(location_){}
 
-	inline double operator()() const {
-		return location + ::tan(M_PI * unif_rand()) ;
-	}
+    inline double operator()() const {
+        return location + ::tan(M_PI * unif_rand()) ;
+    }
 
 private:
-	double location ;
-} ;
+    double location ;
+};
 
 class CauchyGenerator_0 : public ::Rcpp::Generator<double> {
 public:
 
-	CauchyGenerator_0(){}
+    CauchyGenerator_0(){}
 
-	inline double operator()() const {
-		return ::tan(M_PI * unif_rand()) ;
-	}
+    inline double operator()() const {
+        return ::tan(M_PI * unif_rand()) ;
+    }
 
-} ;
+};
 
 } // stats
-
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rchisq.h
+++ b/inst/include/Rcpp/stats/random/rchisq.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rchisq.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,23 +23,22 @@
 #define Rcpp__stats__random_rchisq_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class ChisqGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class ChisqGenerator : public ::Rcpp::Generator<double> {
-		public:
+    ChisqGenerator( double df_ ) : df_2(df_ / 2.0) {}
 
-			ChisqGenerator( double df_ ) : df_2(df_ / 2.0) {}
+    inline double operator()() const {
+        return ::Rf_rgamma( df_2, 2.0 ) ;
+    }
 
-			inline double operator()() const {
-				return ::Rf_rgamma( df_2, 2.0 ) ;
-			}
+private:
+    double df_2 ;
+};
 
-		private:
-			double df_2 ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rexp.h
+++ b/inst/include/Rcpp/stats/random/rexp.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rexp.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,31 +23,28 @@
 #define Rcpp__stats__random_rexp_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class ExpGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class ExpGenerator : public ::Rcpp::Generator<double> {
-		public:
+    ExpGenerator( double scale_ ) : scale(scale_) {}
 
-			ExpGenerator( double scale_ ) : scale(scale_) {}
+    inline double operator()() const {
+        return scale * exp_rand() ;
+    }
 
-			inline double operator()() const {
-				return scale * exp_rand() ;
-			}
+private:
+    double scale ;
+};
 
-		private:
-			double scale ;
-		} ;
+class ExpGenerator__rate1 : public Generator<double>{
+public:
+    ExpGenerator__rate1(){}
+    inline double operator()() const { return exp_rand() ; }
+};
 
-
-		class ExpGenerator__rate1 : public Generator<double>{
-		public:
-		    ExpGenerator__rate1(){}
-		    inline double operator()() const { return exp_rand() ; }
-		} ;
-
-	} // stats
-
+} // stats
 }
 
 #endif

--- a/inst/include/Rcpp/stats/random/rf.h
+++ b/inst/include/Rcpp/stats/random/rf.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rf.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,57 +23,53 @@
 #define Rcpp__stats__random_rf_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class FGenerator_Finite_Finite : public ::Rcpp::Generator<double> {
+public:
 
-		class FGenerator_Finite_Finite : public ::Rcpp::Generator<double> {
-		public:
+    FGenerator_Finite_Finite( double n1_, double n2_ ) :
+        n1__2(n1_ / 2.0 ), n2__2(n2_ / 2.0 ), ratio(n2_/n1_) {}
 
-			FGenerator_Finite_Finite( double n1_, double n2_ ) :
-				n1__2(n1_ / 2.0 ), n2__2(n2_ / 2.0 ), ratio(n2_/n1_) {}
+    inline double operator()() const {
+        // here we know that both n1 and n2 are finite
+        // return ( ::rchisq( n1 ) / n1 ) / ( ::rchisq( n2 ) / n2 );
+        return ratio * ::Rf_rgamma( n1__2, 2.0 ) / ::Rf_rgamma( n2__2, 2.0 ) ;
+    }
 
-			inline double operator()() const {
-				// here we know that both n1 and n2 are finite
-				// return ( ::rchisq( n1 ) / n1 ) / ( ::rchisq( n2 ) / n2 );
-				return ratio * ::Rf_rgamma( n1__2, 2.0 ) / ::Rf_rgamma( n2__2, 2.0 ) ;
-			}
+private:
+    double n1__2, n2__2, ratio ;
+};
 
-		private:
-			double n1__2, n2__2, ratio ;
-		} ;
+class FGenerator_NotFinite_Finite : public ::Rcpp::Generator<double> {
+public:
 
+    FGenerator_NotFinite_Finite( double n2_ ) : n2( n2_), n2__2(n2_ / 2.0 ) {}
 
-		class FGenerator_NotFinite_Finite : public ::Rcpp::Generator<double> {
-		public:
+    inline double operator()() const {
+        // return n2  / ::rchisq( n2 ) ;
+        return n2 / ::Rf_rgamma( n2__2, 2.0 ) ;
+    }
 
-			FGenerator_NotFinite_Finite( double n2_ ) : n2( n2_), n2__2(n2_ / 2.0 ) {}
+private:
+    double n2, n2__2 ;
+};
 
-			inline double operator()() const {
-				// return n2  / ::rchisq( n2 ) ;
-				return n2 / ::Rf_rgamma( n2__2, 2.0 ) ;
-			}
+class FGenerator_Finite_NotFinite : public ::Rcpp::Generator<double> {
+public:
 
-		private:
-			double n2, n2__2 ;
-		} ;
+    FGenerator_Finite_NotFinite( double n1_ ) : n1(n1_), n1__2(n1_ / 2.0 ) {}
 
+    inline double operator()() const {
+        // return ::rchisq( n1 ) / n1 ;
+        return ::Rf_rgamma( n1__2, 2.0 ) / n1 ;
+    }
 
-		class FGenerator_Finite_NotFinite : public ::Rcpp::Generator<double> {
-		public:
+private:
+    double n1, n1__2 ;
+};
 
-			FGenerator_Finite_NotFinite( double n1_ ) : n1(n1_), n1__2(n1_ / 2.0 ) {}
-
-			inline double operator()() const {
-				// return ::rchisq( n1 ) / n1 ;
-				return ::Rf_rgamma( n1__2, 2.0 ) / n1 ;
-			}
-
-		private:
-			double n1, n1__2 ;
-		} ;
-
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rgamma.h
+++ b/inst/include/Rcpp/stats/random/rgamma.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rgamma.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,19 +23,18 @@
 #define Rcpp__stats__random_rgamma_h
 
 namespace Rcpp {
-    namespace stats {
+namespace stats {
 
-        class GammaGenerator : public Generator<double>{
-        public:
-            GammaGenerator(double a_, double scale_) :
-                a(a_), scale(scale_) {}
-            inline double operator()() const { return ::Rf_rgamma(a, scale ) ;}
-        private:
-            double a, scale ;
-        } ;
-    }    // stats
+class GammaGenerator : public Generator<double>{
+public:
+    GammaGenerator(double a_, double scale_) :
+        a(a_), scale(scale_) {}
+    inline double operator()() const { return ::Rf_rgamma(a, scale ) ;}
+private:
+    double a, scale ;
+};
 
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rgeom.h
+++ b/inst/include/Rcpp/stats/random/rgeom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rgeom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,23 +23,22 @@
 #define Rcpp__stats__random_rgeom_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class GeomGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class GeomGenerator : public ::Rcpp::Generator<double> {
-		public:
+    GeomGenerator( double p ) : lambda( (1-p)/p  ) {}
 
-			GeomGenerator( double p ) : lambda( (1-p)/p  ) {}
+    inline double operator()() const {
+        return ::Rf_rpois(exp_rand() * lambda);
+    }
 
-			inline double operator()() const {
-				return ::Rf_rpois(exp_rand() * lambda);
-			}
+private:
+    double lambda ;
+};
 
-		private:
-			double lambda ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rhyper.h
+++ b/inst/include/Rcpp/stats/random/rhyper.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rhyper.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,18 +23,18 @@
 #define Rcpp__stats__random_rhyper_h
 
 namespace Rcpp {
-    namespace stats {
+namespace stats {
 
-        class HyperGenerator : public Generator<double>{
-        public:
-            HyperGenerator( double nn1_, double nn2_, double kk_) :
-                nn1(nn1_), nn2(nn2_), kk(kk_){}
-            inline double operator()() const { return ::Rf_rhyper(nn1, nn2, kk) ;}
-        private:
-            double nn1, nn2, kk ;
-        } ;
-    }
+class HyperGenerator : public Generator<double>{
+public:
+    HyperGenerator( double nn1_, double nn2_, double kk_) :
+        nn1(nn1_), nn2(nn2_), kk(kk_){}
+    inline double operator()() const { return ::Rf_rhyper(nn1, nn2, kk) ;}
+private:
+    double nn1, nn2, kk ;
+};
 
+}
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rlnorm.h
+++ b/inst/include/Rcpp/stats/random/rlnorm.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rlnorm.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,53 +23,51 @@
 #define Rcpp__stats__random_rlnorm_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
+
+class LNormGenerator : public Generator<double> {
+public:
+
+    LNormGenerator( double meanlog_ = 0.0 , double sdlog_ = 1.0 ) :
+        meanlog(meanlog_), sdlog(sdlog_) {}
+
+    inline double operator()() const {
+        return ::exp( meanlog + sdlog * ::norm_rand() ) ;
+    }
+
+private:
+    double meanlog ;
+    double sdlog ;
+};
 
 
-		class LNormGenerator : public Generator<double> {
-		public:
+class LNormGenerator_1 : public Generator<double> {
+public:
 
-			LNormGenerator( double meanlog_ = 0.0 , double sdlog_ = 1.0 ) :
-				meanlog(meanlog_), sdlog(sdlog_) {}
+    LNormGenerator_1( double meanlog_ = 0.0 ) :
+        meanlog(meanlog_) {}
 
-			inline double operator()() const {
-				return ::exp( meanlog + sdlog * ::norm_rand() ) ;
-			}
+    inline double operator()() const {
+        return ::exp( meanlog + ::norm_rand() ) ;
+    }
 
-		private:
-			double meanlog ;
-			double sdlog ;
-		} ;
-
-
-		class LNormGenerator_1 : public Generator<double> {
-		public:
-
-			LNormGenerator_1( double meanlog_ = 0.0 ) :
-				meanlog(meanlog_) {}
-
-			inline double operator()() const {
-				return ::exp( meanlog + ::norm_rand() ) ;
-			}
-
-		private:
-			double meanlog ;
-		} ;
+private:
+    double meanlog ;
+};
 
 
-		class LNormGenerator_0 : public Generator<double> {
-		public:
+class LNormGenerator_0 : public Generator<double> {
+public:
 
-			LNormGenerator_0( ) {}
+    LNormGenerator_0( ) {}
 
-			inline double operator()() const {
-				return ::exp(::norm_rand() ) ;
-			}
+    inline double operator()() const {
+        return ::exp(::norm_rand() ) ;
+    }
 
-		} ;
+};
 
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rlogis.h
+++ b/inst/include/Rcpp/stats/random/rlogis.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rlogis.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,56 +23,54 @@
 #define Rcpp__stats__random_rlogis_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
+
+class LogisGenerator : public ::Rcpp::Generator<double> {
+public:
+
+    LogisGenerator( double location_, double scale_ ) :
+        location(location_), scale(scale_) {}
+
+    inline double operator()() const {
+        double u = unif_rand() ;
+        return location + scale * ::log(u / (1. - u));
+    }
+
+private:
+    double location ;
+    double scale ;
+};
 
 
-		class LogisGenerator : public ::Rcpp::Generator<double> {
-		public:
+class LogisGenerator_1 : public ::Rcpp::Generator<double> {
+public:
 
-			LogisGenerator( double location_, double scale_ ) :
-				location(location_), scale(scale_) {}
+    LogisGenerator_1( double location_) :
+        location(location_) {}
 
-			inline double operator()() const {
-				double u = unif_rand() ;
-				return location + scale * ::log(u / (1. - u));
-			}
+    inline double operator()() const {
+        double u = unif_rand() ;
+        return location + ::log(u / (1. - u));
+    }
 
-		private:
-			double location ;
-			double scale ;
-		} ;
-
-
-		class LogisGenerator_1 : public ::Rcpp::Generator<double> {
-		public:
-
-			LogisGenerator_1( double location_) :
-				location(location_) {}
-
-			inline double operator()() const {
-				double u = unif_rand() ;
-				return location + ::log(u / (1. - u));
-			}
-
-		private:
-			double location ;
-		} ;
+private:
+    double location ;
+};
 
 
-		class LogisGenerator_0 : public ::Rcpp::Generator<double> {
-		public:
+class LogisGenerator_0 : public ::Rcpp::Generator<double> {
+public:
 
-			LogisGenerator_0() {}
+    LogisGenerator_0() {}
 
-			inline double operator()() const {
-				double u = unif_rand() ;
-				return ::log(u / (1. - u));
-			}
+    inline double operator()() const {
+        double u = unif_rand() ;
+        return ::log(u / (1. - u));
+    }
 
-		} ;
+};
 
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rnbinom.h
+++ b/inst/include/Rcpp/stats/random/rnbinom.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rnbinom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,25 +23,25 @@
 #define Rcpp__stats__random_rnbinom_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class NBinomGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class NBinomGenerator : public ::Rcpp::Generator<double> {
-		public:
+    NBinomGenerator( double siz_, double prob_ ) :
+        siz(siz_), lambda( (1-prob_)/prob_ ) {}
 
-			NBinomGenerator( double siz_, double prob_ ) :
-				siz(siz_), lambda( (1-prob_)/prob_ ) {}
+    inline double operator()() const {
+        return ::Rf_rpois( ::Rf_rgamma( siz, lambda ) ) ;
+    }
 
-			inline double operator()() const {
-				return ::Rf_rpois( ::Rf_rgamma( siz, lambda ) ) ;
-			}
+private:
+    double siz ;
+    double lambda ;
+};
 
-		private:
-			double siz ;
-			double lambda ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif
+

--- a/inst/include/Rcpp/stats/random/rnbinom_mu.h
+++ b/inst/include/Rcpp/stats/random/rnbinom_mu.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rnbinom_mu.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,25 +23,24 @@
 #define Rcpp__stats__random_rnbinom_mu_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class NBinomGenerator_Mu : public ::Rcpp::Generator<double> {
+public:
 
-		class NBinomGenerator_Mu : public ::Rcpp::Generator<double> {
-		public:
+    NBinomGenerator_Mu( double siz_, double mu_ ) :
+        siz(siz_), lambda( mu_ / siz_ ) {}
 
-			NBinomGenerator_Mu( double siz_, double mu_ ) :
-				siz(siz_), lambda( mu_ / siz_ ) {}
+    inline double operator()() const {
+        return ::Rf_rpois( ::Rf_rgamma( siz, lambda ) ) ;
+    }
 
-			inline double operator()() const {
-				return ::Rf_rpois( ::Rf_rgamma( siz, lambda ) ) ;
-			}
+private:
+    double siz ;
+    double lambda ;
+};
 
-		private:
-			double siz ;
-			double lambda ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rnchisq.h
+++ b/inst/include/Rcpp/stats/random/rnchisq.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rnchisq.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,33 +23,32 @@
 #define Rcpp__stats__random_rnchisq_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class NChisqGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class NChisqGenerator : public ::Rcpp::Generator<double> {
-		public:
+    NChisqGenerator( double df_, double lambda_ ) :
+        df(df_), df_2(df_ / 2.0), lambda_2(lambda_ / 2.0 ) {}
 
-			NChisqGenerator( double df_, double lambda_ ) :
-				df(df_), df_2(df_ / 2.0), lambda_2(lambda_ / 2.0 ) {}
+    inline double operator()() const {
+        double r = ::Rf_rpois( lambda_2 ) ;
+        // if( r > 0.0 ) r = Rf_rchisq( 2. * r ) ;
+        // replace by so that we can skip the tests in rchisq
+        // because there is no point in doing them as we know the
+        // outcome for sure
+        if( r > 0.0 ) r = ::Rf_rgamma( r, 2. ) ;
+        if (df > 0.) r += ::Rf_rgamma( df_2, 2.);
+        return r;
+    }
 
-			inline double operator()() const {
-				double r = ::Rf_rpois( lambda_2 ) ;
-				// if( r > 0.0 ) r = Rf_rchisq( 2. * r ) ;
-				// replace by so that we can skip the tests in rchisq
-				// because there is no point in doing them as we know the
-				// outcome for sure
-				if( r > 0.0 ) r = ::Rf_rgamma( r, 2. ) ;
-				if (df > 0.) r += ::Rf_rgamma( df_2, 2.);
-				return r;
-			}
+private:
+    double df ;
+    double df_2 ;
+    double lambda_2 ;
+};
 
-		private:
-			double df ;
-			double df_2 ;
-			double lambda_2 ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rnorm.h
+++ b/inst/include/Rcpp/stats/random/rnorm.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rnorm.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,70 +23,61 @@
 #define Rcpp__stats__random_rnorm_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class NormGenerator : public Generator<double> {
+public:
 
-		class NormGenerator : public Generator<double> {
-		public:
+    NormGenerator( double mean_ = 0.0 , double sd_ = 1.0 ) :
+        mean(mean_), sd(sd_) {}
 
-			NormGenerator( double mean_ = 0.0 , double sd_ = 1.0 ) :
-				mean(mean_), sd(sd_) {}
+    inline double operator()() const {
+        return mean + sd * ::norm_rand() ;
+    }
 
-			inline double operator()() const {
-				return mean + sd * ::norm_rand() ;
-			}
+private:
+    double mean ;
+    double sd ;
+};
 
-		private:
-			double mean ;
-			double sd ;
-		} ;
+class NormGenerator__sd1 : public Generator<double> {
+public:
 
+    NormGenerator__sd1( double mean_ = 0.0 ) : mean(mean_) {}
 
+    inline double operator()() const {
+        return mean + ::norm_rand() ;
+    }
 
-		class NormGenerator__sd1 : public Generator<double> {
-		public:
+private:
+    double mean ;
+};
 
-			NormGenerator__sd1( double mean_ = 0.0 ) : mean(mean_) {}
+class NormGenerator__mean0 : public Generator<double> {
+public:
 
-			inline double operator()() const {
-				return mean + ::norm_rand() ;
-			}
+    NormGenerator__mean0( double sd_ = 1.0 ) : sd(sd_) {}
 
-		private:
-			double mean ;
-		} ;
+    inline double operator()() const {
+        return sd * ::norm_rand() ;
+    }
 
+private:
+    double sd ;
+};
 
+class NormGenerator__mean0__sd1 : public Generator<double> {
+public:
 
-		class NormGenerator__mean0 : public Generator<double> {
-		public:
+    NormGenerator__mean0__sd1( ) {}
 
-			NormGenerator__mean0( double sd_ = 1.0 ) : sd(sd_) {}
+    inline double operator()() const {
+        return ::norm_rand() ;
+    }
 
-			inline double operator()() const {
-				return sd * ::norm_rand() ;
-			}
+};
 
-		private:
-			double sd ;
-		} ;
-
-
-		class NormGenerator__mean0__sd1 : public Generator<double> {
-		public:
-
-			NormGenerator__mean0__sd1( ) {}
-
-			inline double operator()() const {
-				return ::norm_rand() ;
-			}
-
-		} ;
-
-	} // stats
-
-
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rpois.h
+++ b/inst/include/Rcpp/stats/random/rpois.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rpois.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,18 +23,17 @@
 #define Rcpp__stats__random_rpois_h
 
 namespace Rcpp {
-    namespace stats{
+namespace stats{
 
+class PoissonGenerator : public Generator<double>{
+public:
+    PoissonGenerator( double mu_ ) : mu(mu_){}
+    inline double operator()() const { return ::Rf_rpois(mu); }
+private:
+    double mu ;
+};
 
-    	class PoissonGenerator : public Generator<double>{
-    	public:
-    	    PoissonGenerator( double mu_ ) : mu(mu_){}
-    	    inline double operator()() const { return ::Rf_rpois(mu); }
-    	private:
-    	    double mu ;
-    	} ;
-    }  // stats
-
+}  // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rsignrank.h
+++ b/inst/include/Rcpp/stats/random/rsignrank.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rsignrank.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,18 +23,18 @@
 #define Rcpp__stats__random_rsignrank_h
 
 namespace Rcpp {
-    namespace stats{
+namespace stats{
 
 
-		class SignRankGenerator : public Generator<double>{
-		public:
-		    SignRankGenerator(double nn_) : nn(nn_){}
-		    inline double operator()() const { return ::Rf_rsignrank(nn) ; }
-		private:
-		    double nn ;
-		} ;
-    } // stats
+class SignRankGenerator : public Generator<double>{
+public:
+    SignRankGenerator(double nn_) : nn(nn_){}
+    inline double operator()() const { return ::Rf_rsignrank(nn) ; }
+private:
+    double nn ;
+};
 
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rt.h
+++ b/inst/include/Rcpp/stats/random/rt.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rt.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,30 +23,29 @@
 #define Rcpp__stats__random_rt_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class TGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class TGenerator : public ::Rcpp::Generator<double> {
-		public:
+    TGenerator( double df_ ) : df(df_), df_2(df_/2.0) {}
 
-			TGenerator( double df_ ) : df(df_), df_2(df_/2.0) {}
+    inline double operator()() const {
+        /* Some compilers (including MW6) evaluated this from right to left
+           return norm_rand() / sqrt(rchisq(df) / df); */
+        double num = norm_rand();
 
-			inline double operator()() const {
-				/* Some compilers (including MW6) evaluated this from right to left
-				   return norm_rand() / sqrt(rchisq(df) / df); */
-				double num = norm_rand();
+        // return num / sqrt(rchisq(df) / df);
+        // replaced by the followoing line to skip the test in
+        // rchisq because we already know
+        return num / ::sqrt( ::Rf_rgamma(df_2, 2.0) / df);
+    }
 
-				// return num / sqrt(rchisq(df) / df);
-				// replaced by the followoing line to skip the test in
-				// rchisq because we already know
-				return num / ::sqrt( ::Rf_rgamma(df_2, 2.0) / df);
-			}
+private:
+    double df, df_2 ;
+};
 
-		private:
-			double df, df_2 ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/runif.h
+++ b/inst/include/Rcpp/stats/random/runif.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // runif.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,40 +23,38 @@
 #define Rcpp__stats__random_runif_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class UnifGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class UnifGenerator : public ::Rcpp::Generator<double> {
-		public:
+    UnifGenerator( double min_ = 0.0, double max_ = 1.0) :
+        min(min_), diff(max_ - min_) {}
 
-			UnifGenerator( double min_ = 0.0, double max_ = 1.0) :
-				min(min_), diff(max_ - min_) {}
+    inline double operator()() const {
+        double u;
+        do {u = unif_rand();} while (u <= 0 || u >= 1);
+        return min + diff * u;
+    }
 
-			inline double operator()() const {
-				double u;
-				do {u = unif_rand();} while (u <= 0 || u >= 1);
-				return min + diff * u;
-			}
+private:
+    double min;
+    double diff ;
+};
 
-		private:
-			double min;
-			double diff ;
-		} ;
+class UnifGenerator__0__1 : public ::Rcpp::Generator<double> {
+public:
 
+    UnifGenerator__0__1() {}
 
-		class UnifGenerator__0__1 : public ::Rcpp::Generator<double> {
-		public:
+    inline double operator()() const {
+        double u;
+        do {u = unif_rand();} while (u <= 0 || u >= 1);
+        return u;
+    }
+};
 
-			UnifGenerator__0__1() {}
-
-			inline double operator()() const {
-				double u;
-				do {u = unif_rand();} while (u <= 0 || u >= 1);
-				return u;
-			}
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rweibull.h
+++ b/inst/include/Rcpp/stats/random/rweibull.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rweibull.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,39 +23,37 @@
 #define Rcpp__stats__random_rweibull_h
 
 namespace Rcpp {
-	namespace stats {
+namespace stats {
 
+class WeibullGenerator : public ::Rcpp::Generator<double> {
+public:
 
-		class WeibullGenerator : public ::Rcpp::Generator<double> {
-		public:
+    WeibullGenerator( double shape_, double scale_ ) :
+        shape_inv( 1/shape_), scale(scale_) {}
 
-			WeibullGenerator( double shape_, double scale_ ) :
-				shape_inv( 1/shape_), scale(scale_) {}
+    inline double operator()() const {
+        return scale * ::R_pow(-::log(unif_rand()), shape_inv );
+    }
 
-			inline double operator()() const {
-				return scale * ::R_pow(-::log(unif_rand()), shape_inv );
-			}
+private:
+    double shape_inv, scale ;
+};
 
-		private:
-			double shape_inv, scale ;
-		} ;
+class WeibullGenerator__scale1 : public ::Rcpp::Generator<double> {
+public:
 
+    WeibullGenerator__scale1( double shape_ ) :
+        shape_inv( 1/shape_) {}
 
-		class WeibullGenerator__scale1 : public ::Rcpp::Generator<double> {
-		public:
+    inline double operator()() const {
+        return ::R_pow(-::log(unif_rand()), shape_inv );
+    }
 
-			WeibullGenerator__scale1( double shape_ ) :
-				shape_inv( 1/shape_) {}
+private:
+    double shape_inv ;
+};
 
-			inline double operator()() const {
-				return ::R_pow(-::log(unif_rand()), shape_inv );
-			}
-
-		private:
-			double shape_inv ;
-		} ;
-	} // stats
-
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/random/rwilcox.h
+++ b/inst/include/Rcpp/stats/random/rwilcox.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // rwilcox.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2012 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,17 +23,17 @@
 #define Rcpp__stats__random_rwilcox_h
 
 namespace Rcpp {
-    namespace stats {
+namespace stats {
 
-        class WilcoxGenerator : public Generator<double>{
-        public:
-            WilcoxGenerator( double mm_, double nn_) : mm(mm_), nn(nn_){}
-            inline double operator()() const { return ::Rf_rwilcox(mm,nn); }
-        private:
-            double mm, nn ;
-        } ;
-    } // stats
+class WilcoxGenerator : public Generator<double>{
+public:
+    WilcoxGenerator( double mm_, double nn_) : mm(mm_), nn(nn_){}
+    inline double operator()() const { return ::Rf_rwilcox(mm,nn); }
+private:
+    double mm, nn ;
+};
 
+} // stats
 } // Rcpp
 
 #endif

--- a/inst/include/Rcpp/stats/stats.h
+++ b/inst/include/Rcpp/stats/stats.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // binom.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -24,9 +24,9 @@
 
 #include <Rcpp/stats/dpq/dpq.h>
 
-#define ML_POSINF	R_PosInf
-#define ML_NEGINF	R_NegInf
-#define ML_NAN		R_NaN
+#define ML_POSINF       R_PosInf
+#define ML_NEGINF       R_NegInf
+#define ML_NAN          R_NaN
 
 #include <Rcpp/stats/unif.h>
 #include <Rcpp/stats/norm.h>

--- a/inst/include/Rcpp/stats/t.h
+++ b/inst/include/Rcpp/stats/t.h
@@ -1,8 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // t.h: Rcpp R/C++ interface class library -- t distribution
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/stats/unif.h
+++ b/inst/include/Rcpp/stats/unif.h
@@ -1,11 +1,10 @@
-
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // auto generated file (from script/stats.R)
 //
 // unif.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2011 Douglas Bates, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -28,13 +27,15 @@
 namespace Rcpp {
 namespace stats {
 
-inline double dunif_1(double x, double a/*, double b [=1.]*/ , int give_log){
-	return ::Rf_dunif(x, a, 1.0, give_log ) ;
+inline double dunif_1(double x, double a/*, double b [=1.]*/ ,
+                      int give_log) {
+    return ::Rf_dunif(x, a, 1.0, give_log ) ;
 }
-inline double dunif_0( double x /*, double a [=0.], double b [=1.]*/ , int give_log){
+inline double dunif_0( double x /*, double a [=0.], double b [=1.]*/ ,
+                       int give_log) {
 #ifdef IEEE_754
     if (ISNAN(x) )
-	return x + 1.0 ;
+        return x + 1.0 ;
 #endif
 
     if (0.0 <= x && x <= 1.0) return give_log ? 0.0 : 1.0 ;
@@ -42,27 +43,30 @@ inline double dunif_0( double x /*, double a [=0.], double b [=1.]*/ , int give_
 }
 
 
-inline double punif_1(double x, double a /*, double b [=1.0]*/, int lower_tail, int log_p) {
-	return ::Rf_punif( x, a, 1.0, lower_tail, log_p ) ;
+inline double punif_1(double x, double a /*, double b [=1.0]*/,
+                      int lower_tail, int log_p) {
+    return ::Rf_punif( x, a, 1.0, lower_tail, log_p ) ;
 }
-inline double punif_0(double x /*, double a [=0.0], double b [=1.0]*/, int lower_tail, int log_p) {
+inline double punif_0(double x /*, double a [=0.0], double b [=1.0]*/,
+                      int lower_tail, int log_p) {
 #ifdef IEEE_754
     if (ISNAN(x))
-	return x + 1.0 ;
+        return x + 1.0 ;
 #endif
     if (x >= 1.0)
-	return R_DT_1;
+        return R_DT_1;
     if (x <= 0.0)
-	return R_DT_0;
+        return R_DT_0;
     if (lower_tail) return R_D_val(x);
     else return R_D_val(1-x);
 
 }
 
-inline double qunif_1(double p, double a /*, double b [=1.0] */, int lower_tail, int log_p) {
+inline double qunif_1(double p, double a /*, double b [=1.0] */,
+                      int lower_tail, int log_p) {
 #ifdef IEEE_754
     if (ISNAN(p) || ISNAN(a) )
-	return p + a + 1.0 ;
+        return p + a + 1.0 ;
 #endif
     R_Q_P01_check(p);
     if (!R_FINITE(a) ) return R_NaN;
@@ -71,10 +75,12 @@ inline double qunif_1(double p, double a /*, double b [=1.0] */, int lower_tail,
 
     return a + R_DT_qIv(p) * (1.0 - a);
 }
-inline double qunif_0(double p /*, double a [=0.0], double b [=1.0] */, int lower_tail, int log_p) {
+
+inline double qunif_0(double p /*, double a [=0.0], double b [=1.0] */,
+                      int lower_tail, int log_p) {
 #ifdef IEEE_754
     if (ISNAN(p)  )
-	return p + 1.0 ;
+        return p + 1.0 ;
 #endif
     R_Q_P01_check(p);
 


### PR DESCRIPTION
no code changes here but some overdue (?) / marginally useful cleanups 
- updated emacs header line removing more instances of the old one imposing tabs
- ran M-x untabify
- ran Emacs reindent; still left of bunch of the non-standard Romain-esque whitespace

none of this _really_ matters but it was triggered in part by @ellert and his PR #437 and subsequent discussion