### PR TITLE
Fix the string replace

### DIFF
--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -262,7 +262,8 @@ namespace Rcpp {
             RCPP_STRING_DEBUG_2("String::replace_first(const char* = '%s' , const char* = '%s')", s, news);
             if (is_na()) return *this;
             setBuffer();
-            size_t index = buffer.find_first_of(s);
+            std::string s2 = std::string(s);
+            size_t index = std::distance(buffer.begin(), std::search(buffer.begin(), buffer.end(), s2.begin(), s2.end()));
             if (index != std::string::npos) buffer.replace(index, strlen(s), news);
             valid = false;
             return *this;
@@ -287,7 +288,8 @@ namespace Rcpp {
             RCPP_STRING_DEBUG_2("String::replace_last(const char* = '%s' , const char* = '%s')", s, news);
             if (is_na()) return *this;
             setBuffer();
-            size_t index = buffer.find_last_of(s);
+            std::string s2 = std::string(s);
+            size_t index = std::distance(buffer.begin(), std::find_end(buffer.begin(), buffer.end(), s2.begin(), s2.end()));
             if (index != std::string::npos) buffer.replace(index, strlen(s), news);
             valid = false;
             return *this;
@@ -313,10 +315,13 @@ namespace Rcpp {
             RCPP_STRING_DEBUG_2("String::replace_all(const char* = '%s' , const char* = '%s')", s, news);
             if (is_na()) return *this;
             setBuffer();
-            size_t lens = strlen(s), len_news = strlen(news), index = buffer.find(s);
-            while(index != std::string::npos) {
-                buffer.replace(index, lens, news);
-                index = buffer.find(s, index + len_news);
+            std::string s2 = std::string(s);
+            std::string::iterator iter = buffer.begin();
+            while(true) {
+                iter = std::search(iter, buffer.end(), s2.begin(), s2.end());
+                if (iter == buffer.end()) break;
+                size_t index = std::distance(buffer.begin(), iter);
+                if (index != std::string::npos) buffer.replace(index, strlen(s), news);
             }
             valid = false;
             return *this;

--- a/inst/unitTests/runit.String.R
+++ b/inst/unitTests/runit.String.R
@@ -24,13 +24,13 @@ if (.runThisTest) {
     .setUp <- Rcpp:::unitTestSetup("String.cpp")
 
     test.replace_all <- function(){
-        checkEquals( String_replace_all("foobar", "o", "*"), "f**bar")
+        checkEquals( String_replace_all("abcdbacdab", "ab", "AB"), "ABcdbacdAB")
     }
     test.replace_first <- function(){
-        checkEquals( String_replace_first("foobar", "o", "*"), "f*obar")
+        checkEquals( String_replace_first("abcdbacdab", "ab", "AB"), "ABcdbacdab")
     }
     test.replace_last <- function(){
-        checkEquals( String_replace_last("foobar", "o", "*"), "fo*bar")
+        checkEquals( String_replace_last("abcdbacdab", "ab", "AB"), "abcdbacdAB")
     }
 
     test.String.sapply <- function(){


### PR DESCRIPTION
The CRAN version:

```cpp
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
String replace() {
  String foo("abba");
  return foo.replace_first("ba", "BA");
}

/*
> Rcpp::sourceCpp("test.cpp")
> replace()
[1] "BAba"
*/
```

After fix:

```r
> Rcpp::sourceCpp("test.cpp")
> replace()
[1] "abBA"
```

@kevinushey 