### PR TITLE
[WIP] investigate -Wconversion warnings (close#391)

### DIFF
--- a/inst/include/Rcpp/Dimension.h
+++ b/inst/include/Rcpp/Dimension.h
@@ -40,16 +40,16 @@ namespace Rcpp{
 	        return *this ;
 	    }
 	    Dimension(const size_t& n1) : dims(1){
-	        dims[0] = n1 ;
+	        dims[0] = static_cast<int>(n1) ;
 	    }
 	    Dimension(const size_t& n1, const size_t& n2) : dims(2){
-	        dims[0] = n1 ;
-	        dims[1] = n2 ;
+	        dims[0] = static_cast<int>(n1) ;
+	        dims[1] = static_cast<int>(n2) ;
 	    }
 	    Dimension(const size_t& n1, const size_t& n2, const size_t& n3) : dims(3){
-	        dims[0] = n1 ;
-	        dims[1] = n2 ;
-	        dims[2] = n3 ;
+	        dims[0] = static_cast<int>(n1) ;
+	        dims[1] = static_cast<int>(n2) ;
+	        dims[2] = static_cast<int>(n3) ;
 	    }
 	    operator SEXP() const ;
 

--- a/inst/include/Rcpp/api/meat/module/Module.h
+++ b/inst/include/Rcpp/api/meat/module/Module.h
@@ -23,12 +23,12 @@
 namespace Rcpp {
 
     inline List Module::classes_info(){
-	    int n = classes.size() ;
+	    size_t n = classes.size() ;
 	    CharacterVector names(n) ;
 	    List info(n);
 	    CLASS_MAP::iterator it = classes.begin() ;
 	    std::string buffer ;
-	    for( int i=0; i<n; i++, ++it){
+	    for( size_t i=0; i<n; i++, ++it){
 	        names[i] = it->first ;
 	        info[i]  = CppClass( this , it->second, buffer ) ;
 	    }

--- a/inst/include/Rcpp/barrier.h
+++ b/inst/include/Rcpp/barrier.h
@@ -22,14 +22,14 @@
 #ifndef Rcpp__barrier__h
 #define Rcpp__barrier__h
 
-SEXP get_string_elt(SEXP, int) ;
-const char* char_get_string_elt(SEXP, int) ;
-void set_string_elt(SEXP, int, SEXP) ;
-void char_set_string_elt(SEXP, int, const char*) ;
+SEXP get_string_elt(SEXP, R_xlen_t) ;
+const char* char_get_string_elt(SEXP, R_xlen_t) ;
+void set_string_elt(SEXP, R_xlen_t, SEXP) ;
+void char_set_string_elt(SEXP, R_xlen_t, const char*) ;
 SEXP* get_string_ptr(SEXP) ;
 
-SEXP get_vector_elt(SEXP, int) ;
-void set_vector_elt(SEXP, int, SEXP ) ;
+SEXP get_vector_elt(SEXP, R_xlen_t) ;
+void set_vector_elt(SEXP, R_xlen_t, SEXP ) ;
 SEXP* get_vector_ptr(SEXP) ;
 const char* char_nocheck( SEXP ) ;
 void* dataptr(SEXP) ;

--- a/inst/include/Rcpp/hash/IndexHash.h
+++ b/inst/include/Rcpp/hash/IndexHash.h
@@ -185,8 +185,8 @@ namespace Rcpp{
         }
 
         /* NOTE: we are returning a 1-based index ! */
-        inline int get_index(STORAGE value) const {
-            int addr = get_addr(value) ;
+        inline unsigned int get_index(STORAGE value) const {
+            unsigned int addr = get_addr(value) ;
             while (data[addr]) {
               if (src[data[addr] - 1] == value)
                 return data[addr];
@@ -197,16 +197,16 @@ namespace Rcpp{
         }
 
         // defined below
-        int get_addr(STORAGE value) const ;
+        unsigned int get_addr(STORAGE value) const ;
     } ;
 
     template <>
-    inline int IndexHash<INTSXP>::get_addr(int value) const {
+    inline unsigned int IndexHash<INTSXP>::get_addr(int value) const {
         return RCPP_HASH(value) ;
     }
     template <>
-    inline int IndexHash<REALSXP>::get_addr(double val) const {
-      int addr;
+    inline unsigned int IndexHash<REALSXP>::get_addr(double val) const {
+      unsigned int addr;
       union dint_u {
           double d;
           unsigned int u[2];
@@ -222,9 +222,9 @@ namespace Rcpp{
     }
 
     template <>
-    inline int IndexHash<STRSXP>::get_addr(SEXP value) const {
+    inline unsigned int IndexHash<STRSXP>::get_addr(SEXP value) const {
         intptr_t val = (intptr_t) value;
-        int addr;
+        unsigned int addr;
         #if (defined _LP64) || (defined __LP64__) || (defined WIN64)
           addr = RCPP_HASH((val & 0xffffffff) ^ (val >> 32));
         #else

--- a/inst/include/Rcpp/hash/SelfHash.h
+++ b/inst/include/Rcpp/hash/SelfHash.h
@@ -75,8 +75,8 @@ namespace sugar{
         }
 
         /* NOTE: we are returning a 1-based index ! */
-        int get_index(STORAGE value) const {
-            int addr = get_addr(value) ;
+        unsigned int get_index(STORAGE value) const {
+            unsigned int addr = get_addr(value) ;
             while (data[addr]) {
               if (src[data[addr] - 1] == value)
                 return data[addr];
@@ -87,16 +87,16 @@ namespace sugar{
         }
 
         // defined below
-        int get_addr(STORAGE value) const ;
+        unsigned int get_addr(STORAGE value) const ;
     } ;
 
     template <>
-    inline int SelfHash<INTSXP>::get_addr(int value) const {
+    inline unsigned int SelfHash<INTSXP>::get_addr(int value) const {
         return RCPP_HASH(value) ;
     }
     template <>
-    inline int SelfHash<REALSXP>::get_addr(double val) const {
-      int addr;
+    inline unsigned int SelfHash<REALSXP>::get_addr(double val) const {
+      unsigned addr;
       union dint_u {
           double d;
           unsigned int u[2];
@@ -112,9 +112,9 @@ namespace sugar{
     }
 
     template <>
-    inline int SelfHash<STRSXP>::get_addr(SEXP value) const {
+    inline unsigned int SelfHash<STRSXP>::get_addr(SEXP value) const {
         intptr_t val = (intptr_t) value;
-        int addr;
+        unsigned int addr;
         #if (defined _LP64) || (defined __LP64__) || (defined WIN64)
           addr = RCPP_HASH((val & 0xffffffff) ^ (val >> 32));
         #else

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -115,7 +115,7 @@ inline SEXP primitive_range_wrap__impl__nocast( InputIterator first, InputIterat
 	Shield<SEXP> x( Rf_allocVector( RTYPE, size ) );
 
 	typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
-	int __trip_count = size >> 2 ;
+	int __trip_count = static_cast<int>(size >> 2) ;
 	STORAGE* start = r_vector_start<RTYPE>(x) ;
 	int i = 0 ;
 	for ( ; __trip_count > 0 ; --__trip_count) {

--- a/inst/include/Rcpp/module/Module.h
+++ b/inst/include/Rcpp/module/Module.h
@@ -71,11 +71,11 @@ namespace Rcpp {
          * vector of arity of all the functions exported by the module
          */
         IntegerVector functions_arity(){
-	        int n = functions.size() ;
+	        size_t n = functions.size() ;
 	        IntegerVector x( n ) ;
 	        CharacterVector names( n );
 	        MAP::iterator it = functions.begin() ;
-	        for( int i=0; i<n; i++, ++it){
+	        for(size_t i=0; i<n; i++, ++it){
 	            x[i] = (it->second)->nargs() ;
 	            names[i] = it->first ;
 	        }
@@ -87,10 +87,10 @@ namespace Rcpp {
          * vector of names of the functions
          */
         CharacterVector functions_names(){
-	        int n = functions.size() ;
+	        size_t n = functions.size() ;
 	        CharacterVector names( n );
 	        MAP::iterator it = functions.begin() ;
-	        for( int i=0; i<n; i++, ++it){
+	        for(size_t i=0; i<n; i++, ++it){
 	            names[i] = it->first ;
 	        }
 	        return names ;
@@ -100,10 +100,10 @@ namespace Rcpp {
          * exposed class names
          */
         inline CharacterVector class_names(){
-            int n = classes.size() ;
+            size_t n = classes.size() ;
             CharacterVector names( n );
             CLASS_MAP::iterator it = classes.begin() ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 names[i] = it->first ;
             }
             return names ;
@@ -118,11 +118,11 @@ namespace Rcpp {
          * completion information
          */
         CharacterVector complete(){
-            int nf = functions.size() ;
-            int nc = classes.size() ;
-            int n = nf + nc ;
+            size_t nf = functions.size() ;
+            size_t nc = classes.size() ;
+            size_t n = nf + nc ;
             CharacterVector res( n ) ;
-            int i=0;
+            size_t i=0;
             MAP::iterator it = functions.begin();
             std::string buffer ;
             for( ; i<nf; i++, ++it) {
@@ -135,7 +135,7 @@ namespace Rcpp {
                 res[i] = buffer ;
             }
             CLASS_MAP::iterator cit = classes.begin() ;
-            for( int j=0; j<nc; j++, i++, ++cit){
+            for( size_t j=0; j<nc; j++, i++, ++cit){
                 res[i] = cit->first ;
             }
             return res ;
@@ -154,9 +154,9 @@ namespace Rcpp {
          */
         inline SEXP get_function( const std::string& name_ ){
             MAP::iterator it = functions.begin() ;
-            int n = functions.size() ;
+            size_t n = functions.size() ;
             CppFunction* fun = 0 ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 if( name_.compare( it->first ) == 0){
                     fun = it->second ;
                     break ;
@@ -179,9 +179,9 @@ namespace Rcpp {
          */
         inline DL_FUNC get_function_ptr( const std::string& name_ ){
 	        MAP::iterator it = functions.begin() ;
-	        int n = functions.size() ;
+	        size_t n = functions.size() ;
 	        CppFunction* fun = 0 ;
-	        for( int i=0; i<n; i++, ++it){
+	        for( size_t i=0; i<n; i++, ++it){
 	            if( name_.compare( it->first ) == 0){
 	                fun = it->second ;
 	                break ;

--- a/inst/include/Rcpp/routines.h
+++ b/inst/include/Rcpp/routines.h
@@ -44,13 +44,13 @@ std::string   demangle(const std::string& name);
 const char*   short_file_name(const char* );
 int*          get_cache(int n);
 SEXP          stack_trace( const char *file, int line);
-SEXP          get_string_elt(SEXP s, int i);
-const char*   char_get_string_elt(SEXP s, int i);
-void          set_string_elt(SEXP s, int i, SEXP v);
-void          char_set_string_elt(SEXP s, int i, const char* v);
+SEXP          get_string_elt(SEXP s, R_xlen_t i);
+const char*   char_get_string_elt(SEXP s, R_xlen_t i);
+void          set_string_elt(SEXP s, R_xlen_t i, SEXP v);
+void          char_set_string_elt(SEXP s, R_xlen_t i, const char* v);
 SEXP*         get_string_ptr(SEXP s);
-SEXP          get_vector_elt(SEXP v, int i);
-void          set_vector_elt(SEXP v, int i, SEXP x);
+SEXP          get_vector_elt(SEXP v, R_xlen_t i);
+void          set_vector_elt(SEXP v, R_xlen_t i, SEXP x);
 SEXP*         get_vector_ptr(SEXP v);
 const char*   char_nocheck(SEXP x);
 void*         dataptr(SEXP x);
@@ -149,26 +149,26 @@ inline attribute_hidden SEXP stack_trace( const char *file, int line){
     return fun(file, line);
 }
 
-inline attribute_hidden SEXP get_string_elt(SEXP s, int i){
-    typedef SEXP (*Fun)(SEXP, int);
+inline attribute_hidden SEXP get_string_elt(SEXP s, R_xlen_t i){
+    typedef SEXP (*Fun)(SEXP, R_xlen_t);
     static Fun fun = GET_CALLABLE("get_string_elt");
     return fun(s, i);
 }
 
-inline attribute_hidden const char* char_get_string_elt(SEXP s, int i){
-    typedef const char* (*Fun)(SEXP, int);
+inline attribute_hidden const char* char_get_string_elt(SEXP s, R_xlen_t i){
+    typedef const char* (*Fun)(SEXP, R_xlen_t);
     static Fun fun = GET_CALLABLE("char_get_string_elt");
     return fun(s, i);
 }
 
-inline attribute_hidden void set_string_elt(SEXP s, int i, SEXP v){
-    typedef void (*Fun)(SEXP,int,SEXP);
+inline attribute_hidden void set_string_elt(SEXP s, R_xlen_t i, SEXP v){
+    typedef void (*Fun)(SEXP, R_xlen_t, SEXP);
     static Fun fun = GET_CALLABLE("set_string_elt");
     fun(s, i, v);
 }
 
-inline attribute_hidden void char_set_string_elt(SEXP s, int i, const char* v){
-    typedef void (*Fun)(SEXP,int, const char*);
+inline attribute_hidden void char_set_string_elt(SEXP s, R_xlen_t i, const char* v){
+    typedef void (*Fun)(SEXP, R_xlen_t, const char*);
     static Fun fun = GET_CALLABLE("char_set_string_elt");
     fun(s, i, v );
 }
@@ -179,14 +179,14 @@ inline attribute_hidden SEXP* get_string_ptr(SEXP s){
     return fun(s);
 }
 
-inline attribute_hidden SEXP get_vector_elt(SEXP v, int i){
-    typedef SEXP (*Fun)(SEXP, int );
+inline attribute_hidden SEXP get_vector_elt(SEXP v, R_xlen_t i){
+    typedef SEXP (*Fun)(SEXP, R_xlen_t );
     static Fun fun = GET_CALLABLE("get_vector_elt");
     return fun(v, i);
 }
 
-inline attribute_hidden void set_vector_elt(SEXP v, int i, SEXP x){
-    typedef void (*Fun)(SEXP, int, SEXP);
+inline attribute_hidden void set_vector_elt(SEXP v, R_xlen_t i, SEXP x){
+    typedef void (*Fun)(SEXP, R_xlen_t, SEXP);
     static Fun fun = GET_CALLABLE("set_vector_elt");
     fun(v, i, x);
 }

--- a/inst/include/Rcpp/sugar/Range.h
+++ b/inst/include/Rcpp/sugar/Range.h
@@ -26,17 +26,17 @@ namespace Rcpp{
 
     class Range : public VectorBase<INTSXP,false, Range >{
     public:
-        Range( int start_, int end__ ) : start(start_), end_(end__){
+        Range( R_xlen_t start_, R_xlen_t end__ ) : start(start_), end_(end__){
             if( start_ > end__ ){
                 throw std::range_error( "upper value must be greater than lower value" ) ;
             }
         }
 
-        inline int size() const{
+        inline R_xlen_t size() const{
             return end_ - start + 1;
         }
 
-        inline int operator[]( int i) const {
+        inline R_xlen_t operator[]( R_xlen_t i) const {
             return start + i ;
         }
 
@@ -60,29 +60,29 @@ namespace Rcpp{
             return orig ;
         }
 
-        Range& operator+=(int n) {
+        Range& operator+=(R_xlen_t n) {
             start += n ; end_ += n ;
             return *this ;
         }
 
-        Range& operator-=(int n) {
+        Range& operator-=(R_xlen_t n) {
             start -= n ; end_ -= n ;
             return *this ;
         }
 
-        Range operator+( int n ){
+        Range operator+( R_xlen_t n ){
             return Range( start + n, end_ + n ) ;
         }
-        Range operator-( int n ){
+        Range operator-( R_xlen_t n ){
             return Range( start - n, end_ - n ) ;
         }
 
-        inline int get_start() const { return start ; }
-        inline int get_end() const { return end_ ; }
+        inline R_xlen_t get_start() const { return start ; }
+        inline R_xlen_t get_end() const { return end_ ; }
 
     private:
-        int start ;
-        int end_ ;
+        R_xlen_t start ;
+        R_xlen_t end_ ;
     } ;
 
 }

--- a/inst/include/Rcpp/vector/no_init.h
+++ b/inst/include/Rcpp/vector/no_init.h
@@ -66,7 +66,7 @@ private:
     int nc;
 } ;
 
-inline no_init_vector no_init(int size) {
+inline no_init_vector no_init(R_xlen_t size) {
     return no_init_vector(size);
 }
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1496,7 +1496,7 @@ namespace attributes {
         // Look for the signature termination ({ or ; not inside quotes)
         // on this line and then subsequent lines if necessary
         std::string signature;
-        for (int i = lineNumber; i<lines_.size(); i++) {
+        for (size_t i = lineNumber; i<lines_.size(); i++) {
             std::string line;
             line = lines_[i];
             bool insideQuotes = false;

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -31,22 +31,22 @@
 namespace Rcpp { SEXP Rcpp_eval(SEXP, SEXP); }
 
 // [[Rcpp::register]]
-SEXP get_string_elt(SEXP x, int i) {
+SEXP get_string_elt(SEXP x, R_xlen_t i) {
     return STRING_ELT(x, i);
 }
 
 // [[Rcpp::register]]
-const char* char_get_string_elt(SEXP x, int i) {
+const char* char_get_string_elt(SEXP x, R_xlen_t i) {
     return CHAR(STRING_ELT(x, i));
 }
 
 // [[Rcpp::register]]
-void set_string_elt(SEXP x, int i, SEXP value) {
+void set_string_elt(SEXP x, R_xlen_t i, SEXP value) {
     SET_STRING_ELT(x, i, value);
 }
 
 // [[Rcpp::register]]
-void char_set_string_elt(SEXP x, int i, const char* value) {
+void char_set_string_elt(SEXP x, R_xlen_t i, const char* value) {
     SET_STRING_ELT(x, i, Rf_mkChar(value));
 }
 
@@ -56,12 +56,12 @@ SEXP* get_string_ptr(SEXP x) {
 }
 
 // [[Rcpp::register]]
-SEXP get_vector_elt(SEXP x, int i) {
+SEXP get_vector_elt(SEXP x, R_xlen_t i) {
     return VECTOR_ELT(x, i);
 }
 
 // [[Rcpp::register]]
-void set_vector_elt(SEXP x, int i, SEXP value) {
+void set_vector_elt(SEXP x, R_xlen_t i, SEXP value) {
     SET_VECTOR_ELT(x, i, value);
 }
 


### PR DESCRIPTION
I spent some time investigating the `-Wconversion` warnings and fixed most of them.

Places I fixed:

(1) `string_elt` and `vector_elt` should accept `R_xlen_t` (https://github.com/wch/r-source/blob/trunk/src/include/Rinternals.h#L557-L558). This is something we really need to fix.

(2) length of vector should be `size_t` not `int`.

(3) the hashing functions should return `unsigned int` as we defined `RCPP_HASH` (https://github.com/RcppCore/Rcpp/blob/master/inst/include/Rcpp/hash/IndexHash.h#L46)

(4) I think `Range` sugar should accept `R_xlen_t` as start and end.

Places I don't fix:

(1) warnings in `rowSums.h` (https://github.com/RcppCore/Rcpp/blob/master/inst/include/Rcpp/sugar/functions/rowSums.h#L70). I think it is fine.

(2) `Date` and `Datetime`. I think @eddelbuettel knows these classes far better than me, so I didn't touch them.

Please take a look @kevinushey @eddelbuettel 