### PR TITLE
Support R 3.3.0 Windows new toolchain 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-03-27  Qin Wenfeng  <mail@qinwenfeng.com>
+
+        * R/Attributes.R: Support R 3.3.0 Windows new toolchain
+
 2016-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION: Rolled Date and minor Version

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -705,9 +705,11 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
 
             # Check version
             ver <- key$`Current Version`
-            if (ver %in% (c("2.15", "2.16", "3.0", "3.1", "3.2", "3.3"))) {
+            if (ver %in% (c("2.15", "2.16", "3.0", "3.1", "3.2", "3.3", "3.4"))) {
                 # See if the InstallPath leads to the expected directories
-                isGcc49 <- FALSE
+                # R version 3.3.0 alpha (2016-03-25 r70378)
+                isGcc49 <- ver %in% c("3.3", "3.4") && as.numeric(R.Version()$`svn rev`) >= 70378
+
                 rToolsPath <- key$`InstallPath`
                 if (!is.null(rToolsPath)) {
                     # add appropriate path entries
@@ -721,8 +723,10 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
                         env <- list()
                         path <- paste(path, collapse = .Platform$path.sep)
                         env$PATH <- paste(path, Sys.getenv("PATH"), sep=.Platform$path.sep)
-                        if (isGcc49)
-                            env$RTOOLS <- .rtoolsPath(rToolsPath)
+                        if (isGcc49) {
+                            env$RTOOLS  <- .rtoolsPath(rToolsPath)
+                            env$BINPREF <- file.path(env$RTOOLS, "mingw_$(WIN)/bin//", fsep = "/")
+                        }
                         return(env)
                     }
                 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,10 @@
       The checks for different C library implementations now also check for Musl
       used by Alpine Linux (Sergio Marques in PR \ghpr{449}).
     }
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR \ghpr{451}).
+    }
   }
 }
       


### PR DESCRIPTION
Tested with [R-3.3.0 alpha](https://cran.r-project.org/bin/windows/base/rtest.html) build for Windows  with Rtools 3.3.