### PR TITLE
Fixing ambiguous arithmetic operators for Matrix/Vector on 32-bit

### DIFF
--- a/inst/include/Rcpp/sugar/operators/divides.h
+++ b/inst/include/Rcpp/sugar/operators/divides.h
@@ -409,19 +409,19 @@ namespace sugar{
 }
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Divides_Vector_Primitive< RTYPE , NA, T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Divides_Vector_Primitive< RTYPE , NA, T > >::type
 operator/(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	U rhs
+	const U &rhs
 ) {
 	return sugar::Divides_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Divides_Primitive_Vector< RTYPE , NA,T> >::type
+inline typename traits::enable_if< traits::is_convertible< typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Divides_Primitive_Vector< RTYPE , NA,T> >::type
 operator/(
-	U lhs,
+	const U &lhs,
 	const VectorBase<RTYPE,NA,T>& rhs
 ) {
 	return sugar::Divides_Primitive_Vector<RTYPE,NA,T>( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/divides.h
+++ b/inst/include/Rcpp/sugar/operators/divides.h
@@ -408,20 +408,20 @@ namespace sugar{
 
 }
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Divides_Vector_Primitive< RTYPE , NA, T >
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Divides_Vector_Primitive< RTYPE , NA, T > >::type
 operator/(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename traits::storage_type<RTYPE>::type rhs
+	U rhs
 ) {
 	return sugar::Divides_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Divides_Primitive_Vector< RTYPE , NA,T>
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Divides_Primitive_Vector< RTYPE , NA,T> >::type
 operator/(
-	typename traits::storage_type<RTYPE>::type lhs,
+	U lhs,
 	const VectorBase<RTYPE,NA,T>& rhs
 ) {
 	return sugar::Divides_Primitive_Vector<RTYPE,NA,T>( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/minus.h
+++ b/inst/include/Rcpp/sugar/operators/minus.h
@@ -413,19 +413,19 @@ namespace sugar{
 }
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Minus_Vector_Primitive< RTYPE , NA, T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Minus_Vector_Primitive< RTYPE , NA, T > >::type
 operator-(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	U rhs
+	const U &rhs
 ) {
 	return sugar::Minus_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Minus_Primitive_Vector< RTYPE , NA,T> >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Minus_Primitive_Vector< RTYPE , NA,T> >::type
 operator-(
-	U lhs,
+	const U &lhs,
 	const VectorBase<RTYPE,NA,T>& rhs
 ) {
 	return sugar::Minus_Primitive_Vector<RTYPE,NA,T>( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/minus.h
+++ b/inst/include/Rcpp/sugar/operators/minus.h
@@ -412,20 +412,20 @@ namespace sugar{
 
 }
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Minus_Vector_Primitive< RTYPE , NA, T >
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Minus_Vector_Primitive< RTYPE , NA, T > >::type
 operator-(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename traits::storage_type<RTYPE>::type rhs
+	U rhs
 ) {
 	return sugar::Minus_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Minus_Primitive_Vector< RTYPE , NA,T>
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Minus_Primitive_Vector< RTYPE , NA,T> >::type
 operator-(
-	typename traits::storage_type<RTYPE>::type lhs,
+	U lhs,
 	const VectorBase<RTYPE,NA,T>& rhs
 ) {
 	return sugar::Minus_Primitive_Vector<RTYPE,NA,T>( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/plus.h
+++ b/inst/include/Rcpp/sugar/operators/plus.h
@@ -442,20 +442,20 @@ namespace sugar{
 
 }
 
-template <int RTYPE,bool NA, typename T>
+template <int RTYPE,bool NA, typename T, typename U>
 inline sugar::Plus_Vector_Primitive<RTYPE,NA,T>
 operator+(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename traits::storage_type<RTYPE>::type rhs
+	U rhs
 ) {
 	return sugar::Plus_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
-template <int RTYPE,bool NA, typename T>
+template <int RTYPE,bool NA, typename T, typename U>
 inline sugar::Plus_Vector_Primitive< RTYPE , NA , T >
 operator+(
-	typename traits::storage_type<RTYPE>::type rhs,
+	U rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Plus_Vector_Primitive<RTYPE,NA, T >( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/plus.h
+++ b/inst/include/Rcpp/sugar/operators/plus.h
@@ -442,8 +442,9 @@ namespace sugar{
 
 }
 
+
 template <int RTYPE,bool NA, typename T, typename U>
-inline sugar::Plus_Vector_Primitive<RTYPE,NA,T>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, typename sugar::Plus_Vector_Primitive<RTYPE,NA,T> >::type
 operator+(
 	const VectorBase<RTYPE,NA,T>& lhs,
 	U rhs
@@ -453,7 +454,7 @@ operator+(
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline sugar::Plus_Vector_Primitive< RTYPE , NA , T >
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, typename sugar::Plus_Vector_Primitive< RTYPE , NA , T > >::type
 operator+(
 	U rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
@@ -463,19 +464,19 @@ operator+(
 
 
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T>
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T> >::type
 operator+(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename sugar::NonaPrimitive< typename traits::storage_type<RTYPE>::type > rhs
+	typename sugar::NonaPrimitive< U > rhs
 ) {
 	return sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Plus_Vector_Primitive_nona< RTYPE , NA , T >
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Plus_Vector_Primitive_nona< RTYPE , NA , T > >::type
 operator+(
-	typename sugar::NonaPrimitive< typename traits::storage_type<RTYPE>::type > rhs,
+	typename sugar::NonaPrimitive< U > rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Plus_Vector_Primitive_nona<RTYPE,NA, T >( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/plus.h
+++ b/inst/include/Rcpp/sugar/operators/plus.h
@@ -444,19 +444,19 @@ namespace sugar{
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, typename sugar::Plus_Vector_Primitive<RTYPE,NA,T> >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, typename sugar::Plus_Vector_Primitive<RTYPE,NA,T> >::type
 operator+(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	U rhs
+	const U &rhs
 ) {
 	return sugar::Plus_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, typename sugar::Plus_Vector_Primitive< RTYPE , NA , T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, typename sugar::Plus_Vector_Primitive< RTYPE , NA , T> >::type
 operator+(
-	U rhs,
+	const U &rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Plus_Vector_Primitive<RTYPE,NA, T >( lhs, rhs ) ;
@@ -465,18 +465,18 @@ operator+(
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T> >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T> >::type
 operator+(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename sugar::NonaPrimitive< U > rhs
+	const typename sugar::NonaPrimitive< U > &rhs
 ) {
 	return sugar::Plus_Vector_Primitive_nona<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Plus_Vector_Primitive_nona< RTYPE , NA , T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Plus_Vector_Primitive_nona< RTYPE , NA , T> >::type
 operator+(
-	typename sugar::NonaPrimitive< U > rhs,
+	const typename sugar::NonaPrimitive< U > &rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Plus_Vector_Primitive_nona<RTYPE,NA, T >( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/times.h
+++ b/inst/include/Rcpp/sugar/operators/times.h
@@ -424,20 +424,20 @@ namespace sugar{
 
 }
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Times_Vector_Primitive<RTYPE,NA,T>
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive<RTYPE,NA,T> >::type
 operator*(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename traits::storage_type<RTYPE>::type rhs
+	U rhs
 ) {
 	return sugar::Times_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Times_Vector_Primitive< RTYPE , NA , T >
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive< RTYPE , NA , T > >::type
 operator*(
-	typename traits::storage_type<RTYPE>::type rhs,
+	U rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Times_Vector_Primitive<RTYPE,NA, T >( lhs, rhs ) ;
@@ -445,19 +445,19 @@ operator*(
 
 
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Times_Vector_Primitive_nona<RTYPE,NA,T>
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive_nona<RTYPE,NA,T> >::type
 operator*(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename sugar::NonaPrimitive< typename traits::storage_type<RTYPE>::type > rhs
+	typename sugar::NonaPrimitive< U > rhs
 ) {
 	return sugar::Times_Vector_Primitive_nona<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
-template <int RTYPE,bool NA, typename T>
-inline sugar::Times_Vector_Primitive_nona< RTYPE , NA , T >
+template <int RTYPE,bool NA, typename T, typename U>
+inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive_nona< RTYPE , NA , T > >::type
 operator*(
-	typename sugar::NonaPrimitive< typename traits::storage_type<RTYPE>::type > rhs,
+	typename sugar::NonaPrimitive< U > rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Times_Vector_Primitive_nona<RTYPE,NA, T >( lhs, rhs ) ;

--- a/inst/include/Rcpp/sugar/operators/times.h
+++ b/inst/include/Rcpp/sugar/operators/times.h
@@ -425,19 +425,19 @@ namespace sugar{
 }
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive<RTYPE,NA,T> >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Times_Vector_Primitive<RTYPE,NA,T> >::type
 operator*(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	U rhs
+	const U &rhs
 ) {
 	return sugar::Times_Vector_Primitive<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive< RTYPE , NA , T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Times_Vector_Primitive< RTYPE , NA , T > >::type
 operator*(
-	U rhs,
+	const U &rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Times_Vector_Primitive<RTYPE,NA, T >( lhs, rhs ) ;
@@ -446,18 +446,18 @@ operator*(
 
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive_nona<RTYPE,NA,T> >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Times_Vector_Primitive_nona<RTYPE,NA,T> >::type
 operator*(
 	const VectorBase<RTYPE,NA,T>& lhs,
-	typename sugar::NonaPrimitive< U > rhs
+	const typename sugar::NonaPrimitive< U > &rhs
 ) {
 	return sugar::Times_Vector_Primitive_nona<RTYPE,NA,T>( lhs, rhs ) ;
 }
 
 template <int RTYPE,bool NA, typename T, typename U>
-inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference<U>::type >::value, sugar::Times_Vector_Primitive_nona< RTYPE , NA , T > >::type
+inline typename traits::enable_if<traits::is_convertible<typename traits::remove_const_and_reference<U>::type, typename traits::storage_type<RTYPE>::type>::value, sugar::Times_Vector_Primitive_nona< RTYPE , NA , T > >::type
 operator*(
-	typename sugar::NonaPrimitive< U > rhs,
+	const typename sugar::NonaPrimitive< U > &rhs,
 	const VectorBase<RTYPE,NA,T>& lhs
 ) {
 	return sugar::Times_Vector_Primitive_nona<RTYPE,NA, T >( lhs, rhs ) ;

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -249,9 +249,9 @@ inline std::ostream &operator<<(std::ostream & s, const Matrix<REALSXP, StorageP
 
 #define RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(__OPERATOR__)                                                                    \
     template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
-    inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference< T >::type >::value, \
-         Matrix<RTYPE, StoragePolicy> >::type operator __OPERATOR__ (const Matrix<RTYPE, StoragePolicy> &lhs,                 \
-        T rhs) {                                                                                                              \
+    inline typename traits::enable_if< traits::is_convertible< typename traits::remove_const_and_reference< T >::type,        \
+         typename Matrix<RTYPE, StoragePolicy>::stored_type >::value, Matrix<RTYPE, StoragePolicy> >::type                    \
+             operator __OPERATOR__ (const Matrix<RTYPE, StoragePolicy> &lhs, const T &rhs) {                                  \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(lhs) __OPERATOR__ rhs;             \
         v.attr("dim") = Vector<INTSXP>::create(lhs.nrow(), lhs.ncol());                                                       \
         return as< Matrix<RTYPE, StoragePolicy> >(v);                                                                         \
@@ -266,9 +266,9 @@ RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(/)
 
 #define RCPP_GENERATE_SCALAR_MATRIX_OPERATOR(__OPERATOR__)                                                                    \
     template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
-    inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference< T >::type >::value, \
-         Matrix<RTYPE, StoragePolicy> >::type operator __OPERATOR__ (T lhs,                                                   \
-        const Matrix<RTYPE, StoragePolicy> &rhs) {                                                                            \
+    inline typename traits::enable_if< traits::is_convertible< typename traits::remove_const_and_reference< T >::type,        \
+         typename Matrix<RTYPE, StoragePolicy>::stored_type >::value, Matrix<RTYPE, StoragePolicy> >::type                    \
+             operator __OPERATOR__ (const T &lhs, const Matrix<RTYPE, StoragePolicy> &rhs) {                                  \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(rhs);                              \
         v = lhs __OPERATOR__ v;                                                                                               \
         v.attr("dim") = Vector<INTSXP>::create(rhs.nrow(), rhs.ncol());                                                       \

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -249,7 +249,8 @@ inline std::ostream &operator<<(std::ostream & s, const Matrix<REALSXP, StorageP
 
 #define RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(__OPERATOR__)                                                                    \
     template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
-    inline Matrix<RTYPE, StoragePolicy> operator __OPERATOR__ (const Matrix<RTYPE, StoragePolicy> &lhs,                       \
+    inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference< T >::type >::value, \
+         Matrix<RTYPE, StoragePolicy> >::type operator __OPERATOR__ (const Matrix<RTYPE, StoragePolicy> &lhs,                 \
         T rhs) {                                                                                                              \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(lhs) __OPERATOR__ rhs;             \
         v.attr("dim") = Vector<INTSXP>::create(lhs.nrow(), lhs.ncol());                                                       \
@@ -265,7 +266,8 @@ RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(/)
 
 #define RCPP_GENERATE_SCALAR_MATRIX_OPERATOR(__OPERATOR__)                                                                    \
     template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
-    inline Matrix<RTYPE, StoragePolicy> operator __OPERATOR__ (T lhs,                                                         \
+    inline typename traits::enable_if< traits::is_primitive< typename traits::remove_const_and_reference< T >::type >::value, \
+         Matrix<RTYPE, StoragePolicy> >::type operator __OPERATOR__ (T lhs,                                                   \
         const Matrix<RTYPE, StoragePolicy> &rhs) {                                                                            \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(rhs);                              \
         v = lhs __OPERATOR__ v;                                                                                               \

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -248,9 +248,9 @@ inline std::ostream &operator<<(std::ostream & s, const Matrix<REALSXP, StorageP
 }
 
 #define RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(__OPERATOR__)                                                                    \
-    template <int RTYPE, template <class> class StoragePolicy >                                                               \
+    template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
     inline Matrix<RTYPE, StoragePolicy> operator __OPERATOR__ (const Matrix<RTYPE, StoragePolicy> &lhs,                       \
-        const typename Matrix<RTYPE, StoragePolicy>::stored_type &rhs) {                                                      \
+        T rhs) {                                                                                                              \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(lhs) __OPERATOR__ rhs;             \
         v.attr("dim") = Vector<INTSXP>::create(lhs.nrow(), lhs.ncol());                                                       \
         return as< Matrix<RTYPE, StoragePolicy> >(v);                                                                         \
@@ -264,8 +264,8 @@ RCPP_GENERATE_MATRIX_SCALAR_OPERATOR(/)
 #undef RCPP_GENERATE_MATRIX_SCALAR_OPERATOR
 
 #define RCPP_GENERATE_SCALAR_MATRIX_OPERATOR(__OPERATOR__)                                                                    \
-    template <int RTYPE, template <class> class StoragePolicy >                                                               \
-    inline Matrix<RTYPE, StoragePolicy> operator __OPERATOR__ (const typename Matrix<RTYPE, StoragePolicy>::stored_type &lhs, \
+    template <int RTYPE, template <class> class StoragePolicy, typename T >                                                   \
+    inline Matrix<RTYPE, StoragePolicy> operator __OPERATOR__ (T lhs,                                                         \
         const Matrix<RTYPE, StoragePolicy> &rhs) {                                                                            \
         Vector<RTYPE, StoragePolicy> v = static_cast<const Vector<RTYPE, StoragePolicy> &>(rhs);                              \
         v = lhs __OPERATOR__ v;                                                                                               \


### PR DESCRIPTION
So the crux of this is it makes templates that match exactly the function calls that happened.  I achieved this by adding another template parameter to each of the arithmetic operators for for `Vector` and `Matrix` and then restricting the values allowed for this template parameter using `enable_if`.

Additionally, the same ambiguities can be exposed with the following C++ code on 64-bit (though it's unlikely anyone would have done this):

```c++
#include <Rcpp.h>

void testFunction(Rcpp::NumericVector x, long l)
{
        Rcpp::NumericVector y = x + l;
}

void testFunction2(Rcpp::NumericMatrix x, long l)
{
        Rcpp::NumericMatrix y = x + l;
}
```
@eddelbuettel, @kevinushey, @thirdwing please have a look.