### PR TITLE
Annotate stop() with NORET

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-06-02  Kirill Müller <krlmlr@mailbox.org>
+
+        * inst/include/Rcpp/algorithm.h: Use "long long" only if available
+        * inst/include/Rcpp/exceptions.h: Annotate stop() with NORET
+
 2016-05-18  Daniel C. Dillon  <dcdillon@gmail.com>
 
         * inst/include/Rcpp/algorithm.h: New approach for sugar

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,11 @@
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
+      \item The \code{long long} data type is used only if it is available,
+      to avoid compiler warnings (Kirill Müller in \ghpr{488}).
+      \item The compiler is made aware that \code{stop()} never returns, to
+      improve code path analysis (Kirill Müller in \ghpr{487} addressing issue
+      \ghit{486}).
       \item String replacement was corrected (Qiang in \ghpr{479} following
       mailing list bug report by Masaki Tsuda)
     }

--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -12,7 +12,9 @@ namespace helpers {
     typedef struct {char a[2];} CTYPE_SHORT;
     typedef struct {char a[3];} CTYPE_INT;
     typedef struct {char a[4];} CTYPE_LONG;
+#ifdef RCPP_HAS_LONG_LONG_TYPES
     typedef struct {char a[5];} CTYPE_LONG_LONG;
+#endif
     typedef struct {char a[6];} CTYPE_FLOAT;
     typedef struct {char a[7];} CTYPE_DOUBLE;
     typedef struct {char a[8];} CTYPE_LONG_DOUBLE;
@@ -21,7 +23,9 @@ namespace helpers {
     typedef struct {char a[11];} CTYPE_UNSIGNED_SHORT;
     typedef struct {char a[12];} CTYPE_UNSIGNED_INT;
     typedef struct {char a[13];} CTYPE_UNSIGNED_LONG;
+#ifdef RCPP_HAS_LONG_LONG_TYPES
     typedef struct {char a[14];} CTYPE_UNSIGNED_LONG_LONG;
+#endif
     typedef struct {char a[128];} CTYPE_UNKNOWN;
 
     template< std::size_t I >
@@ -39,8 +43,10 @@ namespace helpers {
     template<>
     struct ctype_helper< sizeof(CTYPE_LONG) > { typedef long type; static const bool value = true; };
 
+#ifdef RCPP_HAS_LONG_LONG_TYPES
     template<>
     struct ctype_helper< sizeof(CTYPE_LONG_LONG) > { typedef long long type; static const bool value = true; };
+#endif
 
     template<>
     struct ctype_helper< sizeof(CTYPE_FLOAT) > { typedef float type; static const bool value = true; };
@@ -66,8 +72,10 @@ namespace helpers {
     template<>
     struct ctype_helper< sizeof(CTYPE_UNSIGNED_LONG) > { typedef unsigned long type; static const bool value = true; };
 
+#ifdef RCPP_HAS_LONG_LONG_TYPES
     template<>
     struct ctype_helper< sizeof(CTYPE_UNSIGNED_LONG_LONG) > { typedef unsigned long long type; static const bool value = true; };
+#endif
 
 
     template< typename T >
@@ -77,7 +85,9 @@ namespace helpers {
         static CTYPE_SHORT test(const short &);
         static CTYPE_INT test(const int &);
         static CTYPE_LONG test(const long &);
+#ifdef RCPP_HAS_LONG_LONG_TYPES
         static CTYPE_LONG_LONG test(const long long &);
+#endif
         static CTYPE_FLOAT test(const float &);
         static CTYPE_DOUBLE test(const double &);
         static CTYPE_LONG_DOUBLE test(const long double &);
@@ -86,7 +96,9 @@ namespace helpers {
         static CTYPE_UNSIGNED_SHORT test(const unsigned short &);
         static CTYPE_UNSIGNED_INT test(const unsigned int &);
         static CTYPE_UNSIGNED_LONG test(const unsigned long &);
+#ifdef RCPP_HAS_LONG_LONG_TYPES
         static CTYPE_UNSIGNED_LONG_LONG test(const unsigned long long &);
+#endif
         static CTYPE_UNKNOWN test(...);
 
         static T make();
@@ -101,7 +113,9 @@ namespace helpers {
         static CTYPE_SHORT test(const short &);
         static CTYPE_INT test(const int &);
         static CTYPE_LONG test(const long &);
+#ifdef RCPP_HAS_LONG_LONG_TYPES
         static CTYPE_LONG_LONG test(const long long &);
+#endif
         static CTYPE_FLOAT test(const float &);
         static CTYPE_DOUBLE test(const double &);
         static CTYPE_LONG_DOUBLE test(const long double &);
@@ -110,7 +124,9 @@ namespace helpers {
         static CTYPE_UNSIGNED_SHORT test(const unsigned short &);
         static CTYPE_UNSIGNED_INT test(const unsigned int &);
         static CTYPE_UNSIGNED_LONG test(const unsigned long &);
+#ifdef RCPP_HAS_LONG_LONG_TYPES
         static CTYPE_UNSIGNED_LONG_LONG test(const unsigned long long &);
+#endif
         static CTYPE_UNKNOWN test(...);
 
         static T make();

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -247,57 +247,57 @@ namespace Rcpp{
         Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
     }
 
-    inline void stop(const std::string& message) {
+    inline void NORET stop(const std::string& message) {
         throw Rcpp::exception(message.c_str());
     }
     
     template <typename T1>
-    inline void stop(const char* fmt, const T1& arg1) {
+    inline void NORET stop(const char* fmt, const T1& arg1) {
         throw Rcpp::exception( tfm::format(fmt, arg1 ).c_str() );
     }
     
     template <typename T1, typename T2>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2 ).c_str() );
     }
     
     template <typename T1, typename T2, typename T3>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
     }
     
     template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
-    inline void stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
     }
 }


### PR DESCRIPTION
per @kevinushey's suggestion. Fixes #486.

Closes #488 (=includes it).