### PR TITLE
Sugar function sample with unit tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-12-10  Nathan Russell  <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/sugar/functions/sample.h: New function
+        sample()
+        * inst/include/Rcpp/sugar/functions/functions.h: Idem
+        * inst/unitTests/cpp/sugar.cpp: Unit tests for sample()
+        * inst/unitTests/runit.sugar.R: Idem
+
 2016-12-10  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/loadRcppModules.R: Added #nocov tags

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,6 +12,11 @@
       \item Date and Datetime object and vector now have format methods and
       \code{operator<<} support (PR\ghpr{599})
     }
+    \item Changes in Rcpp Sugar:
+    \itemize{
+      \item Added new Sugar function \code{sample()} (Nathan Russell in 
+      \ghpr{610}).
+    }
     \item Changes in Rcpp unit tests
     \itemize{
       \item Added Environment::find unit tests and an Environment::get(Symbol)

--- a/inst/include/Rcpp/sugar/functions/functions.h
+++ b/inst/include/Rcpp/sugar/functions/functions.h
@@ -86,5 +86,7 @@
 
 #include <Rcpp/sugar/functions/rowSums.h>
 
+#include <Rcpp/sugar/functions/sample.h>
+
 #endif
 

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -1,0 +1,495 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// sample.h: Rcpp R/C++ interface class library -- sample
+//
+// Copyright (C) 2016 Nathan Russell
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__sugar__sample_h
+#define Rcpp__sugar__sample_h
+
+#include <alloca.h>
+
+//  In order to mirror the behavior of `base::sample` 
+//  as closely as possible, this file contains adaptations 
+//  of several functions in R/src/main/random.c:
+//
+//      * do_sample - general logic as well as the empirical sampling routine.
+//
+//      * FixupProb - an auxiliary function.
+//
+//      * walker_ProbSampleReplace, ProbSampleReplace, and ProbSampleNoReplace -
+//        algorithms for sampling according to a supplied probability vector.
+//
+//  For each of the sampling routines, two signatures are provided: 
+//
+//      * A version that returns an integer vector, which can be used to 
+//        generate 0-based indices (one_based = false) or 1-based indices 
+//        (one_based = true) -- where the latter corresponds to the 
+//        bahavior of `base::sample.int`. 
+//
+//      * A version which takes an input Vector<> (rather than an integer 'n'),
+//        and samples its elements -- this corresponds to `base::sample`.
+
+namespace Rcpp {
+namespace sugar {
+
+// Adapted from `FixupProb`
+// Normalizes a probability vector 'p' S.T. sum(p) == 1
+inline void Normalize(Vector<REALSXP>& p, int require_k, bool replace)
+{
+    double sum = 0.0;
+    int npos = 0, i = 0, n = p.size();
+
+    for ( ; i < n; i++) {
+        if (!R_FINITE(p[i]) || (p[i] < 0)) {
+            stop("Probabilities must be finite and non-negative!");
+        }
+        npos += (p[i] > 0.0);
+        sum += p[i];
+    }
+
+    if ((!npos) || (!replace && (require_k > npos))) {
+        stop("Too few positive probabilities!");
+    }
+
+    for (i = 0; i < n; i++) {
+        p[i] /= sum;
+    }
+}
+
+// Adapted from `ProbSampleReplace`
+// Index version
+inline Vector<INTSXP> SampleReplace(Vector<REALSXP>& p, int n, int k, bool one_based)
+{
+    Vector<INTSXP> perm = no_init(n), ans = no_init(k);
+    double rU = 0.0;
+    int i = 0, j = 0, nm1 = n - 1;
+
+    int adj = one_based ? 0 : 1;
+
+    for ( ; i < n; i++) {
+        perm[i] = i + 1;
+    }
+
+    Rf_revsort(p.begin(), perm.begin(), n);
+
+    for (i = 1; i < n; i++) {
+        p[i] += p[i - 1];
+    }
+
+    for (i = 0; i < k; i++) {
+        rU = unif_rand();
+        for (j = 0; j < nm1; j++) {
+            if (rU <= p[j]) {
+                break;
+            }
+        }
+        ans[i] = perm[j] - adj;
+    }
+
+    return ans;
+}
+
+// Element version
+template <int RTYPE>
+inline Vector<RTYPE> SampleReplace(Vector<REALSXP>& p, int k, const Vector<RTYPE>& ref)
+{
+    int n = ref.size();
+
+    Vector<INTSXP> perm = no_init(n);
+    Vector<RTYPE> ans = no_init(k);
+
+    double rU = 0.0;
+    int i = 0, j = 0, nm1 = n - 1;
+
+    for ( ; i < n; i++) {
+        perm[i] = i + 1;
+    }
+
+    Rf_revsort(p.begin(), perm.begin(), n);
+
+    for (i = 1; i < n; i++) {
+        p[i] += p[i - 1];
+    }
+
+    for (i = 0; i < k; i++) {
+        rU = unif_rand();
+        for (j = 0; j < nm1; j++) {
+            if (rU <= p[j]) {
+                break;
+            }
+        }
+        ans[i] = ref[perm[j] - 1];
+    }
+
+    return ans;
+}
+
+// Adapted from `walker_ProbSampleReplace`
+// Index version
+#define SMALL 10000
+inline Vector<INTSXP> WalkerSample(const Vector<REALSXP>& p, int n, int nans, bool one_based)
+{
+    Vector<INTSXP> a = no_init(n), ans = no_init(nans);
+    double *q, rU;
+    int i, j, k;
+    int *HL, *H, *L;
+
+    int adj = one_based ? 1 : 0;
+
+    if (n <= SMALL) {
+        R_CheckStack2(n * (sizeof(int) + sizeof(double)));
+        HL = static_cast<int*>(::alloca(n * sizeof(int)));
+        q = static_cast<double*>(::alloca(n * sizeof(double)));
+    } else {
+        HL = static_cast<int*>(Calloc(n, int));
+        q = static_cast<double*>(Calloc(n, double));
+    }
+
+    H = HL - 1; L = HL + n;
+    for (i = 0; i < n; i++) {
+        q[i] = p[i] * n;
+        if (q[i] < 1.0) {
+            *++H = i;
+        } else {
+            *--L = i;
+        }
+    }
+
+    if (H >= HL && L < HL + n) {
+        for (k = 0; k < n - 1; k++) {
+            i = HL[k];
+            j = *L;
+            a[i] = j;
+            q[j] += q[i] - 1;
+
+            L += (q[j] < 1.0);
+
+            if (L >= HL + n) {
+                break;
+            }
+        }
+    }
+
+    for (i = 0; i < n; i++) {
+        q[i] += i;
+    }
+
+    for (i = 0; i < nans; i++) {
+        rU = unif_rand() * n;
+        k = static_cast<int>(rU);
+        ans[i] = (rU < q[k]) ? k + adj : a[k] + adj;
+    }
+
+    if (n > SMALL) {
+        Free(HL);
+        Free(q);
+    }
+
+    return ans;
+}
+
+// Element version
+template <int RTYPE>
+inline Vector<RTYPE> WalkerSample(const Vector<REALSXP>& p, int nans, const Vector<RTYPE>& ref)
+{
+    int n = ref.size();
+
+    Vector<INTSXP> a = no_init(n);
+    Vector<RTYPE> ans = no_init(nans);
+
+    double *q, rU;
+    int i, j, k;
+    int *HL, *H, *L;
+
+    if (n <= SMALL) {
+        R_CheckStack2(n * (sizeof(int) + sizeof(double)));
+        HL = static_cast<int*>(::alloca(n * sizeof(int)));
+        q = static_cast<double*>(::alloca(n * sizeof(double)));
+    } else {
+        HL = static_cast<int*>(Calloc(n, int));
+        q = static_cast<double*>(Calloc(n, double));
+    }
+
+    H = HL - 1; L = HL + n;
+    for (i = 0; i < n; i++) {
+        q[i] = p[i] * n;
+        if (q[i] < 1.0) {
+            *++H = i;
+        } else {
+            *--L = i;
+        }
+    }
+
+    if (H >= HL && L < HL + n) {
+        for (k = 0; k < n - 1; k++) {
+            i = HL[k];
+            j = *L;
+            a[i] = j;
+            q[j] += q[i] - 1;
+
+            L += (q[j] < 1.0);
+
+            if (L >= HL + n) {
+                break;
+            }
+        }
+    }
+
+    for (i = 0; i < n; i++) {
+        q[i] += i;
+    }
+
+    for (i = 0; i < nans; i++) {
+        rU = unif_rand() * n;
+        k = static_cast<int>(rU);
+        ans[i] = (rU < q[k]) ? ref[k] : ref[a[k]];
+    }
+
+    if (n > SMALL) {
+        Free(HL);
+        Free(q);
+    }
+
+    return ans;
+}
+#undef SMALL
+
+// Adapted from `ProbSampleNoReplace`
+// Index version
+inline Vector<INTSXP> SampleNoReplace(Vector<REALSXP>& p, int n, int nans, bool one_based)
+{
+    Vector<INTSXP> perm = no_init(n), ans = no_init(nans);
+    double rT, mass, totalmass;
+    int i, j, k, n1;
+
+    int adj = one_based ? 0 : 1;
+
+    for (i = 0; i < n; i++) {
+        perm[i] = i + 1;
+    }
+
+    Rf_revsort(p.begin(), perm.begin(), n);
+
+    totalmass = 1.0;
+    for (i = 0, n1 = n - 1; i < nans; i++, n1--) {
+        rT = totalmass * unif_rand();
+        mass = 0.0;
+
+        for (j = 0; j < n1; j++) {
+            mass += p[j];
+            if (rT <= mass) {
+                break;
+            }
+        }
+
+        ans[i] = perm[j] - adj;
+        totalmass -= p[j];
+
+        for (k = j; k < n1; k++) {
+            p[k] = p[k + 1];
+            perm[k] = perm[k + 1];
+        }
+    }
+
+    return ans;
+}
+
+// Element version
+template <int RTYPE>
+inline Vector<RTYPE> SampleNoReplace(Vector<REALSXP>& p, int nans, const Vector<RTYPE>& ref)
+{
+    int n = ref.size();
+
+    Vector<INTSXP> perm = no_init(n);
+    Vector<RTYPE> ans = no_init(nans);
+
+    double rT, mass, totalmass;
+    int i, j, k, n1;
+
+    for (i = 0; i < n; i++) {
+        perm[i] = i + 1;
+    }
+
+    Rf_revsort(p.begin(), perm.begin(), n);
+
+    totalmass = 1.0;
+    for (i = 0, n1 = n - 1; i < nans; i++, n1--) {
+        rT = totalmass * unif_rand();
+        mass = 0.0;
+
+        for (j = 0; j < n1; j++) {
+            mass += p[j];
+            if (rT <= mass) {
+                break;
+            }
+        }
+
+        ans[i] = ref[perm[j] - 1];
+        totalmass -= p[j];
+
+        for (k = j; k < n1; k++) {
+            p[k] = p[k + 1];
+            perm[k] = perm[k + 1];
+        }
+    }
+
+    return ans;
+}
+
+// Adapted from segment of `do_sample`
+// Index version
+inline Vector<INTSXP> EmpiricalSample(int n, int size, bool replace, bool one_based)
+{
+    Vector<INTSXP> ans = no_init(size);
+    Vector<INTSXP>::iterator ians = ans.begin(), eans = ans.end();
+
+    int adj = one_based ? 1 : 0;
+
+    if (replace || size < 2) {
+        for ( ; ians != eans; ++ians) {
+            *ians = static_cast<int>(n * unif_rand() + adj);
+        }
+        return ans;
+    }
+
+    int* x = reinterpret_cast<int*>(R_alloc(n, sizeof(int)));
+    for (int i = 0; i < n; i++) {
+        x[i] = i;
+    }
+
+    for ( ; ians != eans; ++ians) {
+        int j = static_cast<int>(n * unif_rand());
+        *ians = x[j] + adj;
+        x[j] = x[--n];
+    }
+
+    return ans;
+}
+
+// Element version
+template <int RTYPE>
+inline Vector<RTYPE> EmpiricalSample(int size, bool replace, const Vector<RTYPE>& ref)
+{
+    int n = ref.size();
+
+    Vector<RTYPE> ans = no_init(size);
+    typename Vector<RTYPE>::iterator ians = ans.begin(), eans = ans.end();
+
+    if (replace || size < 2) {
+        for ( ; ians != eans; ++ians) {
+            *ians = ref[static_cast<int>(n * unif_rand())];
+        }
+        return ans;
+    }
+
+    int* x = reinterpret_cast<int*>(R_alloc(n, sizeof(int)));
+    for (int i = 0; i < n; i++) {
+        x[i] = i;
+    }
+
+    for ( ; ians != eans; ++ians) {
+        int j = static_cast<int>(n * unif_rand());
+        *ians = ref[x[j]];
+        x[j] = x[--n];
+    }
+
+    return ans;
+}
+
+typedef Nullable< Vector<REALSXP> > probs_t;
+
+} // sugar
+
+// Adapted from `do_sample`
+inline Vector<INTSXP> 
+sample(int n, int size, bool replace = false, sugar::probs_t probs = R_NilValue, bool one_based = true)
+{
+    if (probs.isNotNull()) {
+        Vector<REALSXP> p = clone(probs.get());
+        if (static_cast<int>(p.size()) != n) {
+            stop("probs.size() != n!");
+        }
+
+        sugar::Normalize(p, size, replace);
+
+        if (replace) {
+            int i = 0, nc = 0;
+            for ( ; i < n; i++) {
+                nc += (n * p[i] > 0.1);
+            }
+
+            return nc > 200 ? sugar::WalkerSample(p, n, size, one_based) :
+                              sugar::SampleReplace(p, n, size, one_based);
+        }
+
+        if (size > n) {
+            stop("Sample size must be <= n when not using replacement!");
+        }
+
+        return sugar::SampleNoReplace(p, n, size, one_based);
+    }
+
+    if (!replace && size > n) {
+        stop("Sample size must be <= n when not using replacement!");
+    }
+
+    return sugar::EmpiricalSample(n, size, replace, one_based);
+}
+
+template <int RTYPE>
+inline Vector<RTYPE> 
+sample(const Vector<RTYPE>& x, int size, bool replace = false, sugar::probs_t probs = R_NilValue)
+{
+    int n = x.size();
+
+    if (probs.isNotNull()) {
+        Vector<REALSXP> p = clone(probs.get());
+        if (static_cast<int>(p.size()) != n) {
+            stop("probs.size() != n!");
+        }
+
+        sugar::Normalize(p, size, replace);
+
+        if (replace) {
+            int i = 0, nc = 0;
+            for ( ; i < n; i++) {
+                nc += (n * p[i] > 0.1);
+            }
+
+            return nc > 200 ? sugar::WalkerSample(p, size, x) :
+                              sugar::SampleReplace(p, size, x);
+        }
+
+        if (size > n) {
+            stop("Sample size must be <= n when not using replacement!");
+        }
+
+        return sugar::SampleNoReplace(p, size, x);
+    }
+
+    if (!replace && size > n) {
+        stop("Sample size must be <= n when not using replacement!");
+    }
+
+    return sugar::EmpiricalSample(size, replace, x);
+}
+
+} // Rcpp
+
+#endif // Rcpp__sugar__sample_h

--- a/inst/unitTests/cpp/sugar.cpp
+++ b/inst/unitTests/cpp/sugar.cpp
@@ -1143,3 +1143,47 @@ Rcpp::ComplexVector cx_col_means(Rcpp::ComplexMatrix x, bool na_rm = false) {
     return colMeans(x, na_rm);
 }
 
+
+// 10 December 2016: sample
+
+// [[Rcpp::export]]
+IntegerVector sample_dot_int(int n, int sz, bool rep = false, sugar::probs_t p = R_NilValue, bool one_based = true)
+{
+    return sample(n, sz, rep, p, one_based);
+}
+
+// [[Rcpp::export]]
+IntegerVector sample_int(IntegerVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}
+
+// [[Rcpp::export]]
+NumericVector sample_dbl(NumericVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}
+
+// [[Rcpp::export]]
+CharacterVector sample_chr(CharacterVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}
+
+// [[Rcpp::export]]
+ComplexVector sample_cx(ComplexVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}
+
+// [[Rcpp::export]]
+LogicalVector sample_lgl(LogicalVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}
+
+// [[Rcpp::export]]
+List sample_list(List x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+{
+    return sample(x, sz, rep, p);
+}

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1663,5 +1663,303 @@ if (.runThisTest) {
         )
 
     }
+    
+    
+    ## 10 December 2016
+    ## sample.int tests
+    test.sugar.sample_dot_int <- function() {
+        
+        set.seed(123); s1 <- sample_dot_int(10, 5)
+        set.seed(123); s2 <- sample(10, 5)
+        
+        checkEquals(
+            s1, s2,
+            "sample.int / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_dot_int(10, 5, TRUE)
+        set.seed(123); s2 <- sample(10, 5, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample.int / with replacement / without probability"
+        )
+        
+
+        px <- rep(c(3, 2, 1), length.out = 10)
+        set.seed(123); s1 <- sample_dot_int(10, 5, FALSE, px)
+        set.seed(123); s2 <- sample(10, 5, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample.int / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_dot_int(10, 5, TRUE, px)
+        set.seed(123); s2 <- sample(10, 5, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample.int / with replacement / with probability"
+        )
+        
+    }
+    
+    
+    ## sample_int tests
+    test.sugar.sample_int <- function() {
+        
+        x <- as.integer(rpois(10, 10))
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_int(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_int / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_int(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_int / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_int(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_int / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_int(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_int / with replacement / with probability"
+        )
+        
+    }
+    
+
+    ## sample_dbl tests
+    test.sugar.sample_dbl <- function() {
+        
+        x <- rnorm(10)
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_dbl(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_dbl / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_dbl(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_dbl / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_dbl(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_dbl / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_dbl(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_dbl / with replacement / with probability"
+        )
+        
+    }
+    
+
+    ## sample_chr tests
+    test.sugar.sample_chr <- function() {
+        
+        x <- sample(letters, 10)
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_chr(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_chr / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_chr(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_chr / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_chr(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_chr / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_chr(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_chr / with replacement / with probability"
+        )
+        
+    }
+    
+    
+    ## sample_cx tests
+    test.sugar.sample_cx <- function() {
+        
+        x <- rnorm(10) + 2i
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_cx(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_cx / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_cx(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_cx / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_cx(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_cx / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_cx(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_cx / with replacement / with probability"
+        )
+        
+    }
+    
+    
+    ## sample_lgl tests
+    test.sugar.sample_lgl <- function() {
+        
+        x <- rbinom(10, 1, 0.5) > 0
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_lgl(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_lgl / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_lgl(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_lgl / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_lgl(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_lgl / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_lgl(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_lgl / with replacement / with probability"
+        )
+        
+    }
+    
+    
+    ## sample_list tests
+    test.sugar.sample_list <- function() {
+        
+        x <- list(
+            letters,
+            1:5, 
+            rnorm(10),
+            state.abb,
+            state.area,
+            state.center,
+            matrix(1:9, 3),
+            mtcars,
+            AirPassengers,
+            BJsales
+        )
+        px <- rep(c(3, 2, 1), length.out = 10)
+        
+        set.seed(123); s1 <- sample_list(x, 6)
+        set.seed(123); s2 <- sample(x, 6)
+        
+        checkEquals(
+            s1, s2,
+            "sample_list / without replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_list(x, 6, TRUE)
+        set.seed(123); s2 <- sample(x, 6, TRUE)
+        
+        checkEquals(
+            s1, s2,
+            "sample_list / with replacement / without probability"
+        )
+        
+        set.seed(123); s1 <- sample_list(x, 6, FALSE, px)
+        set.seed(123); s2 <- sample(x, 6, FALSE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_list / without replacement / with probability"
+        )
+        
+        set.seed(123); s1 <- sample_list(x, 6, TRUE, px)
+        set.seed(123); s2 <- sample(x, 6, TRUE, px)
+        
+        checkEquals(
+            s1, s2,
+            "sample_list / with replacement / with probability"
+        )
+        
+    }
 
 }


### PR DESCRIPTION
This PR adds a sugar function `sample`, with overloads for 
* a single integer as the first argument (behavior of `base::sample.int`) 
* a vector as the first argument (behavior of `base::sample`)