### PR TITLE
Add RCPP_USING_UTF8_ERROR_STRING macro to use UTF-8 encoding exception string in R.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-06-20  Qin Wenfeng <mail@qinwenfeng.com>
+
+        * inst/include/Rcpp/exceptions.h: add RCPP_USING_UTF8_ERROR_STRING macro to use UTF-8 encoding exception string in R
+
 2016-06-14  Artem Klevtsov <a.a.klevtsov@gmail.com>
 
         * inst/include/Rcpp/sugar/functions/na_omit.h: Improve na_omit for

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,6 +14,7 @@
       \ghit{486}).
       \item String replacement was corrected (Qiang in \ghpr{479} following
       mailing list bug report by Masaki Tsuda)
+      \item Add RCPP_USING_UTF8_ERROR_STRING macro to use UTF-8 encoding exception string in R (Qin Wenfeng in \ghpr{493})
     }
     \item Changes in Rcpp Sugar:
     \itemize{


### PR DESCRIPTION
Hi, I posted on Rcpp mailing list last week about [Rcpp exception with UTF-8 strings on Windows](http://lists.r-forge.r-project.org/pipermail/rcpp-devel/2016-June/009291.html).

This PR adds RCPP_USING_UTF8_ERROR_STRING to use UTF-8 encoding exception string in R.

Here is an example for this on Windows.

By default, not using RCPP_USING_UTF8_ERROR_STRING,

```r
sourceCpp(code = "
#include <Rcpp.h>
          
// [[Rcpp::export]]
void error_with_unicode(std::string input){
    Rcpp::stop(input);
}
")
res = try(error_with_unicode(enc2utf8("测试")))
#> Error : 娴嬭瘯
Encoding(res)
#> [1] "unknown"
```

Using RCPP_USING_UTF8_ERROR_STRING,

```r
sourceCpp(code = "
#define RCPP_USING_UTF8_ERROR_STRING
#include <Rcpp.h>

// [[Rcpp::export]]
void error_with_unicode(std::string input){
    Rcpp::stop(input);
}
")
res = try(error_with_unicode(enc2utf8("测试")))
#> Error : 测试
Encoding(res)
#> [1] "UTF-8"
```