### PR TITLE
Modernizing fastlm and functionCallback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2016-08-05  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/examples/FastLM/fastLMviaArmadillo.r: format fix
+        * inst/examples/FastLM/lmGSL.R: Updated example to use 
+        Rcpp attributes instead of cxxfunction
+        * inst/examples/FastLM/lmArmadillo.R: Idem
+        * inst/examples/functionCallback/newApiExample.r: Idem
+        * inst/examples/RcppInline/RcppInlineExample.r: Idem
+        * inst/examples/RcppInline/RcppInlineWithLibsExamples.r: Idem
+        * inst/examples/RcppInline/UncaughtExceptions.r: Idem
+        * inst/examples/RcppInline/external_pointer.r: Idem
+
 2016-08-04  James J Balamuta  <balamut2@illinois.edu>
 
         * src/attributes.cpp: Correct variable re-declaration

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -31,7 +31,8 @@
     \itemize{
       \item Examples that used cxxfunction() from the inline package have been
       rewritten to use either sourceCpp() or cppFunction() 
-      (James Balamuta in \ghpr{532} addressing issue \ghit{56}).
+      (James Balamuta in \ghpr{535}, \ghpr{534}, and \ghpr{532} 
+      addressing issue \ghit{56}).
     }
   }
 }

--- a/inst/examples/FastLM/fastLMviaArmadillo.r
+++ b/inst/examples/FastLM/fastLMviaArmadillo.r
@@ -27,8 +27,8 @@ checkLmArmadillo <- function(y, X) {
     fun <- lmArmadillo()
     res <- fun(y, X)
     fit <- lm(y ~ X - 1)
-    rc <- all.equal( res[[1]], as.numeric(coef(fit))) &
-          all.equal( res[[2]], as.numeric(coef(summary(fit))[,2]))
+    rc <- all.equal( as.numeric(res[[1]]), as.numeric(coef(fit))) &
+          all.equal( as.numeric(res[[2]]), as.numeric(coef(summary(fit))[,2]))
     invisible(rc)
 }
 

--- a/inst/examples/functionCallback/newApiExample.r
+++ b/inst/examples/functionCallback/newApiExample.r
@@ -1,7 +1,6 @@
 #!/usr/bin/env r
 
 suppressMessages(library(Rcpp))
-suppressMessages(library(inline))
 
 # R function that will be called from C++
 vecfunc <- function(x) {
@@ -11,6 +10,12 @@ vecfunc <- function(x) {
     Sys.sleep(0.225)                    # sleep before next call
     return(y)
 }
+
+## NOTE: This is the old way to compile Rcpp code inline.
+## The code here has left as a historical artifact and tribute to the old way.
+## Please use the code under the "new" inline compilation section.
+
+suppressMessages(library(inline))
 
 # C++ source code to operate on function and vector
 cpp <- '
@@ -26,6 +31,20 @@ cpp <- '
 # create a C++ function
 funx <- cxxfunction(signature(N = "integer" , xvec = "numeric", fun = "function" ),
                     body=cpp, include = "using namespace Rcpp; ", plugin = "Rcpp")
+
+
+## NOTE: Within this section, the new way to compile Rcpp code inline has been
+## written. Please use the code next as a template for your own project.
+
+# C++ source code to operate on function and vector
+cppFunction('
+NumericVector funx(int n, NumericVector numvec, Function f){
+    for( int i = 0; i < n; i++ ){
+       numvec = f( numvec ) ;
+    }
+    return numvec ;
+}')
+
 
 # create the vector
 xvec <- sqrt(c(1:12, 11:1))


### PR DESCRIPTION
Part of #56's push to switch examples away from the cxxfunction to Rcpp
attributes.