### PR TITLE
Add test code coverage tracking

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ doxyfile
 .clang_format
 vignettes/getCurrentVersionsOfCitedPackages.R
 ^Contributing.md$
+^\.codecov\.yml$

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ install:
 script: 
   - ./run.sh run_tests
 
+after_success:
+  - R -e 'install.packages("covr")' -e 'covr::codecov()'
+
 after_failure:
   - ./run.sh dump_logs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - ./run.sh run_tests
 
 after_success:
-  - R -e 'install.packages("covr")' -e 'covr::codecov()'
+  - ./run.sh coverage
 
 after_failure:
   - ./run.sh dump_logs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Rcpp [![Build Status](https://travis-ci.org/RcppCore/Rcpp.svg)](https://travis-ci.org/RcppCore/Rcpp) [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/Rcpp)](https://cran.r-project.org/package=Rcpp) [![Downloads](http://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen)](http://www.r-pkg.org/pkg/Rcpp)
+## Rcpp [![Build Status](https://travis-ci.org/RcppCore/Rcpp.svg)](https://travis-ci.org/RcppCore/Rcpp) [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/Rcpp)](https://cran.r-project.org/package=Rcpp) [![Downloads](http://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen)](http://www.r-pkg.org/pkg/Rcpp) [![Coverage Status](https://img.shields.io/codecov/c/github/RcppCore/Rcpp/master.svg)](https://codecov.io/github/RcppCore/Rcpp?branch=master)
 
 ### Seamless R and C++ Integration
 


### PR DESCRIPTION
This adds test code coverage tracking and reports with [covr](https://cran.r-project.org/package=covr) and [codecov.io](https://codecov.io/).

The normal travis status is reported as soon as the build is successful, the coverage status is reported separately and only runs on successful builds. By default the coverage status fails if the PR is not covered by tests, which helps ensure new contributions are tested. This default can be changed if desired by modifying [.codecov.yml](https://github.com/codecov/support/wiki/Codecov-Yaml).

The reports can be viewed by clicking on the README badge or directly at https://codecov.io/github/RcppCore/Rcpp and track results over time.