### PR TITLE
R/Module.R: avoid calling as.character on a C++Object

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-04-11  Ben Goodrich  <goodrich.ben@gmail.com>
+        * R/Module.R: Avoid calling as.character() on a C++Object to prevent race
+
 2016-04-02  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION: Rolled to minor version 0.12.4.3

--- a/R/Module.R
+++ b/R/Module.R
@@ -111,7 +111,7 @@ setMethod("initialize", "Module",
 
 .get_Module_Class <- function( x, name, pointer =  .getModulePointer(x) ){
     value <- .Call( Module__get_class, pointer, name )
-    value@generator <-  get("refClassGenerators",envir=x)[[as.character(value)]]
+    value@generator <- get("refClassGenerators", envir=x)[[value@.Data]]
     value
 }
 
@@ -215,7 +215,7 @@ Module <- function( module, PACKAGE = methods::getPackageName(where), where = to
     for( i in seq_along(classes) ){
         CLASS <- classes[[i]]
 
-        clname <- as.character(CLASS)
+        clname <- CLASS@.Data
 
         fields <- cpp_fields( CLASS, where )
         methods <- cpp_refMethods(CLASS, where)
@@ -276,7 +276,7 @@ Module <- function( module, PACKAGE = methods::getPackageName(where), where = to
 
     for( i in seq_along(classes) ){
         CLASS <- classes[[i]]
-        clname <- as.character(CLASS)
+        clname <- CLASS@.Data
         demangled_name <- sub( "^Rcpp_", "", clname )
         .classes_map[[ CLASS@typeid ]] <- storage[[ demangled_name ]] <- .get_Module_Class( module, demangled_name, xp )
 


### PR DESCRIPTION
This fixes a mysterious race on Debian unstable with R 3.3.0 beta
that was triggered when loading the rstanarm package

Closes #458