### PR TITLE
updated one unit test for new datetime vectors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-10-30  Dirk Eddelbuettel  <edd@debian.org>
+
+        * src/api.cpp: New capabilities field for new date(time) vectors
+        * inst/unitTests/runit.Date.R (test.DatetimeVector.ctor): Differentiate
+        in test as case of 'Inf' is handling differently by new and old datetime
+        classes (and passed through as is by new ones which is better)
+        * inst/unitTests/runit.InternalFunctionCPP11.R: Small cosmetic edit
+
 2016-10-24  Qiang Kou  <qkou@umail.iu.edu>
 
         * inst/include/Rcpp/sugar/Range.h : fix range sugar ambiguity

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -24,6 +24,8 @@
     \item Changes in Rcpp unit tests
     \itemize{
       \item A test for expression vectors was corrected.
+      \item The constructor test for datetime vectors reflects the new classes
+      which treats Inf correctly (and still as a non-finite value)
     }
     \item Updated Date and Datetime vector classes:
     \itemize{
@@ -35,6 +37,7 @@
       \item By defining \code{RCPP_NEW_DATE_DATETIME_VECTORS} the new classes
       can activated. We intend to make the new classes the default no sooner
       than twelve months from this release.
+      \item The \code{capabilities()} function can also be tested for this feature
     }
   }
 }

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env r
 # -*- mode: R; tab-width: 4; -*-
 #
-# Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2010 - 2016   Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -163,9 +163,18 @@ if (.runThisTest) {
         fun <- DatetimeVector_ctor
         now <- Sys.time()
         checkEquals(fun(now + (0:4)*60), now+(0:4)*60, msg = "Datetime.ctor.sequence")
-        vec <- c(now, NA, NaN, Inf, now+2.345)
-        posixtNA <- as.POSIXct(NA,  origin="1970-01-01")
-        checkEquals(fun(vec), c(now, rep(posixtNA, 3), now+2.345), msg = "Datetime.ctor.set")
+        if (Rcpp:::capabilities()[["new date(time) vectors"]]) {
+            vec <- c(now, NA, NaN, now+2.345)
+            posixtNA <- as.POSIXct(NA,  origin="1970-01-01")
+            checkEquals(fun(vec), c(now, rep(posixtNA, 2), now+2.345), msg = "Datetime.ctor.NA.NaN.set")
+            vec <- c(now, -Inf, Inf, now+2.345)
+            checkEquals(sum(is.finite(fun(vec))), 2, msg = "Datetime.ctor.Inf.finite.set")
+            checkEquals(sum(is.infinite(fun(vec))), 2, msg = "Datetime.ctor.Inf.notfinite.set")
+        } else {
+            vec <- c(now, NA, NaN, Inf, now+2.345)
+            posixtNA <- as.POSIXct(NA, origin="1970-01-01")
+            checkEquals(fun(vec), c(now, rep(posixtNA, 3), now+2.345), msg = "Datetime.ctor.NA.NaN.Inf.set")
+        }
     }
 
 }

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -170,6 +170,11 @@ if (.runThisTest) {
             vec <- c(now, -Inf, Inf, now+2.345)
             checkEquals(sum(is.finite(fun(vec))), 2, msg = "Datetime.ctor.Inf.finite.set")
             checkEquals(sum(is.infinite(fun(vec))), 2, msg = "Datetime.ctor.Inf.notfinite.set")
+            vec <- c(now, NA, NaN, Inf, now+2.345)
+            posixtNA <- as.POSIXct(NA, origin="1970-01-01")
+            posixtInf <- as.POSIXct(Inf, origin="1970-01-01")
+            checkEquals(fun(vec), c(now, rep(posixtNA, 2), posixtInf, now+2.345),
+                        msg = "Datetime.ctor.NA.NaN.Inf.set")
         } else {
             vec <- c(now, NA, NaN, Inf, now+2.345)
             posixtNA <- as.POSIXct(NA, origin="1970-01-01")

--- a/inst/unitTests/runit.InternalFunctionCPP11.R
+++ b/inst/unitTests/runit.InternalFunctionCPP11.R
@@ -20,7 +20,7 @@
 
 .runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
 
-if( .runThisTest && Rcpp:::capabilities()[["full C++11 support"]] ) {
+if( .runThisTest && Rcpp:::capabilities()[["Full C++11 support"]] ) {
 
     .tearDown <- function(){
         gc()

--- a/inst/unitTests/runit.InternalFunctionCPP11.R
+++ b/inst/unitTests/runit.InternalFunctionCPP11.R
@@ -20,7 +20,7 @@
 
 .runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
 
-if( .runThisTest && Rcpp:::capabilities()[["Full C++11 support"]] ) {
+if( .runThisTest && Rcpp:::capabilities()[["full C++11 support"]] ) {
 
     .tearDown <- function(){
         gc()

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,9 +1,8 @@
 // -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-// jedit: :folding=explicit:
 //
 // api.cpp: Rcpp R/C++ interface class library -- Rcpp api
 //
-// Copyright (C) 2012 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -155,8 +154,8 @@ SEXP as_character_externalptr(SEXP xp) {
 
 // [[Rcpp::internal]]
 SEXP rcpp_capabilities() {
-    Shield<SEXP> cap(Rf_allocVector(LGLSXP, 12));
-    Shield<SEXP> names(Rf_allocVector(STRSXP, 12));
+    Shield<SEXP> cap(Rf_allocVector(LGLSXP, 13));
+    Shield<SEXP> names(Rf_allocVector(STRSXP, 13));
     #ifdef HAS_VARIADIC_TEMPLATES
         LOGICAL(cap)[0] = TRUE;
     #else
@@ -216,6 +215,13 @@ SEXP rcpp_capabilities() {
       LOGICAL(cap)[11] = FALSE;
     #endif
 
+    #ifdef RCPP_NEW_DATE_DATETIME_VECTORS
+      LOGICAL(cap)[12] = TRUE;
+    #else
+      LOGICAL(cap)[12] = FALSE;
+    #endif
+
+
     SET_STRING_ELT(names, 0, Rf_mkChar("variadic templates"));
     SET_STRING_ELT(names, 1, Rf_mkChar("initializer lists"));
     SET_STRING_ELT(names, 2, Rf_mkChar("exception handling"));
@@ -227,7 +233,8 @@ SEXP rcpp_capabilities() {
     SET_STRING_ELT(names, 8, Rf_mkChar("long long"));
     SET_STRING_ELT(names, 9, Rf_mkChar("C++0x unordered maps"));
     SET_STRING_ELT(names, 10, Rf_mkChar("C++0x unordered sets"));
-    SET_STRING_ELT(names, 11, Rf_mkChar("Full C++11 support"));
+    SET_STRING_ELT(names, 11, Rf_mkChar("full C++11 support")); // switched from 'Full' to 'full'
+    SET_STRING_ELT(names, 12, Rf_mkChar("new date(time) vectors"));
     Rf_setAttrib(cap, R_NamesSymbol, names);
     return cap;
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -233,7 +233,7 @@ SEXP rcpp_capabilities() {
     SET_STRING_ELT(names, 8, Rf_mkChar("long long"));
     SET_STRING_ELT(names, 9, Rf_mkChar("C++0x unordered maps"));
     SET_STRING_ELT(names, 10, Rf_mkChar("C++0x unordered sets"));
-    SET_STRING_ELT(names, 11, Rf_mkChar("full C++11 support")); // switched from 'Full' to 'full'
+    SET_STRING_ELT(names, 11, Rf_mkChar("Full C++11 support"));
     SET_STRING_ELT(names, 12, Rf_mkChar("new date(time) vectors"));
     Rf_setAttrib(cap, R_NamesSymbol, names);
     return cap;


### PR DESCRIPTION
treats Inf slightly better
also updated capabilities() so that we can check for it
made one purely cosmetic edit to capabilities and update the one use case

thanks to @dcdillon for the heads-up on the test failing when new datetime vectors were defined in
