### PR TITLE
expose warning() and warningcall() (closes #495)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-06-23  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/print.h (Rcpp): Also expose Rf_warning() and
+        Rf_warningcall() with Rcpp namespace (without leading Rf_)
+
 2016-06-20  Qin Wenfeng <mail@qinwenfeng.com>
 
         * inst/include/Rcpp/exceptions.h: add RCPP_USING_UTF8_ERROR_STRING macro

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,8 @@
 
         * DESCRIPTION (Version): Rolling minor version
 
-        * inst/include/Rcpp/print.h (Rcpp): Also expose Rf_warning() and
-        Rf_warningcall() with Rcpp namespace (without leading Rf_)
+        * inst/include/Rcpp/exceptions.h (Rcpp): Also expose Rf_warningcall()
+        within Rcpp namespace (without leading Rf_) 
 
 2016-06-20  Qin Wenfeng <mail@qinwenfeng.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2016-06-23  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION (Version): Rolling minor version
+
         * inst/include/Rcpp/print.h (Rcpp): Also expose Rf_warning() and
         Rf_warningcall() with Rcpp namespace (without leading Rf_)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.5.2
-Date: 2016-05-22
+Version: 0.12.5.3
+Date: 2016-06-23
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey,
  Qiang Kou, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,7 +17,7 @@
       \item Allow for UTF-8 encoding in error messages via
       \code{RCPP_USING_UTF8_ERROR_STRING} macro (Qin Wenfeng in \ghpr{493})
       \item The R function \code{Rf_warning} and \code{Rf_warningcall} are now
-      provided as well (as usual without leading Rf_) (\ghit{495})
+      provided as well (as usual without leading Rf_) (\ghpr{496} fixing \ghit{495})
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,7 +15,9 @@
       \item String replacement was corrected (Qiang in \ghpr{479} following
       mailing list bug report by Masaki Tsuda)
       \item Allow for UTF-8 encoding in error messages via
-      \code{RCPP_USING_UTF8_ERROR_STRING} macro (Qin Wenfeng in \ghpr{493}) 
+      \code{RCPP_USING_UTF8_ERROR_STRING} macro (Qin Wenfeng in \ghpr{493})
+      \item The R function \code{Rf_warning} and \code{Rf_warningcall} are now
+      provided as well (as usual without leading Rf_) (\ghit{495})
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -16,8 +16,8 @@
       mailing list bug report by Masaki Tsuda)
       \item Allow for UTF-8 encoding in error messages via
       \code{RCPP_USING_UTF8_ERROR_STRING} macro (Qin Wenfeng in \ghpr{493})
-      \item The R function \code{Rf_warning} and \code{Rf_warningcall} are now
-      provided as well (as usual without leading Rf_) (\ghpr{496} fixing \ghit{495})
+      \item The R function \code{Rf_warningcall} is now provided as well (as
+      usual without leading Rf_) (\ghpr{496} fixing \ghit{495}) 
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -2,7 +2,7 @@
 //
 // exceptions.h: Rcpp R/C++ interface class library -- exceptions
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -212,6 +212,10 @@ namespace Rcpp{
 
     inline void warning(const std::string& message) {
         Rf_warning(message.c_str());
+    }
+
+    inline void warningcall(SEXP call, const std::string & s) {
+        Rf_warningcall(call, s.c_str());
     }
 
     template <typename T1>

--- a/inst/include/Rcpp/print.h
+++ b/inst/include/Rcpp/print.h
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// Copyright (C) 2015  Dirk Eddelbuettel
+// Copyright (C) 2015 - 2016  Dirk Eddelbuettel
 //
 // This file is part of Rcpp.
 //
@@ -24,6 +24,14 @@ namespace Rcpp {
 
 inline void print(SEXP s) {
     Rf_PrintValue(s);           // defined in Rinternals.h
+}
+
+inline void warning(const std::string s) {
+    Rf_warning(s.c_str());
+}
+
+inline void warningcall(SEXP call, const std::string s) {
+    Rf_warningcall(call, s.c_str());
 }
 
 }

--- a/inst/include/Rcpp/print.h
+++ b/inst/include/Rcpp/print.h
@@ -26,11 +26,11 @@ inline void print(SEXP s) {
     Rf_PrintValue(s);           // defined in Rinternals.h
 }
 
-inline void warning(const std::string s) {
+inline void warning(const std::string & s) {
     Rf_warning(s.c_str());
 }
 
-inline void warningcall(SEXP call, const std::string s) {
+inline void warningcall(SEXP call, const std::string & s) {
     Rf_warningcall(call, s.c_str());
 }
 

--- a/inst/include/Rcpp/print.h
+++ b/inst/include/Rcpp/print.h
@@ -1,6 +1,6 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// Copyright (C) 2015 - 2016  Dirk Eddelbuettel
+// Copyright (C) 2015  Dirk Eddelbuettel
 //
 // This file is part of Rcpp.
 //
@@ -24,16 +24,6 @@ namespace Rcpp {
 
 inline void print(SEXP s) {
     Rf_PrintValue(s);           // defined in Rinternals.h
-}
-
-inline void warning(const std::string & s) {
-    Rf_warning(s.c_str());
-}
-
-inline void warningcall(SEXP call, const std::string & s) {
-    Rf_warningcall(call, s.c_str());
-}
-
 }
 
 #endif


### PR DESCRIPTION
Uses Rf_* versions as usual