### PR TITLE
Added find() & get() to environment (closes #326)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-07-22  James J Balamuta  <balamut2@illinois.edu>
+        * inst/include/Rcpp/Environment.h: Added get() & find() that accept 
+        a symbol
+        * inst/include/Rcpp.h: Modified header load order so that Symbol.h 
+        is now placed before Environment.h
+
 2016-07-21  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version): Roll minor release
@@ -10,7 +16,7 @@
 
         * DESCRIPTION: Release 0.12.6
         * inst/NEWS.Rd: Release 0.12.6
-	* vignettes/Rcpp.bib: Release 0.12.6, RProtoBuf updates
+        * vignettes/Rcpp.bib: Release 0.12.6, RProtoBuf updates
         * inst/include/Rcpp/config.h: Release 0.12.6
 
         * README.md: Updated counts for dependents and tests

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,8 @@
     \itemize{
       \item The \code{NORET} macro is now defined if it was not already defined
       by R (Kevin fixing issue \ghit{512}). 
+      \item Environment functions get() & find() now accept a Symbol
+      (James Joseph Balamuta in \ghpr{513} addressing issue \ghit{326}).
     }
   }
 }

--- a/inst/include/Rcpp.h
+++ b/inst/include/Rcpp.h
@@ -33,6 +33,8 @@
 #include <Rcpp/clone.h>
 #include <Rcpp/grow.h>
 #include <Rcpp/Dimension.h>
+
+#include <Rcpp/Symbol.h>
 #include <Rcpp/Environment.h>
 
 #include <Rcpp/Vector.h>
@@ -42,7 +44,6 @@
 #include <Rcpp/Promise.h>
 
 #include <Rcpp/XPtr.h>
-#include <Rcpp/Symbol.h>
 #include <Rcpp/DottedPairImpl.h>
 #include <Rcpp/Function.h>
 #include <Rcpp/Language.h>

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -115,6 +115,27 @@ namespace Rcpp{
             }
             return res ;
         }
+        
+        /**
+        * Get an object from the environment
+        *
+        * @param name symbol name to call
+        *
+        * @return a SEXP (possibly R_NilValue)
+        */
+        SEXP get(Symbol name) const {
+            SEXP env = Storage::get__() ;
+            SEXP res = Rf_findVarInFrame( env, name ) ;
+            
+            if( res == R_UnboundValue ) return R_NilValue ;
+            
+            /* We need to evaluate if it is a promise */
+            if( TYPEOF(res) == PROMSXP){
+                res = Rf_eval( res, env ) ;
+            }
+            return res ;
+        }
+        
 
         /**
          * Get an object from the environment or one of its
@@ -130,6 +151,29 @@ namespace Rcpp{
 
             if( res == R_UnboundValue ) throw binding_not_found(name) ;
 
+            /* We need to evaluate if it is a promise */
+            if( TYPEOF(res) == PROMSXP){
+                res = Rf_eval( res, env ) ;
+            }
+            return res ;
+        }
+        
+        /**
+        * Get an object from the environment or one of its
+        * parents
+        *
+        * @param name symbol name to call
+        */
+        SEXP find(Symbol name) const{
+            SEXP env = Storage::get__() ;
+            SEXP res = Rf_findVar( name, env ) ;
+            
+            if( res == R_UnboundValue ) {
+                // Pass on the const char* to the RCPP_EXCEPTION_CLASS's
+                // const std::string& requirement
+                throw binding_not_found(name.c_str()) ;
+            }
+            
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
                 res = Rf_eval( res, env ) ;


### PR DESCRIPTION
Modified load order of Rcpp.h to allow for symbol object to be used within Environment.h by placing Symbol.h before Environment.h

Used the .c_str() on symbol to ensure exception call could be made. (Assuming the symbol name is not NULL).

Fixed a space in changelog 