### PR TITLE
Added constructor to instantiate newDatetimeVector from VectorBase.

### DIFF
--- a/inst/include/Rcpp/date_datetime/newDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/newDatetimeVector.h
@@ -28,10 +28,15 @@ namespace Rcpp {
 
     class newDatetimeVector : public NumericVector {
     public:
+        template <int RTYPE, bool NA, typename VEC>
+        newDatetimeVector( const VectorBase<RTYPE,NA,VEC>& other ) :
+            NumericVector(other) {}
+        
         newDatetimeVector(SEXP vec, const char* tz = "") :
             NumericVector(vec) {
             setClass(tz);
         }
+        
         newDatetimeVector(int n, const char* tz = "") :
             NumericVector(n) {
             setClass(tz);


### PR DESCRIPTION
This fixes the issue where

```c++
#include <Rcpp.h>


// [[Rcpp::export]]
Rcpp::newDatetimeVector test(Rcpp::newDatetimeVector v) {
    Rcpp::newDatetimeVector x = v + 2.;
        return x;
}
```

failed to compile.

It, however, is likely that other issues will crop up at some point due to other missing constructors (since `Vector` has so many and `newDatetimeVector` has so few).  I'd like opinions on whether the rest of the `Vector` constructors should be ported to `newDatetimeVector` at this time, or if we should just wait and see what breaks and port them one at a time.

The same applies to `operator=`, as there don't exist any `operator=` functions that return `newDateTimeVector &`.