### PR TITLE
Modernize rcppgibbs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,10 @@
 2016-08-04  James J Balamuta  <balamut2@illinois.edu>
 
         * src/attributes.cpp: Correct variable re-declaration
-
+        * inst/examples/RcppGibbs/RcppGibbs.R: Updated example to use Rcpp
+        attributes instead of cxxfunction
+        * inst/examples/RcppGibbs/timeRNGs.R: Idem
+        
 2016-08-03  Dirk Eddelbuettel  <edd@debian.org>
 
         * .gitattributes: Added to have ChangeLog and NEWS.Rd merge via union

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -27,6 +27,12 @@
       call the standalone Rmath library. (James Balamuta in \ghpr{514} 
       addressing issue \ghit{28}).
     }
+    \item Changes in Rcpp Examples:
+    \itemize{
+      \item Examples that used cxxfunction() from the inline package have been
+      rewritten to use either sourceCpp() or cppFunction() 
+      (James Balamuta in \ghpr{532} addressing issue \ghit{56}).
+    }
   }
 }
 

--- a/inst/examples/RcppGibbs/timeRNGs.R
+++ b/inst/examples/RcppGibbs/timeRNGs.R
@@ -3,7 +3,11 @@ suppressMessages(library(Rcpp))
 suppressMessages(library(inline))
 suppressMessages(library(rbenchmark))
 
-rcppGamma <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
+## NOTE: This is the old way to compile Rcpp code inline.
+## The code here has left as a historical artifact and tribute to the old way.
+## Please use the code under the "new" inline compilation section.
+
+rcppGamma_old <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
   NumericVector x(xs);
   int n   = x.size();
 
@@ -20,7 +24,7 @@ rcppGamma <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
 ')
 
 
-gslGamma <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
+gslGamma_old <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
                         include='#include <gsl/gsl_rng.h>
                                  #include <gsl/gsl_randist.h>',
                         body='
@@ -39,7 +43,7 @@ gslGamma <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
 ')
 
 
-rcppNormal <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
+rcppNormal_old <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
   NumericVector x(xs);
   int n   = x.size();
 
@@ -56,7 +60,7 @@ rcppNormal <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
 ')
 
 
-gslNormal <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
+gslNormal_old <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
                         include='#include <gsl/gsl_rng.h>
                                  #include <gsl/gsl_randist.h>',
                         body='
@@ -74,6 +78,83 @@ gslNormal <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
   return x;
 ')
 
+
+## NOTE: Within this section, the new way to compile Rcpp code inline has been
+## written. Please use the code next as a template for your own project.
+
+cppFunction('
+NumericVector rcppGamma(NumericVector x){
+    int n   = x.size();
+    
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = R::rgamma(3.0, 1.0/(y*y+4));
+    }
+    
+    // Return to R
+    return x;
+}')
+
+## This approach is a bit sloppy. Generally, you will want to use 
+## sourceCpp() if there are additional includes that are required.
+cppFunction('
+NumericVector gslGamma(NumericVector x){
+    int n   = x.size();
+    
+    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = gsl_ran_gamma(r,3.0,1.0/(y*y+4));
+    }
+    gsl_rng_free(r);
+    
+    // Return to R
+    return x;
+}', includes = '#include <gsl/gsl_rng.h>
+                #include <gsl/gsl_randist.h>',
+    depends = "RcppGSL")
+
+
+cppFunction('
+NumericVector rcppNormal(NumericVector x){
+    int n   = x.size();
+    
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = R::rnorm(1.0/(y+1),1.0/sqrt(2*y+2));
+    }
+    
+    // Return to R
+    return x;
+}')
+
+
+## Here we demonstrate the use of sourceCpp() to show the continuity 
+## of the code artifact.
+
+sourceCpp(code = '
+#include <RcppGSL.h>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
+
+using namespace Rcpp;
+
+// [[Rcpp::depends("RcppGSL")]]
+
+// [[Rcpp::export]]
+NumericVector gslNormal(NumericVector x){
+    int n   = x.size();
+    
+    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = 1.0/(y+1)+gsl_ran_gaussian(r,1.0/sqrt(2*y+2));
+    }
+    gsl_rng_free(r);
+    
+    // Return to R
+    return x;
+}')
 
 x <- rep(NA, 1e6)
 res <- benchmark(rcppGamma(x),


### PR DESCRIPTION
Part of #56's push to switch examples away from the cxxfunction to Rcpp attributes.

From the discussion of #56, it seems like there will be multiple PRs to complete the job. Specifically, 1 PR per example directory / vignette. 