### PR TITLE
Fixed bug relating to copying of FormatList object.

### DIFF
--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -850,6 +850,7 @@ class FormatList
                             const FormatList& list);
 
     private:
+        FormatList(const FormatList& other);
         const detail::FormatArg* m_formatters;
         int m_N;
 };


### PR DESCRIPTION
On the intel compiler, version 15.0.5.223 there appears to be a bug in tinyformat.h, which in my case is triggered by use of the readxl package.

Due to the ridiculous amount of templating it's hard for me to be sure, but I believe that somehow an object of class detail::FormatListN<N> is being copied as an object of class FormatList. The original FormatListN<N> object is then deleted, and the copied FormatList now contains an invalid pointer.

This may be compiler specific. 