### PR TITLE
Remove leading underscore from header guard methods.

### DIFF
--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2149,7 +2149,7 @@ namespace attributes {
     }
 
     std::string CppExportsIncludeGenerator::getHeaderGuard() const {
-        return "_RCPP_" + packageCpp() + "_RCPPEXPORTS_H_GEN_";
+        return "RCPP_" + packageCpp() + "_RCPPEXPORTS_H_GEN_";
     }
 
     CppPackageIncludeGenerator::CppPackageIncludeGenerator(
@@ -2197,7 +2197,7 @@ namespace attributes {
     }
 
     std::string CppPackageIncludeGenerator::getHeaderGuard() const {
-        return "_RCPP_" + packageCpp() + "_H_GEN_";
+        return "RCPP_" + packageCpp() + "_H_GEN_";
     }
 
     RExportsGenerator::RExportsGenerator(const std::string& packageDir,


### PR DESCRIPTION
According to http://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier/228797#228797 leading underscores should be avoided at all.

> Each name that contains a double underscore (_ _) or **begins with an underscore followed by an uppercase letter** (2.11) is reserved to the implementation for any use.

See our discussion on: http://stackoverflow.com/questions/39291133/how-to-change-header-include-guards-in-rcpp-interfaces/39291326?noredirect=1#comment65919759_39291326
