### PR TITLE
Add support for MUSL based Operation Systems

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -34,26 +34,21 @@ using namespace Rcpp;
 #endif
 
 #if defined(__GNUC__)
-    #if defined(_WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__sun) || defined(_AIX)
+    #if defined(_WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__sun) || defined(_AIX) || defined(__MUSL__)
         // do nothing
     #else
-        #ifndef __GLIBC__
-          // do nothing
-        #else
-          #include <execinfo.h>
+        #include <execinfo.h>
 
-          static std::string demangler_one(const char* input) {
-              static std::string buffer;
-              buffer = input;
-              buffer.resize(buffer.find_last_of('+') - 1);
-              buffer.erase(
-                  buffer.begin(),
-                  buffer.begin() + buffer.find_last_of(' ') + 1
-              );
-              return demangle(buffer);
-          }
-        #endif
-
+        static std::string demangler_one(const char* input) {
+            static std::string buffer;
+            buffer = input;
+            buffer.resize(buffer.find_last_of('+') - 1);
+            buffer.erase(
+                buffer.begin(),
+                buffer.begin() + buffer.find_last_of(' ') + 1
+            );
+            return demangle(buffer);
+        }
     #endif
 #endif
 
@@ -261,7 +256,7 @@ SEXP rcpp_can_use_cxx11() {
 // [[Rcpp::register]]
 SEXP stack_trace(const char* file, int line) {
     #if defined(__GNUC__)
-        #if defined(_WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__sun) || defined(_AIX)
+        #if defined(_WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__sun) || defined(_AIX) || defined(__MUSL__)
             // Simpler version for Windows and *BSD
             List trace = List::create(_["file"] = file,
                                       _[ "line"  ] = line,

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -37,18 +37,22 @@ using namespace Rcpp;
     #if defined(_WIN32) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__CYGWIN__) || defined(__sun) || defined(_AIX)
         // do nothing
     #else
-        #include <execinfo.h>
+        #ifndef __GLIBC__
+          // do nothing
+        #else
+          #include <execinfo.h>
 
-        static std::string demangler_one(const char* input) {
-            static std::string buffer;
-            buffer = input;
-            buffer.resize(buffer.find_last_of('+') - 1);
-            buffer.erase(
-                buffer.begin(),
-                buffer.begin() + buffer.find_last_of(' ') + 1
-            );
-            return demangle(buffer);
-        }
+          static std::string demangler_one(const char* input) {
+              static std::string buffer;
+              buffer = input;
+              buffer.resize(buffer.find_last_of('+') - 1);
+              buffer.erase(
+                  buffer.begin(),
+                  buffer.begin() + buffer.find_last_of(' ') + 1
+              );
+              return demangle(buffer);
+          }
+        #endif
 
     #endif
 #endif


### PR DESCRIPTION
Addresses https://github.com/RcppCore/Rcpp/issues/448

**Final solution:** After some discussion we decided the best way would be to add a `__MUSL__` test and get Alpine distributions to add that to the `PKG_CXXFLAGS `

~~Using suggestion recommend by the `musl` F.A.Q.:~~ (Read below)

> Q: application XY misbehaves or crashes at runtime when linked against musl
A: Usually this is because the app has hardcoded glibc-specific assumptions or wrong #ifdefs. See Functional differences from glibc. The most common causes are expectations of gnu getopt behaviour, iconv usage on UCS2 with assumptions that BOM is processed and the byte order detected, assuming that off_t is 32 bit, and assumptions that pthread_create will create sufficiently large stacks by default (crash situation). A good approach to solving the issue is to watch out for #if and #ifdefs in the code and placing some debug #warning there to see which code paths are enabled by the preprocessor. Often the logic taken by #ifdef's is to check a blacklist of preprocessor defines #if __sun__ || __haiku__ || __irix__ || __qnx__ portable_code(); #else glibc_code() #endif. The logic should be the other way round: #ifndef __GLIBC__ portable_code() #else glibc_code(). There's also no point in checking __GLIBC__ version numbers without first making sure that __GLIBC__ is defined at all.

http://wiki.musl-libc.org/wiki/FAQ

