### PR TITLE
operator= for Matrix class (close #563)

### DIFF
--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -85,7 +85,14 @@ public:
         nrows = other.nrows ;
         return *this ;
     }
+
     Matrix& operator=( const SubMatrix<RTYPE>& ) ;
+
+    template <typename T>
+    Matrix& operator=( const T& x) {
+        this->assign_object( x, typename traits::is_sugar_expression<T>::type() ) ;
+        return *this ;
+    }
 
     explicit Matrix( const no_init_matrix& obj) {
         Storage::set__( Rf_allocMatrix( RTYPE, obj.nrow(), obj.ncol() ) );

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -602,6 +602,20 @@ protected:
         internal::r_init_vector<RTYPE>(Storage::get__()) ;
     }
 
+    // sugar
+    template <typename T>
+    inline void assign_object( const T& x, traits::true_type ) {
+        assign_sugar_expression( x.get_ref() ) ;
+    }
+
+    // anything else
+    template <typename T>
+    inline void assign_object( const T& x, traits::false_type ) {
+        Shield<SEXP> wrapped(wrap(x));
+        Shield<SEXP> casted(r_cast<RTYPE>(wrapped));
+        Storage::set__(casted);
+    }
+
 private:
 
     void push_back__impl(const stored_type& object, traits::true_type ) {
@@ -997,20 +1011,6 @@ private:
             Shield<SEXP> casted(r_cast<RTYPE>(wrapped));
             Storage::set__(casted);
         }
-    }
-
-    // sugar
-    template <typename T>
-    inline void assign_object( const T& x, traits::true_type ) {
-        assign_sugar_expression( x.get_ref() ) ;
-    }
-
-    // anything else
-    template <typename T>
-    inline void assign_object( const T& x, traits::false_type ) {
-        Shield<SEXP> wrapped(wrap(x));
-        Shield<SEXP> casted(r_cast<RTYPE>(wrapped));
-        Storage::set__(casted);
     }
 
     // we are importing a real sugar expression, i.e. not a vector


### PR DESCRIPTION
Just make `Matrix` to use the `operator=` from `Vector` class. This should fix #563 
```cpp
#include<Rcpp.h>

using namespace Rcpp;

//[[Rcpp::export]]
NumericMatrix testmat(int n, double fillme) {
  NumericMatrix M(n);
  M = fillme;
  return M;
}

//[[Rcpp::export]]
NumericVector testvec(int n, double fillme) {
  NumericVector M(n);
  M = fillme;
  return M;
}
/*
> Rcpp::sourceCpp("test.cpp")
> testmat(2, 3)
[1] 3
> testvec(2, 3)
[1] 3
*/
```

Personally I prefer being consistent with `Vector`, since `Matrix` is derived from it.

@kevinushey @eddelbuettel 