### PR TITLE
Cleanup stack parsing / demangling

### DIFF
--- a/inst/unitTests/cpp/exceptions.cpp
+++ b/inst/unitTests/cpp/exceptions.cpp
@@ -39,6 +39,14 @@ double takeLogRcpp(double val) {
 }
 
 // [[Rcpp::export]]
+double takeLogStop(double val) {
+    if (val <= 0.0) {
+        Rcpp::stop("Inadmissible value");
+    }
+    return log(val);
+}
+
+// [[Rcpp::export]]
 double takeLogRcppLocation(double val) {
     if (val <= 0.0) {
         throw Rcpp::exception("Inadmissible value", "exceptions.cpp", 44);

--- a/inst/unitTests/runit.exceptions.R
+++ b/inst/unitTests/runit.exceptions.R
@@ -58,6 +58,24 @@ test.rcppException <- function() {
   checkEquals(condition$call, quote(takeLogRcpp(-1L)))
 }
 
+test.rcppStop <- function() {
+
+  # Code works normally without an exception
+  checkIdentical(takeLog(1L), log(1L))
+
+  # C++ exceptions are converted to R conditions
+  condition <- tryCatch(takeLogStop(-1L), error = identity)
+
+  checkIdentical(condition$message, "Inadmissible value")
+  checkIdentical(class(condition), c("Rcpp::exception", "C++Error", "error", "condition"))
+
+  checkTrue(!is.null(condition$cppstack))
+
+  checkIdentical(class(condition$cppstack), "Rcpp_stack_trace")
+
+  checkEquals(condition$call, quote(takeLogStop(-1L)))
+}
+
 test.rcppExceptionLocation <- function() {
 
   # Code works normally without an exception


### PR DESCRIPTION
The main cause of the errors was the logic at https://github.com/RcppCore/Rcpp/compare/master...jimhester:cppstack?expand=1#diff-f885be769bd30163f6d49bcfa6246690L44. If there was no `+` in the stack trace `find_last_of()` would return `std::string::npos (-1)` and resizing to `-2` is obviously an error.

Some compiler versions return the stack trace in slightly different formats, so this error was only apparent with older gcc compilers. I modified the logic to retain more information (now only the demangled name is fixed, the rest of the information remains) and it should also be more robust to future formatting changes.

This was not noticed in previous releases because stack traces were only enabled if the `Rcpp::exception()` was constructed with a file and line. In #582 I modified the default constructor to also include the cpp stack trace, which revealed this bug. Also as noted my tests for the exception code did not include use of `Rcpp::stop()` and this bug did not occur with standard expectations and direct call of `Rcpp::exception()`. We now have an explicit test using `Rcpp::stop()` as well.

Fixes #596 and possibly #593 although that is as yet untested.