### PR TITLE
two refinements for Date.cpp required on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-01-04  Dirk Eddelbuettel  <edd@debian.org>
+
+        * src/Date.cpp (Rcpp): Protect assignment to tm_gmtoff to not being
+        under MinGW; could potentially bite other too-limited systems
+
+        * inst/unitTests/runit.Date.R (test.Datetime.formating): Condition one
+        test out if on Windows
+
 2017-01-01  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/unitTests/runit.Date.R (test.mktime, test.gmtime): New tests

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,8 +3,8 @@
         * src/Date.cpp (Rcpp): Protect assignment to tm_gmtoff to not being
         under MinGW; could potentially bite other too-limited systems
 
-        * inst/unitTests/runit.Date.R (test.Datetime.formating): Condition one
-        test out if on Windows
+        * inst/unitTests/runit.Date.R (test.Datetime.formating): Do not set TZ
+        when running test, only set digits option
 
 2017-01-01  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -217,25 +217,27 @@ if (.runThisTest) {
     }
 
     test.Datetime.formating <- function() {
-        oldTZ <- Sys.getenv("TZ")
-        Sys.setenv(TZ="America/Chicago")
+        if (Sys.info()[["sysname"]] != "Windows") {
+            oldTZ <- Sys.getenv("TZ")
+            Sys.setenv(TZ="America/Chicago")
 
-        olddigits <- getOption("digits.secs")
-        options("digits.secs"=6)
+            olddigits <- getOption("digits.secs")
+            options("digits.secs"=6)
+            
+            d <- as.POSIXct("2016-12-13 14:15:16.123456")
+            checkEquals(Datetime_format(d,"%Y-%m-%d %H:%M:%S"),
+                        format(d, "%Y-%m-%d %H:%M:%OS"),
+                        msg="Datetime.formating.default")
+            checkEquals(Datetime_format(d, "%Y/%m/%d %H:%M:%S"),
+                        format(d, "%Y/%m/%d %H:%M:%OS"),
+                        msg="Datetime.formating.given.format")
+            checkEquals(Datetime_ostream(d),
+                        format(d, "%Y-%m-%d %H:%M:%OS"),
+                        msg="Datetime.formating.ostream")
 
-        d <- as.POSIXct("2016-12-13 14:15:16.123456")
-        checkEquals(Datetime_format(d,"%Y-%m-%d %H:%M:%S"),
-                    format(d, "%Y-%m-%d %H:%M:%OS"),
-                    msg="Datetime.formating.default")
-        checkEquals(Datetime_format(d, "%Y/%m/%d %H:%M:%S"),
-                    format(d, "%Y/%m/%d %H:%M:%OS"),
-                    msg="Datetime.formating.given.format")
-        checkEquals(Datetime_ostream(d),
-                    format(d, "%Y-%m-%d %H:%M:%OS"),
-                    msg="Datetime.formating.ostream")
-
-        Sys.setenv(TZ=oldTZ)
-        options("digits.secs"=olddigits)
+            Sys.setenv(TZ=oldTZ)
+            options("digits.secs"=olddigits)
+        }
     }
 
 

--- a/inst/unitTests/runit.Date.R
+++ b/inst/unitTests/runit.Date.R
@@ -217,27 +217,21 @@ if (.runThisTest) {
     }
 
     test.Datetime.formating <- function() {
-        if (Sys.info()[["sysname"]] != "Windows") {
-            oldTZ <- Sys.getenv("TZ")
-            Sys.setenv(TZ="America/Chicago")
+        olddigits <- getOption("digits.secs")
+        options("digits.secs"=6)
 
-            olddigits <- getOption("digits.secs")
-            options("digits.secs"=6)
-            
-            d <- as.POSIXct("2016-12-13 14:15:16.123456")
-            checkEquals(Datetime_format(d,"%Y-%m-%d %H:%M:%S"),
-                        format(d, "%Y-%m-%d %H:%M:%OS"),
-                        msg="Datetime.formating.default")
-            checkEquals(Datetime_format(d, "%Y/%m/%d %H:%M:%S"),
-                        format(d, "%Y/%m/%d %H:%M:%OS"),
-                        msg="Datetime.formating.given.format")
-            checkEquals(Datetime_ostream(d),
-                        format(d, "%Y-%m-%d %H:%M:%OS"),
-                        msg="Datetime.formating.ostream")
+        d <- as.POSIXct("2016-12-13 14:15:16.123456")
+        checkEquals(Datetime_format(d,"%Y-%m-%d %H:%M:%S"),
+                    format(d, "%Y-%m-%d %H:%M:%OS"),
+                    msg="Datetime.formating.default")
+        checkEquals(Datetime_format(d, "%Y/%m/%d %H:%M:%S"),
+                    format(d, "%Y/%m/%d %H:%M:%OS"),
+                    msg="Datetime.formating.given.format")
+        checkEquals(Datetime_ostream(d),
+                    format(d, "%Y-%m-%d %H:%M:%OS"),
+                    msg="Datetime.formating.ostream")
 
-            Sys.setenv(TZ=oldTZ)
-            options("digits.secs"=olddigits)
-        }
+        options("digits.secs"=olddigits)
     }
 
 

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -1347,9 +1347,10 @@ struct tzhead {
             idays -= ip[tmp->tm_mon];
         tmp->tm_mday = (int) (idays + 1);
         tmp->tm_isdst = 0;
-        //#ifdef HAVE_TM_GMTOFF
+#if ! (defined(__MINGW32__) || defined(__MINGW64__))
+//#ifdef HAVE_TM_GMTOFF
         tmp->tm_gmtoff = offset;
-        //#endif
+#endif
         return tmp;
     }
 


### PR DESCRIPTION
We need one change to compile (!!) on Windows, and on test (using six digits precision) fails.

*Edit* Turns out that was a TZ issue instead.