### PR TITLE
Adjust includes in sample.h, Date.h, and Datetime.h for MinGW

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-12-13  Nathan Russell     <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/sugar/functions/sample.h: Use malloc.h instead of 
+        alloca.h when building on Windows
+        * inst/include/Rcpp/date_datetime/Date.h: Include time.h when building 
+        on Windows
+        * inst/include/Rcpp/date_datetime/Datetime.h: Idem
+
 2016-12-12  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/sugar/functions/sample.h: In case sample.h from the

--- a/inst/include/Rcpp/date_datetime/Date.h
+++ b/inst/include/Rcpp/date_datetime/Date.h
@@ -22,6 +22,10 @@
 #ifndef Rcpp__Date_h
 #define Rcpp__Date_h
 
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#include <time.h>
+#endif
+
 namespace Rcpp {
 
     class Date {

--- a/inst/include/Rcpp/date_datetime/Datetime.h
+++ b/inst/include/Rcpp/date_datetime/Datetime.h
@@ -24,6 +24,10 @@
 
 #include <RcppCommon.h>
 
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#include <time.h>
+#endif
+
 namespace Rcpp {
 
     class Datetime {

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -26,7 +26,11 @@
 #ifndef Rcpp__sugar__sample_h
 #define Rcpp__sugar__sample_h
 
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#include <malloc.h>
+#else
 #include <alloca.h>
+#endif 
 
 //  In order to mirror the behavior of `base::sample` 
 //  as closely as possible, this file contains adaptations 


### PR DESCRIPTION
This addresses two build errors related to MinGW: 
* `::alloca` is defined in `malloc.h` instead of `alloca.h` (`sample.h`)
* `::strftime` and `localtime` (`Datetime.h` only) were not being found (`Date.h` and `Datetime.h`)