### PR TITLE
Module enhancements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,17 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.4.1
+Version: 0.12.4.2
 Date: 2016-03-26
-Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, 
+Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey,
  Qiang Kou, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: The 'Rcpp' package provides R functions as well as C++ classes which
  offer a seamless integration of R and C++. Many R data types and objects can be
  mapped back and forth to C++ equivalents which facilitates both writing of new
- code as well as easier integration of third-party libraries. Documentation 
- about 'Rcpp' is provided by several vignettes included in this package, via the 
- 'Rcpp Gallery' site at <http://gallery.rcpp.org>, the paper by Eddelbuettel and 
- Francois (2011, JSS), and the book by Eddelbuettel (2013, Springer); see 
+ code as well as easier integration of third-party libraries. Documentation
+ about 'Rcpp' is provided by several vignettes included in this package, via the
+ 'Rcpp Gallery' site at <http://gallery.rcpp.org>, the paper by Eddelbuettel and
+ Francois (2011, JSS), and the book by Eddelbuettel (2013, Springer); see
  'citation("Rcpp")' for details on these last two.
 Depends: R (>= 3.0.0)
 Imports: methods, utils

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,7 +32,9 @@ export(Module,
        cpp_object_initializer,
        cpp_object_dummy,
        Rcpp.plugin.maker,
-       copy
+       copy,
+       destruct,
+       is_destructed
        )
 S3method( print, bytes )
 exportClass(RcppClass)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,10 +30,9 @@ export(Module,
        demangle,
        sizeof,
        cpp_object_initializer,
-       cpp_object_dummy, 
-       Rcpp.plugin.maker
+       cpp_object_dummy,
+       Rcpp.plugin.maker,
+       copy
        )
 S3method( print, bytes )
 exportClass(RcppClass)
-
-

--- a/R/Module.R
+++ b/R/Module.R
@@ -439,6 +439,14 @@ cpp_fields <- function( CLASS, where){
     paste0("Rcpp_",name)
 
 copy <- function( obj ){
-		xp <- .Call(copy_constructor, obj$.cppclass, obj$.pointer )
+		.Call(copy_constructor, obj$.cppclass, obj$.pointer )
+}
 
+destruct <- function(obj){
+		.Call(destructor, obj$.cppclass, obj$.pointer)
+		invisible(NULL)
+}
+
+is_destructed <- function(obj){
+		.Call(is_destructed_impl, obj$.pointer)
 }

--- a/R/Module.R
+++ b/R/Module.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2010 - 2014 John Chambers, Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2010 - 2016 John Chambers, Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -127,7 +127,6 @@ new_CppObject_xp <- function(module, pointer, ...) {
 
 new_dummyObject <- function(...)
     .External( class__dummyInstance, ...)
-
 
 # class method for $initialize
 cpp_object_initializer <- function(.self, .refClassDef, ..., .object_pointer){
@@ -438,3 +437,8 @@ cpp_fields <- function( CLASS, where){
 
 .CppClassName <- function(name)
     paste0("Rcpp_",name)
+
+copy <- function( obj ){
+		xp <- .Call(copy_constructor, obj$.cppclass, obj$.pointer )
+
+}

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,9 +17,7 @@
     \item Changes in Rcpp Modules:
     \itemize{
       \item New function \code{copy} to invoke the copy constructor of a
-      C++ class that has been exposed by modules. \code{copy} only
-      works if the copy constructor has been declared by the
-      \code{copy\_constructor} module declaration.
+      C++ class that has been exposed by modules. 
     }
   }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,9 +14,16 @@
     \itemize{
       R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR \ghpr{451}).
     }
+    \item Changes in Rcpp Modules:
+    \itemize{
+      \item New function \code{copy} to invoke the copy constructor of a
+      C++ class that has been exposed by modules. \code{copy} only
+      works if the copy constructor has been declared by the
+      \code{copy\_constructor} module declaration.
+    }
   }
 }
-      
+
 \section{Changes in Rcpp version 0.12.4 (2016-03-22)}{
   \itemize{
     \item Changes in Rcpp API:
@@ -65,13 +72,13 @@
       \ghpr{406} by Qiang fixing \ghit{365}).
       \item A missing \code{std::hash} function interface for
       \code{Rcpp::String} has been addded (PR \ghpr{408} by Qiang fixing
-      \ghit{84}). 
+      \ghit{84}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{
       \item Avoid invalid function names when generating C++ interfaces (PR
       \ghpr{403} by JJ fixing \ghit{402}).
-      \item Insert additional space around \code{&} in function interface (PR 
+      \item Insert additional space around \code{&} in function interface (PR
       \ghpr{400} by Kazuki Fukui fixing \ghit{278}).
     }
     \item Changes in Rcpp Modules:
@@ -95,7 +102,7 @@
       by Florian)
       \item Before creating a single String object from a \code{SEXP}, ensure
       that it is from a vector of length one (PR \ghpr{376} by Dirk, fixing
-      \ghit{375}). 
+      \ghit{375}).
       \item No longer use \code{STRING_ELT} as a left-hand side, thanks to a
       heads-up by Luke Tierney (PR \ghpr{378} by Dirk, fixing \ghit{377}).
       \item Rcpp Module objects are now checked more carefully (PR \ghpr{381}
@@ -107,7 +114,7 @@
       \item \code{operator<<()} now always shows decimal points (PR \ghpr{396}
       by Dan)
       \item Matrix classes now have a \code{transpose()} function (PR \ghpr{397}
-      by Dirk fixing \ghit{383}) 
+      by Dirk fixing \ghit{383})
       \item \code{operator<<()} for complex types was added (PRs \ghpr{398} by
       Qiang and \ghpr{399} by Dirk, fixing \ghit{187})
     }
@@ -125,20 +132,20 @@
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The \code{NEWS} file now links to GitHub issue tickets and pull
-      requests. 
+      requests.
       \item The \code{Rcpp.bib} file with bibliographic references was updated.
     }
   }
 }
-      
+
 \section{Changes in Rcpp version 0.12.1 (2015-09-10)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
-      \item Correct use of WIN32 instead of _WIN32 to please Windows 10 
+      \item Correct use of WIN32 instead of _WIN32 to please Windows 10
       \item Add an assignment operator to \code{DimNameProxy} (PR \ghpr{339} by Florian)
       \item Add vector and matrix accessors \code{.at()} with bounds checking
-      (PR \ghpr{342} by Florian) 
+      (PR \ghpr{342} by Florian)
       \item Correct character vector conversion from single char (PR \ghpr{344} by
       Florian fixing issue \ghit{343})
       \item Correct on use of \code{R_xlen_t} back to \code{size_t} (PR \ghpr{348} by
@@ -186,13 +193,13 @@
       R expressions; this should resolve errors where calling handlers (e.g.
       through \code{suppressMessages()}) were not properly respected.
       \item All internal length variables have been changed from \code{R_len_t}
-      to \code{R_xlen_t} to support vectors longer than 2^31-1 elements (via 
+      to \code{R_xlen_t} to support vectors longer than 2^31-1 elements (via
       PR \ghpr{303} by Qiang Kou).
       \item The sugar function \code{sapply} now supports lambda functions
       (addressing \ghit{213} thanks to Matt Dziubinski)
       \item The \code{var} sugar function now uses a more robust two-pass
       method, supports complex numbers, with new unit tests added (via PR
-      \ghpr{320} by Matt Dziubinski) 
+      \ghpr{320} by Matt Dziubinski)
       \item \code{String} constructors now allow encodings (via PR \ghpr{310}
       by Qiang Kou)
       \item \code{String} objects are preserving the underlying \code{SEXP}
@@ -201,7 +208,7 @@
       \item DataFrame constructors are now a little more careful (via PR
       \ghpr{301} by Romain Francois)
       \item For R 3.2.0 or newer, \code{Rf_installChar()} is used instead of
-      \code{Rf_install(CHAR())} (via PR \ghpr{332}). 
+      \code{Rf_install(CHAR())} (via PR \ghpr{332}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{
@@ -233,7 +240,7 @@
       matrices (via a pull request by Dmitrii Meleshko).
       \item A new \code{empty()} string constructor was added (via another pull
       request).
-      \item Better support for Vectors with a storage policy different from the 
+      \item Better support for Vectors with a storage policy different from the
       default, i.e. \code{NoProtectStorage}, was added.
     }
     \item Changes in Rcpp Attributes:
@@ -258,16 +265,16 @@
       \item The \code{Rcpp::Environment} constructor can now use a supplied
       parent environment.
       \item The \code{Rcpp::Function} constructor can now use a supplied
-      environment or namespace. 
+      environment or namespace.
       \item The \code{attributes_hidden} macro from R is used to shield internal
       functions; the \code{R_ext/Visibility.h} header is now included as well.
-      \item A \code{Rcpp::print} function was added as a wrapper around \code{Rf_PrintValue}. 
+      \item A \code{Rcpp::print} function was added as a wrapper around \code{Rf_PrintValue}.
     }
     \item Changes in Rcpp Attributes:
     \itemize{
       \item The \code{pkg_types.h} file is now included in \code{RcppExports.cpp}
-      if it is present in either the \code{inst/include} or \code{src}. 
-      \item \code{sourceCpp} was modified to allow includes of local files 
+      if it is present in either the \code{inst/include} or \code{src}.
+      \item \code{sourceCpp} was modified to allow includes of local files
       (e.g. \code{#include "foo.hpp"}). Implementation files (*.cc; *.cpp) corresponding
       to local includes are also automatically built if they exist.
       \item The generated attributes code was simplified with respect to

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,7 +17,12 @@
     \item Changes in Rcpp Modules:
     \itemize{
       \item New function \code{copy} to invoke the copy constructor of a
-      C++ class that has been exposed by modules. 
+      C++ class that has been exposed by modules.
+      \item New function \code{destruct} to explicitely call the
+      destructor of the underlying C++ object without waiting for the
+      garbage collector.
+      \item New function \code{is\_destructed} to check if an object has been
+      destructed (presumably by \code{destruct} )
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,6 @@
 #define RCPP_VERSION Rcpp_Version(0,12,4)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,12,4,1)
+#define RCPP_DEV_VERSION RcppDevVersion(0,12,4,2)
 
 #endif
-

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -2,7 +2,7 @@
 //
 // class.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -60,7 +60,8 @@
             constructors(),
             factories(),
             class_pointer(0),
-            typeinfo_name("")
+            typeinfo_name(""),
+            has_copy_constructor(false)
         {
             class_pointer = get_instance() ;
         }
@@ -111,6 +112,11 @@
             return constructor( docstring, valid ) ;
         }
 
+        self& copy_constructor(){
+            class_pointer->has_copy_constructor = true ;
+            return *this ;
+        }
+
 #include <Rcpp/module/Module_generated_class_constructor.h>
 #include <Rcpp/module/Module_generated_class_factory.h>
 
@@ -146,7 +152,18 @@
 
             throw std::range_error( "no valid constructor available for the argument list" ) ;
             END_RCPP
-                }
+        }
+
+        SEXP invoke_copy_constructor( SEXP object ){
+            BEGIN_RCPP
+
+            if( !has_copy_constructor )
+                stop("copy constructor not exposed") ;
+
+            XP xp(object) ;
+            return internal::make_new_object<Class>( new Class(*xp) ) ;
+            END_RCPP
+        }
 
         bool has_default_constructor(){
             int n = constructors.size() ;
@@ -476,7 +493,7 @@
         vec_signed_factory factories ;
         self* class_pointer ;
         std::string typeinfo_name ;
-
+        bool has_copy_constructor ;
 
         class_( ) : class_Base(), vec_methods(), properties(), specials(0), constructors(), factories() {};
 

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -170,6 +170,14 @@
             END_RCPP
         }
 
+        SEXP invoke_destructor(SEXP object) {
+            BEGIN_RCPP
+            run_finalizer(object);
+            XP(object).release() ;
+            return R_NilValue ;
+            END_RCPP
+        }
+
         bool has_default_constructor(){
             int n = constructors.size() ;
             signed_constructor_class* p ;
@@ -498,7 +506,7 @@
         vec_signed_factory factories ;
         self* class_pointer ;
         std::string typeinfo_name ;
-        
+
         class_( ) : class_Base(), vec_methods(), properties(), specials(0), constructors(), factories() {};
 
 

--- a/inst/include/Rcpp/module/class_Base.h
+++ b/inst/include/Rcpp/module/class_Base.h
@@ -37,6 +37,7 @@ public:
 
     virtual void run_finalizer(SEXP){ }
 
+    virtual SEXP invoke_copy_constructor(SEXP) = 0 ;
     virtual bool has_default_constructor(){ return false ; }
     virtual bool has_method( const std::string& ){
         return false ;

--- a/inst/include/Rcpp/module/class_Base.h
+++ b/inst/include/Rcpp/module/class_Base.h
@@ -38,6 +38,7 @@ public:
     virtual void run_finalizer(SEXP){ }
 
     virtual SEXP invoke_copy_constructor(SEXP) = 0 ;
+    virtual SEXP invoke_destructor(SEXP) = 0 ;
     virtual bool has_default_constructor(){ return false ; }
     virtual bool has_method( const std::string& ){
         return false ;

--- a/inst/include/Rcpp/module/class_Base.h
+++ b/inst/include/Rcpp/module/class_Base.h
@@ -2,7 +2,7 @@
 //
 // class_Base.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -37,6 +37,7 @@ public:
 
     virtual void run_finalizer(SEXP){ }
 
+    virtual SEXP invoke_copy_constructor(SEXP) = 0 ;
     virtual bool has_default_constructor(){ return false ; }
     virtual bool has_method( const std::string& ){
         return false ;
@@ -80,7 +81,7 @@ public:
     }
     void add_enum( const std::string& enum_name, const std::map<std::string, int>& value ){
 	    enums.insert( ENUM_MAP_PAIR( enum_name, value ) ) ;
-	}
+	  }
 
     std::string name ;
     std::string docstring ;

--- a/inst/include/Rcpp/module/class_Base.h
+++ b/inst/include/Rcpp/module/class_Base.h
@@ -37,7 +37,6 @@ public:
 
     virtual void run_finalizer(SEXP){ }
 
-    virtual SEXP invoke_copy_constructor(SEXP) = 0 ;
     virtual bool has_default_constructor(){ return false ; }
     virtual bool has_method( const std::string& ){
         return false ;

--- a/inst/include/Rcpp/traits/has_copy_constructor.h
+++ b/inst/include/Rcpp/traits/has_copy_constructor.h
@@ -1,0 +1,46 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+//
+// Copyright (C) 2016 Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__traits__has_copy_constructor__h
+#define Rcpp__traits__has_copy_constructor__h
+
+namespace Rcpp{
+namespace traits{
+
+  template<typename T>
+  class _has_copy_constructor_helper : __sfinae_types {
+      template<typename U> struct _Wrap_type { };
+
+      template<typename U>
+        static __one __test(U);
+
+      template<typename U>
+        static __two __test(...);
+
+    public:
+      static const bool value = sizeof(__test<T>(0)) == 1;
+    };
+
+  template<typename T> struct has_copy_constructor :
+  	integral_constant<bool,_has_copy_constructor_helper<T>::value> { };
+
+} // traits
+} // Rcpp
+
+#endif

--- a/inst/include/Rcpp/traits/has_copy_constructor.h
+++ b/inst/include/Rcpp/traits/has_copy_constructor.h
@@ -27,7 +27,7 @@ namespace traits{
   template <typename T> struct has_copy_constructor :
     integral_constant<bool, std::is_copy_constructible<T>::value >{} ;
 #else
-  template<typename T> struct has_copy_constructor : true_type ;
+  template<typename T> struct has_copy_constructor : true_type {} ;
 #endif
 
 } // traits

--- a/inst/include/Rcpp/traits/has_copy_constructor.h
+++ b/inst/include/Rcpp/traits/has_copy_constructor.h
@@ -23,22 +23,12 @@
 namespace Rcpp{
 namespace traits{
 
-  template<typename T>
-  class _has_copy_constructor_helper : __sfinae_types {
-      template<typename U> struct _Wrap_type { };
-
-      template<typename U>
-        static __one __test(U);
-
-      template<typename U>
-        static __two __test(...);
-
-    public:
-      static const bool value = sizeof(__test<T>(0)) == 1;
-    };
-
-  template<typename T> struct has_copy_constructor :
-  	integral_constant<bool,_has_copy_constructor_helper<T>::value> { };
+#if defined(RCPP_USING_CXX11)
+  template <typename T> struct has_copy_constructor :
+    integral_constant<bool, std::is_copy_constructible<T>::value >{} ;
+#else
+  template<typename T> struct has_copy_constructor : true_type ;
+#endif
 
 } // traits
 } // Rcpp

--- a/inst/include/Rcpp/traits/has_copy_constructor.h
+++ b/inst/include/Rcpp/traits/has_copy_constructor.h
@@ -33,4 +33,9 @@ namespace traits{
 } // traits
 } // Rcpp
 
+#define RCPP_DISABLE_COPY_CONSTRUCTOR(CLASS)                          \
+  namespace Rcpp { namespace traits {                                 \
+    template <> struct has_copy_constructor<CLASS> : false_type {} ;  \
+  }}
+
 #endif

--- a/inst/include/Rcpp/traits/traits.h
+++ b/inst/include/Rcpp/traits/traits.h
@@ -3,7 +3,7 @@
 //
 // traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
-// Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -44,6 +44,7 @@ struct int2type { enum { value = I }; };
 #include <Rcpp/traits/named_object.h>
 #include <Rcpp/traits/is_convertible.h>
 #include <Rcpp/traits/has_iterator.h>
+#include <Rcpp/traits/has_copy_constructor.h>
 #include <Rcpp/traits/expands_to_logical.h>
 #include <Rcpp/traits/matrix_interface.h>
 #include <Rcpp/traits/is_sugar_expression.h>
@@ -77,4 +78,3 @@ struct int2type { enum { value = I }; };
 #include <Rcpp/traits/is_primitive.h>
 
 #endif
-

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -122,7 +122,7 @@ RCPP_EXPOSED_CLASS(ModuleTest)
 
 namespace Rcpp {
 namespace traits {
-  template <> struct has_copy_constructor<ModuleTest> : false_type ;
+  template <> struct has_copy_constructor<ModuleTest> : false_type {} ;
 }
 }
 

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -119,6 +119,13 @@ public:
 } ;
 
 RCPP_EXPOSED_CLASS(ModuleTest)
+
+namespace Rcpp {
+namespace traits {
+  template <> struct has_copy_constructor<ModuleTest> : false_type ;
+}
+}
+
 class ModuleTest {
 public:
     double value;

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -119,12 +119,7 @@ public:
 } ;
 
 RCPP_EXPOSED_CLASS(ModuleTest)
-
-namespace Rcpp {
-namespace traits {
-  template <> struct has_copy_constructor<ModuleTest> : false_type {} ;
-}
-}
+RCPP_DISABLE_COPY_CONSTRUCTOR(ModuleTest)
 
 class ModuleTest {
 public:

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -203,7 +203,7 @@ RCPP_MODULE(demoModule) {
         ;
 
     class_<ModuleCopyConstructor>( "ModuleCopyConstructor")
-        .constructor<int>
+        .constructor<int>()
         .copy_constructor()
         .field( "x", &ModuleCopyConstructor::x)
     ;

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -204,7 +204,6 @@ RCPP_MODULE(demoModule) {
 
     class_<ModuleCopyConstructor>( "ModuleCopyConstructor")
         .constructor<int>()
-        .copy_constructor()
         .field( "x", &ModuleCopyConstructor::x)
     ;
 }

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -111,6 +111,13 @@ private:
     double min, max;
 };
 
+class ModuleCopyConstructor {
+public:
+  ModuleCopyConstructor(int x_) : x(x_){}
+
+  int x ;
+} ;
+
 RCPP_EXPOSED_CLASS(ModuleTest)
 class ModuleTest {
 public:
@@ -194,6 +201,12 @@ RCPP_MODULE(demoModule) {
 
         .method("get" , &ModuleRandomizer::get)
         ;
+
+    class_<ModuleCopyConstructor>( "ModuleCopyConstructor")
+        .constructor<int>
+        .copy_constructor()
+        .field( "x", &ModuleCopyConstructor::x)
+    ;
 }
 
 // [[Rcpp::export]]
@@ -215,4 +228,3 @@ double attr_Test_get_x_const_pointer(const ModuleTest* x) {
 double attr_Test_get_x_pointer(ModuleTest* x) {
     return x->value;
 }
-

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -104,4 +104,11 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
         checkEquals( g$x, 4L)
     }
 
+    test.Module.destructor <- function(){
+        f <- new( ModuleCopyConstructor, 4L)
+        checkEquals( !is_destructed(f) )
+        destruct(f)
+        checkEquals( is_destructed(f) )
+    }
+
 }

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -106,9 +106,9 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
 
     test.Module.destructor <- function(){
         f <- new( ModuleCopyConstructor, 4L)
-        checkEquals( !is_destructed(f) )
+        checkTrue( !is_destructed(f) )
         destruct(f)
-        checkEquals( is_destructed(f) )
+        checkTrue( is_destructed(f) )
     }
 
 }

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -27,12 +27,12 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
     }
 
     .setUp <- Rcpp:::unitTestSetup("Module.cpp")
-    
+
     test.Module <- function(){
         checkEquals( bar( 2L ), 4L )
         checkEquals( foo( 2L, 10.0 ), 20.0 )
         checkEquals( hello(), "hello" )
-        
+
         w <- new( ModuleWorld )
         checkEquals( w$greet(), "hello" )
         w$set( "hello world" )
@@ -51,7 +51,7 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
         checkEquals( Test_get_x_const_pointer(test), 3.0 )
         checkEquals( Test_get_x_ref(test), 3.0 )
         checkEquals( Test_get_x_pointer(test), 3.0 )
-        
+
         checkEquals( attr_Test_get_x_const_ref(test), 3.0 )
         checkEquals( attr_Test_get_x_const_pointer(test), 3.0 )
         checkEquals( attr_Test_get_x_ref(test), 3.0 )
@@ -92,6 +92,16 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
         checkEquals( test_reference( seq(0,10) ), 11L )
         checkEquals( test_const_reference( seq(0,10) ), 11L )
         checkEquals( test_const( seq(0,10) ), 11L )
+    }
+
+    test.Module.copy.constructor <- function(){
+        f <- new( ModuleCopyConstructor, 2L)
+        g <- copy(f)
+        checkEquals( f$x, g$x )
+        checkTrue( !identical(f$.pointer, g$.pointer) )
+        g$x <- 4L
+        checkEquals( f$x, 2L)
+        checkEquals( g$x, 4L)
     }
 
 }

--- a/man/copy.Rd
+++ b/man/copy.Rd
@@ -1,0 +1,59 @@
+\name{copy}
+\alias{copy}
+\title{
+  Invokes the copy constructor of the C++ class
+}
+\description{
+  Invokes the copy constructor of the C++ class if it has
+  been registered through the \code{.copy_constructor}
+  module declaration
+}
+\usage{
+  copy(obj)
+}
+\arguments{
+  \item{obj}{A C++ object from a class exposed by an Rcpp module}
+}
+\value{
+  A new C++ object that is a copy of the object passed through
+  according to the underlying C++ copy constructor.
+}
+\author{
+  Romain Francois <romain@r-enthusiasts.com>
+}
+\examples{
+\dontrun{
+
+  sourceCpp( code = '
+    #include <Rcpp.h>
+    using namespace Rcpp ;
+
+    class Foo{
+      public:
+        Foo( int x_ ) : x(x_){}
+        int x ;
+    } ;
+
+    RCPP_MODULE(test){
+      class_<Foo>("Foo")
+        .constructor<int>()
+        .copy_constructor()
+        .field( "x", &Foo::x)
+      ;
+  }
+  ')
+  f <- new( Foo, 1 )
+  g <- copy(f)
+
+  # f and g have the same value for the x field
+  f$x == g$x
+
+  # but they are different underlying C++ objects
+  identical(f$.pointer, g$.pointer)
+
+  g$x <- 4
+  f$x
+
+}
+}
+\keyword{ ~kwd1 }

--- a/man/copy.Rd
+++ b/man/copy.Rd
@@ -4,9 +4,9 @@
   Invokes the copy constructor of the C++ class
 }
 \description{
-  Invokes the copy constructor of the C++ class if it has
-  been registered through the \code{.copy_constructor}
-  module declaration
+  Invokes the copy constructor of the C++ class. The function
+  fails if the underlying class does not have a copy
+  constructor.
 }
 \usage{
   copy(obj)
@@ -37,7 +37,6 @@
     RCPP_MODULE(test){
       class_<Foo>("Foo")
         .constructor<int>()
-        .copy_constructor()
         .field( "x", &Foo::x)
       ;
   }

--- a/man/copy.Rd
+++ b/man/copy.Rd
@@ -55,4 +55,4 @@
 
 }
 }
-\keyword{ ~kwd1 }
+\keyword{manip}

--- a/man/destruct.Rd
+++ b/man/destruct.Rd
@@ -1,0 +1,54 @@
+\name{destruct}
+\alias{destruct}
+\alias{is_destructed}
+\title{
+Explicitely destructs the C++ object.
+}
+\description{
+Explicitely invokes the C++ object destructor. 
+}
+\usage{
+destruct(obj)
+is_destructed(obj)
+}
+\arguments{
+  \item{obj}{A C++ object}
+}
+\details{
+\code{destruct} explicitely destruct the C++ object
+\code{is_destructed} checks if it has been destructed
+}
+\value{
+\code{is_destructed} returns a logical.
+}
+\author{
+  Romain Francois <romain@r-enthusiasts.com>
+}
+\examples{
+\dontrun{
+
+  sourceCpp( code = '
+    #include <Rcpp.h>
+    using namespace Rcpp ;
+
+    class Foo{
+      public:
+        Foo( int x_ ) : x(x_){}
+        ~Foo(){ Rprintf("~Foo\\n") ; }
+        int x ;
+    } ;
+
+    RCPP_MODULE(test){
+      class_<Foo>("Foo")
+        .constructor<int>()
+        .field( "x", &Foo::x)
+      ;
+  }
+  ')
+  f <- new( Foo, 1 )
+  destruct(f)
+  is_destructed(f)
+
+}
+}
+\keyword{manip}

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -117,6 +117,13 @@ RCPP_FUN_2( SEXP, copy_constructor, XP_Class cl, SEXP obj){
   return cl->invoke_copy_constructor(obj) ;
 }
 
+RCPP_FUN_2( SEXP, destructor, XP_Class cl, SEXP obj){
+  return cl->invoke_destructor(obj) ;
+}
+RCPP_FUN_1( SEXP, is_destructed_impl, SEXP obj){
+  return Rf_ScalarLogical( R_ExternalPtrAddr(obj) == NULL ) ;
+}
+
 // .External functions
 SEXP InternalFunction_invoke(SEXP args) {
 BEGIN_RCPP

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -2,7 +2,7 @@
 //
 // Module.cpp: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -111,6 +111,10 @@ RCPP_FUN_4(SEXP, CppField__set, XP_Class cl, SEXP field_xp, SEXP obj, SEXP value
 RCPP_FUN_2(SEXP, CppObject__finalize, XP_Class cl, SEXP obj) {
 	cl->run_finalizer(obj);
 	return R_NilValue;
+}
+
+RCPP_FUN_2( SEXP, copy_constructor, XP_Class cl, SEXP obj){
+  return cl->invoke_copy_constructor(obj) ;
 }
 
 // .External functions
@@ -230,4 +234,3 @@ Rcpp::Module* getCurrentScope() {
 void setCurrentScope(Rcpp::Module* scope) {
     Rcpp::current_scope = scope;
 }
-

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -2,7 +2,7 @@
 //
 // Rcpp_init.cpp : Rcpp R/C++ interface class library -- Initialize and register
 //
-// Copyright (C) 2010 - 2015  John Chambers, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  John Chambers, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -53,6 +53,7 @@ static R_CallMethodDef callEntries[]  = {
 
     CALLDEF(CppField__get,3),
     CALLDEF(CppField__set,4),
+    CALLDEF(copy_constructor,2),
 
     CALLDEF(rcpp_capabilities,0),
     CALLDEF(rcpp_can_use_cxx0x,0),

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -54,6 +54,8 @@ static R_CallMethodDef callEntries[]  = {
     CALLDEF(CppField__get,3),
     CALLDEF(CppField__set,4),
     CALLDEF(copy_constructor,2),
+    CALLDEF(destructor, 2),
+    CALLDEF(is_destructed_impl, 1), 
 
     CALLDEF(rcpp_capabilities,0),
     CALLDEF(rcpp_can_use_cxx0x,0),

--- a/src/internal.h
+++ b/src/internal.h
@@ -124,6 +124,8 @@ CALLFUN_1(rcpp_error_recorder);
 CALLFUN_3(CppField__get);
 CALLFUN_4(CppField__set);
 CALLFUN_2(copy_constructor) ;
+CALLFUN_2(destructor) ;
+CALLFUN_1(is_destructed_impl) ;
 
 CALLFUN_0(rcpp_capabilities);
 CALLFUN_0(rcpp_can_use_cxx0x);

--- a/src/internal.h
+++ b/src/internal.h
@@ -2,7 +2,7 @@
 //
 // internal.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2012 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -123,6 +123,7 @@ CALLFUN_0(init_Rcpp_cache);
 CALLFUN_1(rcpp_error_recorder);
 CALLFUN_3(CppField__get);
 CALLFUN_4(CppField__set);
+CALLFUN_2(copy_constructor) ;
 
 CALLFUN_0(rcpp_capabilities);
 CALLFUN_0(rcpp_can_use_cxx0x);


### PR DESCRIPTION
changes in Rcpp modules to allow use of the copy constructor of a class

```
    #include <Rcpp.h>
    using namespace Rcpp ;

    class Foo{
      public:
        Foo( int x_ ) : x(x_){}
        int x ;
    } ;

    RCPP_MODULE(test){
      class_<Foo>("Foo")
        .constructor<int>()
        .field( "x", &Foo::x)
      ;
  }
```

This is associated with the `copy` R function :

```
f <- new( Foo, 1 )
g <- copy( f)
g$x
!identical( g$.pointer, f$.pointer )
```


