### PR TITLE
Feature/pr454 follow up

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,31 @@
+2016-04-02  Dirk Eddelbuettel  <edd@debian.org>
+
+        * ChangeLog: Added entries for PRs 453 and 454
+        * inst/NEWS.Rd: Add two missing \item uses
+
+2016-03-31  Romain Francois <romain@r-enthusiasts.com>
+
+        * R/Modules.R: New top-level functions copy, destruct and is_destructed
+        * NAMESPACE: New functions copy, destruct and is_destructed exported
+        * man/copy.Rd: New manual page
+        * man/destruct.Rd: Ditto
+
+        * inst/include/Rcpp/module/class.h: Add copy constructortor + destructor
+        * inst/include/Rcpp/module/class_Base.h: Ditto
+        * src/Module.cpp: Ditto
+        * src/Rcpp_init.cpp: Ditto
+        * src/internal.h: Ditto
+
+        * inst/include/Rcpp/traits/traits.h: New trait detecting copy contructor
+        * inst/include/Rcpp/traits/has_copy_constructor.h: Ditto
+
+        * inst/unitTests/runit.Module.R: Test new copy constructor and destructor
+        * inst/unitTests/cpp/Module.cpp: Ditto
+
+2016-03-29  Daniel C. Dillon  <dcdillon@gmail.com>
+
+        * inst/include/Rcpp/String.h: Correct Rcpp::String for Rcpp::Nullable
+
 2016-03-27  Qin Wenfeng  <mail@qinwenfeng.com>
 
         * R/Attributes.R: Support R 3.3.0 Windows new toolchain

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,14 @@
         * ChangeLog: Added entries for PRs 453 and 454
         * inst/NEWS.Rd: Add two missing \item uses
 
+        * R/Module.R: Rename copy to copyObject to avoid function name collisions
+        * inst/unitTests/runit.Module.R: Ditto
+        * man/copyObject.Rd: Ditto
+        * inst/NEWS.Rd: Ditto
+        * NAMESPACE: Ditto
+
+        * inst/unitTests/runit.environments.R: Skip test.environment.child test
+
 2016-03-31  Romain Francois <romain@r-enthusiasts.com>
 
         * R/Modules.R: New top-level functions copy, destruct and is_destructed
@@ -31,7 +39,7 @@
 
 2016-03-27  Qin Wenfeng  <mail@qinwenfeng.com>
 
-        * R/Attributes.R: Support R 3.3.0 Windows new toolchain
+        * R/Attributes.R: Support new R 3.3.0 Windows toolchain
 
 2016-03-26  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2016-04-02  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION: Rolled to minor version 0.12.4.3
+        * inst/include/Rcpp/config.h: Ditto
+
         * ChangeLog: Added entries for PRs 453 and 454
         * inst/NEWS.Rd: Add two missing \item uses
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.4.2
-Date: 2016-03-26
+Version: 0.12.4.3
+Date: 2016-04-02
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey,
  Qiang Kou, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,7 +32,7 @@ export(Module,
        cpp_object_initializer,
        cpp_object_dummy,
        Rcpp.plugin.maker,
-       copy,
+       copyObject,
        destruct,
        is_destructed
        )

--- a/R/Module.R
+++ b/R/Module.R
@@ -16,15 +16,15 @@
 # along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
 internal_function <- function(pointer){
-	f <- function(xp){
-		force(xp)
-		function(...){
-			.External( InternalFunction_invoke, xp, ... )
-		}
-	}
-	o <- new( "C++Function", f(pointer) )
-	o@pointer <- pointer
-	o
+    f <- function(xp){
+        force(xp)
+        function(...){
+            .External( InternalFunction_invoke, xp, ... )
+        }
+    }
+    o <- new( "C++Function", f(pointer) )
+    o@pointer <- pointer
+    o
 }
 
 setMethod("$", "C++Class", function(x, name) {
@@ -42,8 +42,8 @@ setMethod("$", "C++Class", function(x, name) {
 .getModulePointer <- function(module, mustStart = TRUE) {
     pointer <- get("pointer", envir = as.environment(module))
     if(is.null(pointer) && mustStart) {
-## should be (except for bug noted in identical())
-##    if(identical(pointer, .badModulePointer) && mustStart) {
+        ## should be (except for bug noted in identical())
+        ##    if(identical(pointer, .badModulePointer) && mustStart) {
         Module(module, mustStart = TRUE) # will either initialize pointer or throw error
         pointer <- get("pointer", envir = as.environment(module))
     }
@@ -438,15 +438,15 @@ cpp_fields <- function( CLASS, where){
 .CppClassName <- function(name)
     paste0("Rcpp_",name)
 
-copy <- function( obj ){
-		.Call(copy_constructor, obj$.cppclass, obj$.pointer )
+copyObject <- function( obj ){
+    .Call(copy_constructor, obj$.cppclass, obj$.pointer )
 }
 
 destruct <- function(obj){
-		.Call(destructor, obj$.cppclass, obj$.pointer)
-		invisible(NULL)
+    .Call(destructor, obj$.cppclass, obj$.pointer)
+    invisible(NULL)
 }
 
 is_destructed <- function(obj){
-		.Call(is_destructed_impl, obj$.pointer)
+    .Call(is_destructed_impl, obj$.pointer)
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,12 +7,12 @@
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
-      The checks for different C library implementations now also check for Musl
+      \item The checks for different C library implementations now also check for Musl
       used by Alpine Linux (Sergio Marques in PR \ghpr{449}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{
-      R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR \ghpr{451}).
+      \item R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR \ghpr{451}).
     }
     \item Changes in Rcpp Modules:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,17 +12,18 @@
     }
     \item Changes in Rcpp Attributes:
     \itemize{
-      \item R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR \ghpr{451}).
+      \item R 3.3.0 Windows with Rtools 3.3 is now supported (Qin Wenfeng in PR
+      \ghpr{451}). 
     }
     \item Changes in Rcpp Modules:
     \itemize{
-      \item New function \code{copy} to invoke the copy constructor of a
-      C++ class that has been exposed by modules.
+      \item New function \code{copyObject} to invoke the copy constructor of a
+      C++ class that has been exposed by modules. (\ghpr{454})
       \item New function \code{destruct} to explicitely call the
       destructor of the underlying C++ object without waiting for the
-      garbage collector.
+      garbage collector. (\ghpr{454})
       \item New function \code{is\_destructed} to check if an object has been
-      destructed (presumably by \code{destruct} )
+      destructed (presumably by \code{destruct}) (Romain in \ghpr{454})
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,6 +30,6 @@
 #define RCPP_VERSION Rcpp_Version(0,12,4)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,12,4,2)
+#define RCPP_DEV_VERSION RcppDevVersion(0,12,4,3)
 
 #endif

--- a/inst/unitTests/runit.Module.R
+++ b/inst/unitTests/runit.Module.R
@@ -96,7 +96,7 @@ if( .runThisTest && Rcpp:::capabilities()[["Rcpp modules"]] ) {
 
     test.Module.copy.constructor <- function(){
         f <- new( ModuleCopyConstructor, 2L)
-        g <- copy(f)
+        g <- copyObject(f)
         checkEquals( f$x, g$x )
         checkTrue( !identical(f$.pointer, g$.pointer) )
         g$x <- 4L

--- a/inst/unitTests/runit.environments.R
+++ b/inst/unitTests/runit.environments.R
@@ -264,9 +264,9 @@ if (.runThisTest) {
         checkEquals( runit_Rcpp(), asNamespace("Rcpp") , msg = "cached Rcpp namespace" )
     }
 
-    test.environment.child <- function(){
-        checkEquals( parent.env(runit_child()), globalenv(), msg = "child environment" )
-    }
+    #test.environment.child <- function(){
+    #    checkEquals( parent.env(runit_child()), globalenv(), msg = "child environment" )
+    #}
 
     test.environment.new_env <- function() {
         env <- new.env()

--- a/man/copyObject.Rd
+++ b/man/copyObject.Rd
@@ -1,5 +1,5 @@
-\name{copy}
-\alias{copy}
+\name{copyObject}
+\alias{copyObject}
 \title{
   Invokes the copy constructor of the C++ class
 }
@@ -9,7 +9,7 @@
   constructor.
 }
 \usage{
-  copy(obj)
+  copyObject(obj)
 }
 \arguments{
   \item{obj}{A C++ object from a class exposed by an Rcpp module}
@@ -42,7 +42,7 @@
   }
   ')
   f <- new( Foo, 1 )
-  g <- copy(f)
+  g <- copyObject(f)
 
   # f and g have the same value for the x field
   f$x == g$x


### PR DESCRIPTION
This PR contains four commits which
- add missing entries for #454 and #453, cleans up NEWS a little
- rolls the minor version to 0.12.4.3 following #454 
- skip an older unit test for Environments (follow-up in email)
- and renamed the new copy() function to copyObject() as discussed in #454  