### PR TITLE
Feature/update date code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-12-30  Dirk Eddelbuettel  <edd@debian.org>
+
+        * src/Date.cpp: Synchronized internal code with R
+
 2016-12-26  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/Attributes.R: Added #nocov markers

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-01-01  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/unitTests/runit.Date.R (test.mktime, test.gmtime): New tests
+        * inst/unitTests/cpp/dates.cpp (test_mktime, test_gmtime): Idem
+
 2016-12-31  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/vector/Matrix.h: Minor simplification

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,3 @@
-2016-12-30  Dirk Eddelbuettel  <edd@debian.org>
-
-        * src/Date.cpp: Synchronized internal code with R
-
-        * inst/unitTests/cpp/dates.cpp (gmtime_mktime): New test
-        * inst/unitTests/runit.Date.R (test.mktime_gmtime): Idem
 2016-12-31  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/vector/Matrix.h: Minor simplification
@@ -15,6 +9,13 @@
         * inst/unitTests/runit.Matrix.R: Added unit tests for diagonally
         filling matrices.
         * inst/unitTests/cpp/Matrix.cpp: Idem
+
+2016-12-30  Dirk Eddelbuettel  <edd@debian.org>
+
+        * src/Date.cpp: Synchronized internal code with R
+
+        * inst/unitTests/cpp/dates.cpp (gmtime_mktime): New test
+        * inst/unitTests/runit.Date.R (test.mktime_gmtime): Idem
 
 2016-12-26  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 
         * src/Date.cpp: Synchronized internal code with R
 
+        * inst/unitTests/cpp/dates.cpp (gmtime_mktime): New test
+        * inst/unitTests/runit.Date.R (test.mktime_gmtime): Idem
+
 2016-12-26  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/Attributes.R: Added #nocov markers

--- a/inst/unitTests/cpp/dates.cpp
+++ b/inst/unitTests/cpp/dates.cpp
@@ -212,3 +212,25 @@ Date gmtime_mktime(Date d) {
     Date newd(chk.tm_year, chk.tm_mon + 1, chk.tm_mday);
     return newd;
 }
+
+// [[Rcpp::export]]
+double test_mktime(Date d) {
+    const int baseYear = 1900;
+    struct tm tm;
+    tm.tm_sec = tm.tm_min = tm.tm_hour = tm.tm_isdst = 0;
+
+    tm.tm_mday  = d.getDay();
+    tm.tm_mon   = d.getMonth() - 1;    // range 0 to 11
+    tm.tm_year  = d.getYear() - baseYear;
+    time_t t = mktime00(tm);    // use mktime() replacement borrowed from R
+    return static_cast<double>(t);
+}
+
+// [[Rcpp::export]]
+Date test_gmtime(double d) {
+    time_t t = static_cast<time_t>(d);
+    struct tm tm = *gmtime_(&t);
+    tm.tm_sec = tm.tm_min = tm.tm_hour = tm.tm_isdst = 0;
+    Date nd(tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
+    return nd;
+}

--- a/inst/unitTests/cpp/dates.cpp
+++ b/inst/unitTests/cpp/dates.cpp
@@ -196,3 +196,19 @@ std::string Datetime_ostream(Datetime d) {
     os << d;
     return os.str();
 }
+
+// [[Rcpp::export]]
+Date gmtime_mktime(Date d) {
+    const int baseYear = 1900;
+    struct tm tm;
+    tm.tm_sec = tm.tm_min = tm.tm_hour = tm.tm_isdst = 0;
+
+    tm.tm_mday  = d.getDay();
+    tm.tm_mon   = d.getMonth() - 1;    // range 0 to 11
+    tm.tm_year  = d.getYear() - baseYear;
+    time_t tmp = mktime00(tm);    // use mktime() replacement borrowed from R
+
+    struct tm chk = *gmtime_(&tmp);
+    Date newd(chk.tm_year, chk.tm_mon + 1, chk.tm_mday);
+    return newd;
+}

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -239,4 +239,11 @@ if (.runThisTest) {
     }
 
 
+    test.mktime_gmtime <- function() {
+        d <- as.Date("2015-12-31")
+        checkEquals(d, gmtime_mktime(d), msg="Date.mktime_gmtime.2015")
+
+        d <- as.Date("1965-12-31")
+        checkEquals(d, gmtime_mktime(d), msg="Date.mktime_gmtime.1965")
+    }
 }

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -246,4 +246,26 @@ if (.runThisTest) {
         d <- as.Date("1965-12-31")
         checkEquals(d, gmtime_mktime(d), msg="Date.mktime_gmtime.1965")
     }
+
+    test.mktime <- function() {
+        d <- as.Date("2015-12-31")
+        checkEquals(test_mktime(d), as.numeric(as.POSIXct(d)), msg="Date.test_mktime.2015")
+
+        d <- as.Date("1970-01-01")
+        checkEquals(test_mktime(d), as.numeric(as.POSIXct(d)), msg="Date.test_mktime.1970")
+
+        d <- as.Date("1954-07-04")
+        checkEquals(test_mktime(d), as.numeric(as.POSIXct(d)), msg="Date.test_mktime.1954")
+    }
+
+    test.gmtime <- function() {
+        oldTZ <- Sys.getenv("TZ")
+        Sys.setenv(TZ="UTC")
+        checkEquals(test_gmtime(1441065600), as.Date("2015-09-01"), msg="Date.test_gmtime.2015")
+
+        checkEquals(test_gmtime(0),          as.Date("1970-01-01"), msg="Date.test_gmtime.1970")
+
+        checkEquals(test_gmtime(-489024000), as.Date("1954-07-04"), msg="Date.test_gmtime.1954")
+        Sys.setenv(TZ=oldTZ)
+    }
 }

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -1315,7 +1315,10 @@ struct tzhead {
             if (increment_overflow(&y, 1))
                 return NULL;
         }
-        tmp->tm_year = y + TM_YEAR_BASE; // FIXME: Unclear why we need to add this here
+        // Previously we returned 'year + base', so keep behaviour
+        // It seems like R now returns just 'year - 1900' (as libc does)
+        // But better for continuity to do as before 
+        tmp->tm_year = y + TM_YEAR_BASE;
         if (increment_overflow(&tmp->tm_year, -TM_YEAR_BASE))
             return NULL;
         tmp->tm_yday = idays;


### PR DESCRIPTION
`src/Date.cpp` basically dates from 2010.  

It contains some stub code we don't use (ie to load a zonefile) but maybe could / should, but that is for another day.

This PR mostly brings in an update to get to what R uses there.  Ultimately I should farm this out but one attempt in repo [rapidatetime](https://github.com/eddelbuettel/rapidatetime) got suck.  Maybe I'll get back to this.

The PR should be harmless.  It tests out fine, and the branch also supports tests of RQuantLib which is one the few packages actually using `Rcpp::Date` a little...