### PR TITLE
Use STRICT_R_HEADERS in Rcpp.h

### DIFF
--- a/inst/include/Rcpp.h
+++ b/inst/include/Rcpp.h
@@ -23,6 +23,11 @@
 #ifndef Rcpp_hpp
 #define Rcpp_hpp
 
+#ifndef STRICT_R_HEADERS
+#define STRICT_R_HEADERS
+#define RCPP_TEMP_STRICT_R_HEADERS
+#endif
+
 /* it is important that this comes first */
 #include <RcppCommon.h>
 
@@ -84,4 +89,10 @@
 #include <Rcpp/api/meat/meat.h>
 
 #include <Rcpp/algorithm.h>
+
+#ifdef RCPP_TEMP_STRICT_R_HEADERS
+#undef STRICT_R_HEADERS
+#undef RCPP_TEMP_STRICT_R_HEADERS
+#endif
+
 #endif


### PR DESCRIPTION
This is only a simple suggestion. It defines `STRICT_R_HEADERS` inside `Rcpp.h` to prevent issues like https://github.com/RcppCore/Rcpp/issues/612 in the future.

I would be much in favor of setting `STRICT_R_HEADERS` unconditionally, but that might break an existing package or two (or perhaps not).