### PR TITLE
Matrix sugar functions eye, ones, and zeros - part of #564

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-10-23  Nathan Russell  <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/sugar/matrix/eye.h: New functions
+        eye(), ones(), and zeros()
+        * inst/include/Rcpp/sugar/matrix/matrix_functions.h: Idem
+        * inst/unitTests/cpp/sugar.cpp: Unit tests for new functions
+        * inst/unitTests/runit.sugar.R: Idem
+
 2016-10-21  Qiang Kou  <qkou@umail.iu.edu>
 
         * inst/include/Rcpp/barrier.h: Change string_elt/vector_elt to accept R_xlen_t

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,6 +15,8 @@
       \item Added new Sugar functions \code{rowSums()}, \code{colSums()},
       \code{rowMeans()}, \code{colMeans()} (PR \ghpr{551} by Nathan Russell 
       fixing \ghit{549})
+      \item Added new (matrix) Sugar functions \code{eye()}, 
+      \code{ones()}, \code{zeros()} (PR \ghpr{566} by Nathan Russell)
     }
     \item Updated Date and Datetime vector classes:
     \itemize{

--- a/inst/include/Rcpp/sugar/matrix/eye.h
+++ b/inst/include/Rcpp/sugar/matrix/eye.h
@@ -1,0 +1,159 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// eye.h: Rcpp R/C++ interface class library -- eye, ones, zeros
+//
+// Copyright (C) 2016 Nathan Russell
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__sugar__eye_h
+#define Rcpp__sugar__eye_h
+
+namespace Rcpp {
+namespace traits {
+
+template<bool>
+struct static_assertion;
+
+template<>
+struct static_assertion<true> {};
+
+template <typename T>
+class one_type {
+private:
+    Rcomplex op(true_type) const {
+        Rcomplex res;
+        res.i = 0.0;
+        res.r = 1.0;
+        return res;
+    }
+    
+    T op(false_type) const {
+        return static_cast<T>(1);
+    }
+    
+public:
+    operator T() const {
+        return op(typename same_type<T, Rcomplex>::type());
+    }
+};
+
+template <typename T>
+class zero_type {
+private:
+    Rcomplex op(true_type) const {
+        Rcomplex res;
+        res.i = 0.0;
+        res.r = 0.0;
+        return res;
+    }
+    
+    T op(false_type) const {
+        return static_cast<T>(0);
+    }
+    
+public:
+    operator T() const {
+        return op(typename same_type<T, Rcomplex>::type());
+    }
+};
+
+} // traits
+
+class eye {
+private:
+    int n;
+    
+public:
+    eye(const int n_) 
+        : n(n_) 
+    {}
+    
+    template <int RTYPE>
+    operator Matrix<RTYPE>() const {
+        typedef typename traits::storage_type<RTYPE>::type stored_type;
+        
+        const bool enabled = 
+            traits::is_arithmetic<stored_type>::value || 
+            traits::same_type<stored_type, Rcomplex>::value;
+
+        traits::static_assertion<enabled> allowed_matrix_type;
+        
+        typedef traits::one_type<stored_type> one_type;
+
+        return Matrix<RTYPE>::diag(n, one_type());
+    }
+};
+
+class ones {
+private: 
+    int n; 
+    
+public:
+    ones(const int n_) 
+        : n(n_) 
+    {}
+    
+    template <int RTYPE>
+    operator Matrix<RTYPE>() const {
+        typedef typename traits::storage_type<RTYPE>::type stored_type;
+
+        const bool enabled = 
+            traits::is_arithmetic<stored_type>::value || 
+            traits::same_type<stored_type, Rcomplex>::value;
+
+        traits::static_assertion<enabled> allowed_matrix_type;
+        
+        typedef traits::one_type<stored_type> one_type;
+
+        Matrix<RTYPE> res(n, n);
+        std::fill(res.begin(), res.end(), one_type());
+        
+        return res;
+    }
+};
+
+class zeros {
+private: 
+    int n; 
+    
+public:
+    zeros(const int n_) 
+        : n(n_) 
+    {}
+    
+    template <int RTYPE>
+    operator Matrix<RTYPE>() const {
+        typedef typename traits::storage_type<RTYPE>::type stored_type;
+
+        const bool enabled = 
+            traits::is_arithmetic<stored_type>::value || 
+            traits::same_type<stored_type, Rcomplex>::value;
+
+        traits::static_assertion<enabled> allowed_matrix_type;
+        
+        typedef traits::zero_type<stored_type> zero_type;
+
+        Matrix<RTYPE> res(n, n);
+        std::fill(res.begin(), res.end(), zero_type());
+        
+        return res;
+    }
+};
+
+} // Rcpp
+
+#endif // Rcpp__sugar__eye_h

--- a/inst/include/Rcpp/sugar/matrix/eye.h
+++ b/inst/include/Rcpp/sugar/matrix/eye.h
@@ -26,10 +26,10 @@ namespace Rcpp {
 namespace traits {
 
 template<bool>
-struct static_assertion;
+struct allowed_matrix_type;
 
 template<>
-struct static_assertion<true> {};
+struct allowed_matrix_type<true> {};
 
 template <typename T>
 class one_type {
@@ -90,7 +90,7 @@ public:
             traits::is_arithmetic<stored_type>::value || 
             traits::same_type<stored_type, Rcomplex>::value;
 
-        traits::static_assertion<enabled> allowed_matrix_type;
+        (void)sizeof(traits::allowed_matrix_type<enabled>);
         
         typedef traits::one_type<stored_type> one_type;
 
@@ -115,7 +115,7 @@ public:
             traits::is_arithmetic<stored_type>::value || 
             traits::same_type<stored_type, Rcomplex>::value;
 
-        traits::static_assertion<enabled> allowed_matrix_type;
+        (void)sizeof(traits::allowed_matrix_type<enabled>);
         
         typedef traits::one_type<stored_type> one_type;
 
@@ -143,7 +143,7 @@ public:
             traits::is_arithmetic<stored_type>::value || 
             traits::same_type<stored_type, Rcomplex>::value;
 
-        traits::static_assertion<enabled> allowed_matrix_type;
+        (void)sizeof(traits::allowed_matrix_type<enabled>);
         
         typedef traits::zero_type<stored_type> zero_type;
 

--- a/inst/include/Rcpp/sugar/matrix/matrix_functions.h
+++ b/inst/include/Rcpp/sugar/matrix/matrix_functions.h
@@ -29,5 +29,6 @@
 #include <Rcpp/sugar/matrix/upper_tri.h>
 #include <Rcpp/sugar/matrix/diag.h>
 #include <Rcpp/sugar/matrix/as_vector.h>
+#include <Rcpp/sugar/matrix/eye.h>
 
 #endif

--- a/inst/unitTests/cpp/sugar.cpp
+++ b/inst/unitTests/cpp/sugar.cpp
@@ -1116,3 +1116,68 @@ Rcpp::ComplexVector cx_col_means(Rcpp::ComplexMatrix x, bool na_rm = false) {
     return colMeans(x, na_rm);
 }
 
+
+// 23 October 2016 
+// non-member eye, ones, and zeros functions
+
+// [[Rcpp::export]]
+Rcpp::NumericMatrix dbl_eye(int n) {
+    return Rcpp::eye(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::IntegerMatrix int_eye(int n) {
+    return Rcpp::eye(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::ComplexMatrix cx_eye(int n) {
+    return Rcpp::eye(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::LogicalMatrix lgl_eye(int n) {
+    return Rcpp::eye(n);
+}
+
+
+// [[Rcpp::export]]
+Rcpp::NumericMatrix dbl_ones(int n) {
+    return Rcpp::ones(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::IntegerMatrix int_ones(int n) {
+    return Rcpp::ones(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::ComplexMatrix cx_ones(int n) {
+    return Rcpp::ones(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::LogicalMatrix lgl_ones(int n) {
+    return Rcpp::ones(n);
+}
+
+
+// [[Rcpp::export]]
+Rcpp::NumericMatrix dbl_zeros(int n) {
+    return Rcpp::zeros(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::IntegerMatrix int_zeros(int n) {
+    return Rcpp::zeros(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::ComplexMatrix cx_zeros(int n) {
+    return Rcpp::zeros(n);
+}
+
+// [[Rcpp::export]]
+Rcpp::LogicalMatrix lgl_zeros(int n) {
+    return Rcpp::zeros(n);
+}

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1633,9 +1633,13 @@ if (.runThisTest) {
             "eye - complex"
         )
         
+        ## diag(TRUE, 3, 3) was registering as 
+        ## a numeric matrix on Travis for some reason
+        mat <- matrix(FALSE, 3, 3)
+        diag(mat) <- TRUE
         checkEquals(
             lgl_eye(3),
-            diag(TRUE, 3, 3),
+            mat,
             "eye - logical"
         )
     }

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1610,5 +1610,91 @@ if (.runThisTest) {
   
     }
     
+    
+    ## 23 October 2016
+    ## sugar eye function
+    test.sugar.eye <- function() {
+        
+        checkEquals(
+            dbl_eye(3),
+            diag(1.0, 3, 3),
+            "eye - numeric"
+        )
+        
+        checkEquals(
+            int_eye(3),
+            diag(1L, 3, 3),
+            "eye - integer"
+        )
+        
+        checkEquals(
+            cx_eye(3),
+            diag(1.0 + 0i, 3, 3),
+            "eye - complex"
+        )
+        
+        checkEquals(
+            lgl_eye(3),
+            diag(TRUE, 3, 3),
+            "eye - logical"
+        )
+    }
+    
+    ## sugar ones function
+    test.sugar.ones <- function() {
+        
+        checkEquals(
+            dbl_ones(3),
+            matrix(1.0, 3, 3),
+            "ones - numeric"
+        )
+        
+        checkEquals(
+            int_ones(3),
+            matrix(1L, 3, 3),
+            "ones - integer"
+        )
+        
+        checkEquals(
+            cx_ones(3),
+            matrix(1.0 + 0i, 3, 3),
+            "ones - complex"
+        )
+        
+        checkEquals(
+            lgl_ones(3),
+            matrix(TRUE, 3, 3),
+            "ones - logical"
+        )
+    }
+    
+    ## sugar ones function
+    test.sugar.zeros <- function() {
+        
+        checkEquals(
+            dbl_zeros(3),
+            matrix(0.0, 3, 3),
+            "zeros - numeric"
+        )
+        
+        checkEquals(
+            int_zeros(3),
+            matrix(0L, 3, 3),
+            "zeros - integer"
+        )
+        
+        checkEquals(
+            cx_zeros(3),
+            matrix(0.0 + 0i, 3, 3),
+            "zeros - complex"
+        )
+        
+        checkEquals(
+            lgl_zeros(3),
+            matrix(FALSE, 3, 3),
+            "zeros - logical"
+        )
+    }
+    
 }
 


### PR DESCRIPTION
This PR adds non-member versions of `eye`, `ones`, and `zeros`. 