### PR TITLE
Fixed signed comparison in IndexHash; unit tests for unique()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2016-11-03  Nathan Russell     <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/hash/IndexHash.h: Add casts to eliminate 
+        signed / unsigned comparison warning
+        * inst/include/Rcpp/hash/SelfHash.h: Idem
+        * inst/unitTests/cpp/sugar.cpp: Added unit tests for sugar function 
+        unique()
+        * inst/unitTests/runit.sugar.R: Idem
+
 2016-10-30  Dirk Eddelbuettel  <edd@debian.org>
 
         * src/api.cpp: New capabilities field for new date(time) vectors

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2016-11-04  Nathan Russell     <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/macros/dispatch.h: Modify variadic macros 
+        to not use GNU extensions
+        * DESCRIPTION: roll minor version
+
 2016-11-03  Nathan Russell     <russell.nr2012@gmail.com>
 
         * inst/include/Rcpp/hash/IndexHash.h: Add casts to eliminate 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.7.3
-Date: 2016-10-20
+Version: 0.12.7.5
+Date: 2016-10-25
 Author: Dirk Eddelbuettel, Romain Francois [2009-2013], JJ Allaire, Kevin Ushey,
  Qiang Kou, Douglas Bates [2010-2012] and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/hash/IndexHash.h
+++ b/inst/include/Rcpp/hash/IndexHash.h
@@ -170,7 +170,7 @@ namespace Rcpp{
             unsigned int addr = get_addr(val) ;
             while (data[addr] && not_equal( src[data[addr] - 1], val)) {
               addr++;
-              if (addr == m) {
+              if (addr == static_cast<unsigned int>(m)) {
                 addr = 0;
               }
             }
@@ -191,7 +191,7 @@ namespace Rcpp{
               if (src[data[addr] - 1] == value)
                 return data[addr];
               addr++;
-              if (addr == m) addr = 0;
+              if (addr == static_cast<unsigned int>(m)) addr = 0;
             }
             return NA_INTEGER;
         }

--- a/inst/include/Rcpp/hash/SelfHash.h
+++ b/inst/include/Rcpp/hash/SelfHash.h
@@ -65,7 +65,7 @@ namespace sugar{
             unsigned int addr = get_addr(val) ;
             while (data[addr] && src[data[addr] - 1] != val) {
               addr++;
-              if (addr == m) addr = 0;
+              if (addr == static_cast<unsigned int>(m)) addr = 0;
             }
             if (!data[addr]) {
                 data[addr] = i ;
@@ -81,7 +81,7 @@ namespace sugar{
               if (src[data[addr] - 1] == value)
                 return data[addr];
               addr++;
-              if (addr == m) addr = 0;
+              if (addr == static_cast<unsigned int>(m)) addr = 0;
             }
             return NA_INTEGER;
         }

--- a/inst/include/Rcpp/macros/dispatch.h
+++ b/inst/include/Rcpp/macros/dispatch.h
@@ -2,7 +2,8 @@
 //
 // dispatch.h: Rcpp R/C++ interface class library -- macros for dispatch
 //
-// Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2016  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2016         Dirk Eddelbuettel, Romain Francois, Artem Klevtsov and Nathan Russell
 //
 // This file is part of Rcpp.
 //
@@ -22,41 +23,62 @@
 #ifndef Rcpp__macros__dispatch_h
 #define Rcpp__macros__dispatch_h
 
-#ifdef RCPP_USING_CXX11
-#define ___RCPP_HANDLE_CASE___(___RTYPE___, ___FUN___, ___OBJECT___,           \
-                               ___RCPPTYPE___, ...)                            \
-  case ___RTYPE___:                                                            \
-    return ___FUN___(::Rcpp::___RCPPTYPE___<___RTYPE___>(___OBJECT___),        \
-                     ##__VA_ARGS__);
+//  The variadic macros below incorporate techniques presented by 
+//  Stack Overflow user Richard Hansen in this answer
+//
+//      http://stackoverflow.com/a/11172679/1869097 
+//
+//  and are necessary to avoid the use of GNU compiler extensions.
 
-#define ___RCPP_RETURN___(__FUN__, __SEXP__, __RCPPTYPE__, ...)                \
-  SEXP __TMP__ = __SEXP__;                                                     \
-  switch (TYPEOF(__TMP__)) {                                                   \
-    ___RCPP_HANDLE_CASE___(INTSXP, __FUN__, __TMP__, __RCPPTYPE__,             \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(REALSXP, __FUN__, __TMP__, __RCPPTYPE__,            \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(RAWSXP, __FUN__, __TMP__, __RCPPTYPE__,             \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(LGLSXP, __FUN__, __TMP__, __RCPPTYPE__,             \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(CPLXSXP, __FUN__, __TMP__, __RCPPTYPE__,            \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(STRSXP, __FUN__, __TMP__, __RCPPTYPE__,             \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(VECSXP, __FUN__, __TMP__, __RCPPTYPE__,             \
-                           ##__VA_ARGS__)                                      \
-    ___RCPP_HANDLE_CASE___(EXPRSXP, __FUN__, __TMP__, __RCPPTYPE__,            \
-                           ##__VA_ARGS__)                                      \
-  default:                                                                     \
-    throw std::range_error("Not a vector");                                    \
+#ifdef RCPP_USING_CXX11
+
+#define ___RCPP_HANDLE_CASE___(___RTYPE___, ___FUN___, ___RCPPTYPE___, ...)                         \
+  case ___RTYPE___:                                                                                 \
+    return ___FUN___(::Rcpp::___RCPPTYPE___<___RTYPE___>(RCPP_MACRO_FIRST(__VA_ARGS__))             \
+            RCPP_MACRO_REST(__VA_ARGS__));
+
+
+#define ___RCPP_RETURN___(__FUN__, __RCPPTYPE__, ...)                                               \
+  SEXP __TMP__ = RCPP_MACRO_FIRST(__VA_ARGS__);                                                     \
+  switch (TYPEOF(__TMP__)) {                                                                        \
+    ___RCPP_HANDLE_CASE___(INTSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                              \
+    ___RCPP_HANDLE_CASE___(REALSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                             \
+    ___RCPP_HANDLE_CASE___(RAWSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                              \
+    ___RCPP_HANDLE_CASE___(LGLSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                              \
+    ___RCPP_HANDLE_CASE___(CPLXSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                             \
+    ___RCPP_HANDLE_CASE___(STRSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                              \
+    ___RCPP_HANDLE_CASE___(VECSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                              \
+    ___RCPP_HANDLE_CASE___(EXPRSXP, __FUN__, __RCPPTYPE__, __VA_ARGS__)                             \
+  default:                                                                                          \
+    throw std::range_error("Not a vector");                                                         \
   }
 
-#define RCPP_RETURN_VECTOR(_FUN_, _SEXP_, ...)                                 \
-  ___RCPP_RETURN___(_FUN_, _SEXP_, Vector, ##__VA_ARGS__)
-#define RCPP_RETURN_MATRIX(_FUN_, _SEXP_, ...)                                 \
-  ___RCPP_RETURN___(_FUN_, _SEXP_, Matrix, ##__VA_ARGS__)
+
+#define RCPP_RETURN_VECTOR(_FUN_, ...)                                                              \
+  ___RCPP_RETURN___(_FUN_, Vector, __VA_ARGS__)
+#define RCPP_RETURN_MATRIX(_FUN_, ...)                                                              \
+  ___RCPP_RETURN___(_FUN_, Matrix, __VA_ARGS__)
+
+
+#define RCPP_MACRO_FIRST(...)                      RCPP_MACRO_FIRST_HELPER(__VA_ARGS__, throwaway)
+#define RCPP_MACRO_FIRST_HELPER(first, ...)        first
+
+#define RCPP_MACRO_REST(...)                       RCPP_MACRO_REST_HELPER(RCPP_MACRO_NUM(__VA_ARGS__), __VA_ARGS__)
+#define RCPP_MACRO_REST_HELPER(qty, ...)           RCPP_MACRO_REST_HELPER2(qty, __VA_ARGS__)
+#define RCPP_MACRO_REST_HELPER2(qty, ...)          RCPP_MACRO_REST_HELPER_##qty(__VA_ARGS__)
+#define RCPP_MACRO_REST_HELPER_ONE(first)
+#define RCPP_MACRO_REST_HELPER_TWOORMORE(first, ...) , __VA_ARGS__
+#define RCPP_MACRO_NUM(...)                                                                         \
+    RCPP_MACRO_SELECT_25TH(__VA_ARGS__, TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE,                 \
+                TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE,                              \
+                TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE,                              \
+                TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE,                              \
+                TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, ONE, throwaway)
+#define RCPP_MACRO_SELECT_25TH(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,                   \
+    a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, ...)           a25
+
 #else
+
 #define ___RCPP_HANDLE_CASE___(___RTYPE___, ___FUN___, ___OBJECT___,           \
                                ___RCPPTYPE___)                                 \
   case ___RTYPE___:                                                            \

--- a/inst/unitTests/cpp/sugar.cpp
+++ b/inst/unitTests/cpp/sugar.cpp
@@ -596,6 +596,21 @@ IntegerVector runit_self_match( CharacterVector x){
 }
 
 // [[Rcpp::export]]
+Rcpp::IntegerVector runit_unique_int(Rcpp::IntegerVector x) {
+    return Rcpp::unique(x);
+}
+
+// [[Rcpp::export]]
+Rcpp::NumericVector runit_unique_dbl(Rcpp::NumericVector x) {
+    return Rcpp::unique(x);
+}
+
+// [[Rcpp::export]]
+Rcpp::CharacterVector runit_unique_ch(Rcpp::CharacterVector x) {
+    return Rcpp::unique(x);
+}
+
+// [[Rcpp::export]]
 IntegerVector runit_table( CharacterVector x){
     return table( x ) ;
 }

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -638,6 +638,50 @@ if (.runThisTest) {
         x <- sample( letters, 1000, replace = TRUE )
         checkEquals( runit_self_match(x), match(x,unique(x)) )
     }
+    
+    test.unique <- function() {
+        x <- sample(LETTERS[1:5], 10, TRUE)
+        checkEquals(
+            sort(unique(x)),
+            sort(runit_unique_ch(x)),
+            "unique / character / without NA"
+        )
+        
+        x <- c(x, NA, NA)
+        checkEquals(
+            sort(unique(x), na.last = TRUE),
+            sort(runit_unique_ch(x), na.last = TRUE),
+            "unique / character / with NA"
+        )
+        
+        x <- sample(1:5, 10, TRUE)
+        checkEquals(
+            sort(unique(x)),
+            sort(runit_unique_int(x)),
+            "unique / integer / without NA"
+        )
+        
+        x <- c(x, NA, NA)
+        checkEquals(
+            sort(unique(x), na.last = TRUE),
+            sort(runit_unique_int(x), na.last = TRUE),
+            "unique / integer / with NA"
+        )
+        
+        x <- sample(1:5 + 0.5, 10, TRUE)
+        checkEquals(
+            sort(unique(x)),
+            sort(runit_unique_dbl(x)),
+            "unique / numeric / without NA"
+        )
+        
+        x <- c(x, NA, NA)
+        checkEquals(
+            sort(unique(x), na.last = TRUE),
+            sort(runit_unique_dbl(x), na.last = TRUE),
+            "unique / numeric / with NA"
+        )
+    }
 
     test.table <- function(){
         x <- sample( letters, 1000, replace = TRUE )


### PR DESCRIPTION
This addresses the compiler warning described in #574, which is also present in `SelfHash`. Unit tests for the sugar function `unique` are also added.