### PR TITLE
Protect tm_gmtoff on Solaris (closes #634)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-01-17  Dirk Eddelbuettel  <edd@debian.org>
+
+        * DESCRIPTION (Version, Date): Roll minor version and Date
+
+        * inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Roll minor
+
+        * src/Date.cpp (Rcpp): Do not access tm_gmtoff on Solaris
+
 2017-01-14  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION: Release 0.12.9

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.9
-Date: 2017-01-14
+Version: 0.12.9.1
+Date: 2017-01-17
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION Rcpp_Version(0,12,9)
 
 // the current source snapshot
-#define RCPP_DEV_VERSION RcppDevVersion(0,12,9,0)
+#define RCPP_DEV_VERSION RcppDevVersion(0,12,9,1)
 
 #endif
 

--- a/src/Date.cpp
+++ b/src/Date.cpp
@@ -1347,7 +1347,7 @@ struct tzhead {
             idays -= ip[tmp->tm_mon];
         tmp->tm_mday = (int) (idays + 1);
         tmp->tm_isdst = 0;
-#if ! (defined(__MINGW32__) || defined(__MINGW64__))
+#if ! (defined(__MINGW32__) || defined(__MINGW64__) || defined(__SUNPRO_CC))
 //#ifdef HAVE_TM_GMTOFF
         tmp->tm_gmtoff = offset;
 #endif


### PR DESCRIPTION
Should work. As usual, cannot test.