### PR TITLE
Use vector for dynamic memory in sample (closes #612)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,13 @@
-2016-12-13  Nathan Russell     <russell.nr2012@gmail.com>
+2016-12-14  Nathan Russell  <russell.nr2012@gmail.com>
 
-        * inst/include/Rcpp/sugar/functions/sample.h: Use malloc.h instead of 
+        * inst/include/Rcpp/sugar/functions/sample.h: Use vector instead of
+        manual memory management.
+
+2016-12-13  Nathan Russell  <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/sugar/functions/sample.h: Use malloc.h instead of
         alloca.h when building on Windows
-        * inst/include/Rcpp/date_datetime/Date.h: Include time.h when building 
+        * inst/include/Rcpp/date_datetime/Date.h: Include time.h when building
         on Windows
         * inst/include/Rcpp/date_datetime/Datetime.h: Idem
 

--- a/Rcpp.Rproj
+++ b/Rcpp.Rproj
@@ -13,6 +13,7 @@ RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This replaces the use of `alloca`, `Calloc`, and `Free` with `std::vector`.