### PR TITLE
Compile Rcpp with STRICT_R_HEADERS on both Unix and Windows

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
-PKG_CPPFLAGS =	-I../inst/include/
+PKG_CPPFLAGS =	-I../inst/include/ -DSTRICT_R_HEADERS
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,2 +1,0 @@
-PKG_CPPFLAGS =	-I../inst/include/
-


### PR DESCRIPTION
Let's see what Travis thinks of this...