### PR TITLE
Fixes for upper_tri and lower_tri with unit tests (closes #641)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2017-01-31  Nathan Russell  <russell.nr2012@gmail.com>
+
+        * inst/include/Rcpp/sugar/matrix/upper_tri.h: Inherit from MatrixBase
+        and use correct comparators in get() to fix segfault
+        * inst/include/Rcpp/sugar/matrix/lower_tri.h: Idem
+        * inst/unitTests/cpp/sugar.cpp: Added unit tests for upper_tri and
+        lower_tri
+        * inst/unitTests/runit.sugar.R: Idem
+
 2017-01-23  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/include/Rcpp/DataFrame.h: Corrected return type for column size.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -10,6 +10,11 @@
       \item Added new size attribute aliases for number of rows and columns in
       DataFrame (James Balamuta in \ghpr{638} addressing \ghit{630}).
     }
+    \item Changes in Rcpp Sugar:
+    \itemize{
+      \item Fixed sugar functions \code{upper_tri()} and \code{lower_tri()}
+      (Nathan Russell in \ghpr{642} addressing \ghit{641}).
+    }
   }
 }
 

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -3,7 +3,7 @@
 // lower_tri.h: Rcpp R/C++ interface class library -- lower.tri
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2017        Dirk Eddelbuettel, Romain Francois, and Nathan Russell
+// Copyright (C) 2017    Dirk Eddelbuettel, Romain Francois, and Nathan Russell
 //
 // This file is part of Rcpp.
 //
@@ -29,31 +29,31 @@ namespace sugar {
 template <int RTYPE, bool NA, typename T>
 class LowerTri : public MatrixBase<LGLSXP, false, LowerTri<RTYPE, NA, T> > {
 public:
-	typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
+    typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
-	LowerTri(const T& lhs, bool diag)
-	    : nr(lhs.nrow()),
+    LowerTri(const T& lhs, bool diag)
+        : nr(lhs.nrow()),
           nc(lhs.ncol()),
-		  getter(diag ? (&LowerTri::get_diag_true) : (&LowerTri::get_diag_false))
+          getter(diag ? (&LowerTri::get_diag_true) : (&LowerTri::get_diag_false))
     {}
 
-	inline int operator()(int i, int j) const { return get(i, j); }
+    inline int operator()(int i, int j) const { return get(i, j); }
 
-	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
-	inline int nrow() const { return nr; }
-	inline int ncol() const { return nc; }
+    inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
+    inline int nrow() const { return nr; }
+    inline int ncol() const { return nc; }
 
 private:
-	typedef bool (LowerTri::*Method)(int, int) const;
+    typedef bool (LowerTri::*Method)(int, int) const;
 
-	int nr, nc;
-	Method getter;
+    int nr, nc;
+    Method getter;
 
-	inline bool get_diag_true(int i, int j) const { return i >= j; }
+    inline bool get_diag_true(int i, int j) const { return i >= j; }
 
-	inline bool get_diag_false(int i, int j) const { return i > j; }
+    inline bool get_diag_false(int i, int j) const { return i > j; }
 
-	inline bool get(int i, int j) const { return (this->*getter)(i, j); }
+    inline bool get(int i, int j) const { return (this->*getter)(i, j); }
 };
 
 } // sugar
@@ -61,7 +61,7 @@ private:
 template <int RTYPE, bool NA, typename T>
 inline sugar::LowerTri<RTYPE, NA, T>
 lower_tri(const Rcpp::MatrixBase<RTYPE, NA, T>& lhs, bool diag = false) {
-	return sugar::LowerTri<RTYPE, NA, T>(lhs, diag);
+    return sugar::LowerTri<RTYPE, NA, T>(lhs, diag);
 }
 
 } // Rcpp

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -1,8 +1,9 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // lower_tri.h: Rcpp R/C++ interface class library -- lower.tri
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2017        Dirk Eddelbuettel, Romain Francois, and Nathan Russell
 //
 // This file is part of Rcpp.
 //
@@ -22,60 +23,47 @@
 #ifndef Rcpp__sugar__lower_tri_h
 #define Rcpp__sugar__lower_tri_h
 
-namespace Rcpp{
-namespace sugar{
+namespace Rcpp {
+namespace sugar {
 
-template <int RTYPE, bool LHS_NA, typename LHS_T>
-class LowerTri : public VectorBase<
-	LGLSXP ,
-	false ,
-	LowerTri<RTYPE,LHS_NA,LHS_T>
-> {
+template <int RTYPE, bool NA, typename T>
+class LowerTri : public MatrixBase<LGLSXP, false, LowerTri<RTYPE, NA, T> > {
 public:
-	typedef Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T> LHS_TYPE ;
+	typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
-	LowerTri( const LHS_TYPE& lhs, bool diag) :
-		nr( lhs.nrow() ), nc( lhs.ncol() ),
-		getter( diag ? (&LowerTri::get_diag_true) : (&LowerTri::get_diag_false) ){}
+	LowerTri(const T& lhs, bool diag)
+	    : nr(lhs.nrow()),
+          nc(lhs.ncol()),
+		  getter(diag ? (&LowerTri::get_diag_true) : (&LowerTri::get_diag_false))
+    {}
 
-	// inline int operator[]( int index ) const {
-	// 	int i = Rcpp::internal::get_line( index, nr ) ;
-	// 	int j = Rcpp::internal::get_column( index, nr, i ) ;
-	// 	return get(i,j) ;
-	// }
-	inline int operator()( int i, int j ) const {
-		return get(i,j) ;
-	}
+	inline int operator()(int i, int j) const { return get(i, j); }
 
-	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 
 private:
-	int nr, nc ;
-	typedef bool (LowerTri::*Method)(int,int) ;
+	typedef bool (LowerTri::*Method)(int, int) const;
 
-	Method getter ;
-	inline bool get_diag_true( int i, int j ){
-		return i <= j ;
-	}
-	inline bool get_diag_false( int i, int j ){
-		return i < j ;
-	}
-	inline bool get( int i, int j){
-		return (this->*getter)(i, j ) ;
-	}
+	int nr, nc;
+	Method getter;
 
-} ;
+	inline bool get_diag_true(int i, int j) const { return i >= j; }
+
+	inline bool get_diag_false(int i, int j) const { return i > j; }
+
+	inline bool get(int i, int j) const { return (this->*getter)(i, j); }
+};
 
 } // sugar
 
-template <int RTYPE, bool LHS_NA, typename LHS_T>
-inline sugar::LowerTri<RTYPE,LHS_NA,LHS_T>
-lower_tri( const Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T>& lhs, bool diag = false){
-	return sugar::LowerTri<RTYPE,LHS_NA,LHS_T>( lhs, diag ) ;
+template <int RTYPE, bool NA, typename T>
+inline sugar::LowerTri<RTYPE, NA, T>
+lower_tri(const Rcpp::MatrixBase<RTYPE, NA, T>& lhs, bool diag = false) {
+	return sugar::LowerTri<RTYPE, NA, T>(lhs, diag);
 }
 
 } // Rcpp
 
-#endif
+#endif // Rcpp__sugar__lower_tri_h

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -29,31 +29,31 @@ namespace sugar {
 template <int RTYPE, bool NA, typename T>
 class UpperTri : public MatrixBase<LGLSXP, false, UpperTri<RTYPE, NA, T> > {
 public:
-	typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
+    typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
-	UpperTri(const T& lhs, bool diag)
-	    : nr(lhs.nrow()),
-		  nc(lhs.ncol()),
-		  getter(diag ? (&UpperTri::get_diag_true) : (&UpperTri::get_diag_false))
+    UpperTri(const T& lhs, bool diag)
+        : nr(lhs.nrow()),
+          nc(lhs.ncol()),
+          getter(diag ? (&UpperTri::get_diag_true) : (&UpperTri::get_diag_false))
     {}
 
-	inline int operator()(int i, int j) const { return get(i, j); }
+    inline int operator()(int i, int j) const { return get(i, j); }
 
-	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
-	inline int nrow() const { return nr; }
-	inline int ncol() const { return nc; }
+    inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
+    inline int nrow() const { return nr; }
+    inline int ncol() const { return nc; }
 
 private:
-	typedef bool (UpperTri::*Method)(int, int) const;
+    typedef bool (UpperTri::*Method)(int, int) const;
 
-	int nr, nc;
-	Method getter;
+    int nr, nc;
+    Method getter;
 
-	inline bool get_diag_true(int i, int j) const { return i <= j; }
+    inline bool get_diag_true(int i, int j) const { return i <= j; }
 
-	inline bool get_diag_false(int i, int j) const { return i < j; }
+    inline bool get_diag_false(int i, int j) const { return i < j; }
 
-	inline bool get(int i, int j) const { return (this->*getter)(i, j); }
+    inline bool get(int i, int j) const { return (this->*getter)(i, j); }
 };
 
 } // sugar
@@ -61,7 +61,7 @@ private:
 template <int RTYPE, bool NA, typename T>
 inline sugar::UpperTri<RTYPE, NA, T>
 upper_tri(const Rcpp::MatrixBase<RTYPE, NA, T>& lhs, bool diag = false) {
-	return sugar::UpperTri<RTYPE, NA, T>(lhs, diag);
+    return sugar::UpperTri<RTYPE, NA, T>(lhs, diag);
 }
 
 } // Rcpp

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -1,8 +1,9 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// upper_tri.h: Rcpp R/C++ interface class library -- lower.tri
+// upper_tri.h: Rcpp R/C++ interface class library -- upper.tri
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2017        Dirk Eddelbuettel, Romain Francois, and Nathan Russell
 //
 // This file is part of Rcpp.
 //
@@ -22,55 +23,47 @@
 #ifndef Rcpp__sugar__upper_tri_h
 #define Rcpp__sugar__upper_tri_h
 
-namespace Rcpp{
-namespace sugar{
+namespace Rcpp {
+namespace sugar {
 
-template <int RTYPE, bool LHS_NA, typename LHS_T>
-class UpperTri : public VectorBase<
-	LGLSXP ,
-	false ,
-	UpperTri<RTYPE,LHS_NA,LHS_T>
-> {
+template <int RTYPE, bool NA, typename T>
+class UpperTri : public MatrixBase<LGLSXP, false, UpperTri<RTYPE, NA, T> > {
 public:
-	typedef Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T> LHS_TYPE ;
+	typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
-	UpperTri( const LHS_TYPE& lhs, bool diag) :
-		nr( lhs.nrow() ), nc( lhs.ncol() ),
-		getter( diag ? (&UpperTri::get_diag_true) : (&UpperTri::get_diag_false) ){}
+	UpperTri(const T& lhs, bool diag)
+	    : nr(lhs.nrow()),
+		  nc(lhs.ncol()),
+		  getter(diag ? (&UpperTri::get_diag_true) : (&UpperTri::get_diag_false))
+    {}
 
-	inline int operator()( int i, int j ) const {
-		return get(i,j) ;
-	}
+	inline int operator()(int i, int j) const { return get(i, j); }
 
-	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc ; }
+	inline R_xlen_t size() const { return static_cast<R_xlen_t>(nr) * nc; }
 	inline int nrow() const { return nr; }
 	inline int ncol() const { return nc; }
 
 private:
-	int nr, nc ;
-	typedef bool (UpperTri::*Method)(int,int) ;
+	typedef bool (UpperTri::*Method)(int, int) const;
 
-	Method getter ;
-	inline bool get_diag_true( int i, int j ){
-		return i >= j ;
-	}
-	inline bool get_diag_false( int i, int j ){
-		return i > j ;
-	}
-	inline bool get( int i, int j){
-		return (this->*getter)(i, j ) ;
-	}
+	int nr, nc;
+	Method getter;
 
-} ;
+	inline bool get_diag_true(int i, int j) const { return i <= j; }
+
+	inline bool get_diag_false(int i, int j) const { return i < j; }
+
+	inline bool get(int i, int j) const { return (this->*getter)(i, j); }
+};
 
 } // sugar
 
-template <int RTYPE, bool LHS_NA, typename LHS_T>
-inline sugar::UpperTri<RTYPE,LHS_NA,LHS_T>
-upper_tri( const Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T>& lhs, bool diag = false){
-	return sugar::UpperTri<RTYPE,LHS_NA,LHS_T>( lhs, diag ) ;
+template <int RTYPE, bool NA, typename T>
+inline sugar::UpperTri<RTYPE, NA, T>
+upper_tri(const Rcpp::MatrixBase<RTYPE, NA, T>& lhs, bool diag = false) {
+	return sugar::UpperTri<RTYPE, NA, T>(lhs, diag);
 }
 
 } // Rcpp
 
-#endif
+#endif // Rcpp__sugar__upper_tri_h

--- a/inst/unitTests/cpp/sugar.cpp
+++ b/inst/unitTests/cpp/sugar.cpp
@@ -749,7 +749,7 @@ IntegerVector runit_cummax_iv(IntegerVector xx){
 }
 
 
-// 18 January 2016: median 
+// 18 January 2016: median
 
 // [[Rcpp::export]]
 double median_dbl(Rcpp::NumericVector x, bool na_rm = false) {
@@ -821,7 +821,7 @@ Rcpp::NumericMatrix n_cbind_ss(double s1, double s2) {
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericMatrix 
+Rcpp::NumericMatrix
 n_cbind9(Rcpp::NumericMatrix m1, Rcpp::NumericVector v1, double s1,
          Rcpp::NumericMatrix m2, Rcpp::NumericVector v2, double s2,
          Rcpp::NumericMatrix m3, Rcpp::NumericVector v3, double s3) {
@@ -832,61 +832,61 @@ n_cbind9(Rcpp::NumericMatrix m1, Rcpp::NumericVector v1, double s1,
 // B. Integer*
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_mm(Rcpp::IntegerMatrix m1, Rcpp::IntegerMatrix m2) {
     return Rcpp::cbind(m1, m2);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_mv(Rcpp::IntegerMatrix m1, Rcpp::IntegerVector v1) {
     return Rcpp::cbind(m1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_ms(Rcpp::IntegerMatrix m1, int s1) {
     return Rcpp::cbind(m1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_vv(Rcpp::IntegerVector v1, Rcpp::IntegerVector v2) {
     return Rcpp::cbind(v1, v2);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_vm(Rcpp::IntegerVector v1, Rcpp::IntegerMatrix m1) {
     return Rcpp::cbind(v1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_vs(Rcpp::IntegerVector v1, int s1) {
     return Rcpp::cbind(v1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_sm(int s1, Rcpp::IntegerMatrix m1) {
     return Rcpp::cbind(s1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_sv(int s1, Rcpp::IntegerVector v1) {
     return Rcpp::cbind(s1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind_ss(int s1, int s2) {
     return Rcpp::cbind(s1, s2);
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerMatrix 
+Rcpp::IntegerMatrix
 i_cbind9(Rcpp::IntegerMatrix m1, Rcpp::IntegerVector v1, int s1,
          Rcpp::IntegerMatrix m2, Rcpp::IntegerVector v2, int s2,
          Rcpp::IntegerMatrix m3, Rcpp::IntegerVector v3, int s3) {
@@ -897,61 +897,61 @@ i_cbind9(Rcpp::IntegerMatrix m1, Rcpp::IntegerVector v1, int s1,
 // C. Complex*
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_mm(Rcpp::ComplexMatrix m1, Rcpp::ComplexMatrix m2) {
     return Rcpp::cbind(m1, m2);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_mv(Rcpp::ComplexMatrix m1, Rcpp::ComplexVector v1) {
     return Rcpp::cbind(m1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_ms(Rcpp::ComplexMatrix m1, Rcomplex s1) {
     return Rcpp::cbind(m1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_vv(Rcpp::ComplexVector v1, Rcpp::ComplexVector v2) {
     return Rcpp::cbind(v1, v2);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_vm(Rcpp::ComplexVector v1, Rcpp::ComplexMatrix m1) {
     return Rcpp::cbind(v1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_vs(Rcpp::ComplexVector v1, Rcomplex s1) {
     return Rcpp::cbind(v1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_sm(Rcomplex s1, Rcpp::ComplexMatrix m1) {
     return Rcpp::cbind(s1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_sv(Rcomplex s1, Rcpp::ComplexVector v1) {
     return Rcpp::cbind(s1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind_ss(Rcomplex s1, Rcomplex s2) {
     return Rcpp::cbind(s1, s2);
 }
 
 // [[Rcpp::export]]
-Rcpp::ComplexMatrix 
+Rcpp::ComplexMatrix
 cx_cbind9(Rcpp::ComplexMatrix m1, Rcpp::ComplexVector v1, Rcomplex s1,
          Rcpp::ComplexMatrix m2, Rcpp::ComplexVector v2, Rcomplex s2,
          Rcpp::ComplexMatrix m3, Rcpp::ComplexVector v3, Rcomplex s3) {
@@ -962,61 +962,61 @@ cx_cbind9(Rcpp::ComplexMatrix m1, Rcpp::ComplexVector v1, Rcomplex s1,
 // D. Logical*
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_mm(Rcpp::LogicalMatrix m1, Rcpp::LogicalMatrix m2) {
     return Rcpp::cbind(m1, m2);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_mv(Rcpp::LogicalMatrix m1, Rcpp::LogicalVector v1) {
     return Rcpp::cbind(m1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_ms(Rcpp::LogicalMatrix m1, bool s1) {
     return Rcpp::cbind(m1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_vv(Rcpp::LogicalVector v1, Rcpp::LogicalVector v2) {
     return Rcpp::cbind(v1, v2);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_vm(Rcpp::LogicalVector v1, Rcpp::LogicalMatrix m1) {
     return Rcpp::cbind(v1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_vs(Rcpp::LogicalVector v1, bool s1) {
     return Rcpp::cbind(v1, s1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_sm(bool s1, Rcpp::LogicalMatrix m1) {
     return Rcpp::cbind(s1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_sv(bool s1, Rcpp::LogicalVector v1) {
     return Rcpp::cbind(s1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind_ss(bool s1, bool s2) {
     return Rcpp::cbind(s1, s2);
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalMatrix 
+Rcpp::LogicalMatrix
 l_cbind9(Rcpp::LogicalMatrix m1, Rcpp::LogicalVector v1, bool s1,
          Rcpp::LogicalMatrix m2, Rcpp::LogicalVector v2, bool s2,
          Rcpp::LogicalMatrix m3, Rcpp::LogicalVector v3, bool s3) {
@@ -1027,31 +1027,31 @@ l_cbind9(Rcpp::LogicalMatrix m1, Rcpp::LogicalVector v1, bool s1,
 // E. Character*
 
 // [[Rcpp::export]]
-Rcpp::CharacterMatrix 
+Rcpp::CharacterMatrix
 c_cbind_mm(Rcpp::CharacterMatrix m1, Rcpp::CharacterMatrix m2) {
     return Rcpp::cbind(m1, m2);
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterMatrix 
+Rcpp::CharacterMatrix
 c_cbind_mv(Rcpp::CharacterMatrix m1, Rcpp::CharacterVector v1) {
     return Rcpp::cbind(m1, v1);
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterMatrix 
+Rcpp::CharacterMatrix
 c_cbind_vv(Rcpp::CharacterVector v1, Rcpp::CharacterVector v2) {
     return Rcpp::cbind(v1, v2);
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterMatrix 
+Rcpp::CharacterMatrix
 c_cbind_vm(Rcpp::CharacterVector v1, Rcpp::CharacterMatrix m1) {
     return Rcpp::cbind(v1, m1);
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterMatrix 
+Rcpp::CharacterMatrix
 c_cbind6(Rcpp::CharacterMatrix m1, Rcpp::CharacterVector v1,
          Rcpp::CharacterMatrix m2, Rcpp::CharacterVector v2,
          Rcpp::CharacterMatrix m3, Rcpp::CharacterVector v3) {
@@ -1154,37 +1154,50 @@ IntegerVector sample_dot_int(int n, int sz, bool rep = false, sugar::probs_t p =
 }
 
 // [[Rcpp::export]]
-IntegerVector sample_int(IntegerVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+IntegerVector sample_int(IntegerVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
 }
 
 // [[Rcpp::export]]
-NumericVector sample_dbl(NumericVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+NumericVector sample_dbl(NumericVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
 }
 
 // [[Rcpp::export]]
-CharacterVector sample_chr(CharacterVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+CharacterVector sample_chr(CharacterVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
 }
 
 // [[Rcpp::export]]
-ComplexVector sample_cx(ComplexVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+ComplexVector sample_cx(ComplexVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
 }
 
 // [[Rcpp::export]]
-LogicalVector sample_lgl(LogicalVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+LogicalVector sample_lgl(LogicalVector x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
 }
 
 // [[Rcpp::export]]
-List sample_list(List x, int sz, bool rep = false, sugar::probs_t p = R_NilValue) 
+List sample_list(List x, int sz, bool rep = false, sugar::probs_t p = R_NilValue)
 {
     return sample(x, sz, rep, p);
+}
+
+
+// 31 January 2017: upper_tri, lower_tri
+
+// [[Rcpp::export]]
+LogicalMatrix UpperTri(NumericMatrix x, bool diag = false) {
+    return upper_tri(x, diag);
+}
+
+// [[Rcpp::export]]
+LogicalMatrix LowerTri(NumericMatrix x, bool diag = false) {
+    return lower_tri(x, diag);
 }

--- a/inst/unitTests/runit.sugar.R
+++ b/inst/unitTests/runit.sugar.R
@@ -1664,260 +1664,260 @@ if (.runThisTest) {
         )
 
     }
-    
-    
+
+
     ## 10 December 2016
     ## sample.int tests
     test.sugar.sample_dot_int <- function() {
-        
+
         set.seed(123); s1 <- sample_dot_int(10, 5)
         set.seed(123); s2 <- sample(10, 5)
-        
+
         checkEquals(
             s1, s2,
             "sample.int / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_dot_int(10, 5, TRUE)
         set.seed(123); s2 <- sample(10, 5, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample.int / with replacement / without probability"
         )
-        
+
 
         px <- rep(c(3, 2, 1), length.out = 10)
         set.seed(123); s1 <- sample_dot_int(10, 5, FALSE, px)
         set.seed(123); s2 <- sample(10, 5, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample.int / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_dot_int(10, 5, TRUE, px)
         set.seed(123); s2 <- sample(10, 5, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample.int / with replacement / with probability"
         )
-        
+
     }
-    
-    
+
+
     ## sample_int tests
     test.sugar.sample_int <- function() {
-        
+
         x <- as.integer(rpois(10, 10))
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_int(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_int / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_int(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_int / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_int(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_int / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_int(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_int / with replacement / with probability"
         )
-        
+
     }
-    
+
 
     ## sample_dbl tests
     test.sugar.sample_dbl <- function() {
-        
+
         x <- rnorm(10)
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_dbl(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_dbl / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_dbl(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_dbl / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_dbl(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_dbl / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_dbl(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_dbl / with replacement / with probability"
         )
-        
+
     }
-    
+
 
     ## sample_chr tests
     test.sugar.sample_chr <- function() {
-        
+
         x <- sample(letters, 10)
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_chr(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_chr / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_chr(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_chr / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_chr(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_chr / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_chr(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_chr / with replacement / with probability"
         )
-        
+
     }
-    
-    
+
+
     ## sample_cx tests
     test.sugar.sample_cx <- function() {
-        
+
         x <- rnorm(10) + 2i
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_cx(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_cx / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_cx(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_cx / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_cx(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_cx / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_cx(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_cx / with replacement / with probability"
         )
-        
+
     }
-    
-    
+
+
     ## sample_lgl tests
     test.sugar.sample_lgl <- function() {
-        
+
         x <- rbinom(10, 1, 0.5) > 0
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_lgl(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_lgl / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_lgl(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_lgl / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_lgl(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_lgl / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_lgl(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_lgl / with replacement / with probability"
         )
-        
+
     }
-    
-    
+
+
     ## sample_list tests
     test.sugar.sample_list <- function() {
-        
+
         x <- list(
             letters,
-            1:5, 
+            1:5,
             rnorm(10),
             state.abb,
             state.area,
@@ -1928,39 +1928,124 @@ if (.runThisTest) {
             BJsales
         )
         px <- rep(c(3, 2, 1), length.out = 10)
-        
+
         set.seed(123); s1 <- sample_list(x, 6)
         set.seed(123); s2 <- sample(x, 6)
-        
+
         checkEquals(
             s1, s2,
             "sample_list / without replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_list(x, 6, TRUE)
         set.seed(123); s2 <- sample(x, 6, TRUE)
-        
+
         checkEquals(
             s1, s2,
             "sample_list / with replacement / without probability"
         )
-        
+
         set.seed(123); s1 <- sample_list(x, 6, FALSE, px)
         set.seed(123); s2 <- sample(x, 6, FALSE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_list / without replacement / with probability"
         )
-        
+
         set.seed(123); s1 <- sample_list(x, 6, TRUE, px)
         set.seed(123); s2 <- sample(x, 6, TRUE, px)
-        
+
         checkEquals(
             s1, s2,
             "sample_list / with replacement / with probability"
         )
-        
+
+    }
+
+
+    ## 31 January 2017
+    ## upper_tri tests
+    test.sugar.upper_tri <- function() {
+
+        x <- matrix(rnorm(9), 3)
+
+        checkEquals(
+            UpperTri(x), upper.tri(x),
+            "upper_tri / symmetric / diag = FALSE"
+        )
+
+        checkEquals(
+            UpperTri(x, TRUE), upper.tri(x, TRUE),
+            "upper_tri / symmetric / diag = TRUE"
+        )
+
+        x <- matrix(rnorm(12), 3)
+
+        checkEquals(
+            UpperTri(x), upper.tri(x),
+            "upper_tri / [3 x 4] / diag = FALSE"
+        )
+
+        checkEquals(
+            UpperTri(x, TRUE), upper.tri(x, TRUE),
+            "upper_tri / [3 x 4] / diag = TRUE"
+        )
+
+        x <- matrix(rnorm(12), 4)
+
+        checkEquals(
+            UpperTri(x), upper.tri(x),
+            "upper_tri / [4 x 3] / diag = FALSE"
+        )
+
+        checkEquals(
+            UpperTri(x, TRUE), upper.tri(x, TRUE),
+            "upper_tri / [4 x 3] / diag = TRUE"
+        )
+
+    }
+
+
+    ## lower_tri tests
+    test.sugar.lower_tri <- function() {
+
+        x <- matrix(rnorm(9), 3)
+
+        checkEquals(
+            LowerTri(x), lower.tri(x),
+            "lower_tri / symmetric / diag = FALSE"
+        )
+
+        checkEquals(
+            LowerTri(x, TRUE), lower.tri(x, TRUE),
+            "lower_tri / symmetric / diag = TRUE"
+        )
+
+        x <- matrix(rnorm(12), 3)
+
+        checkEquals(
+            LowerTri(x), lower.tri(x),
+            "lower_tri / [3 x 4] / diag = FALSE"
+        )
+
+        checkEquals(
+            LowerTri(x, TRUE), lower.tri(x, TRUE),
+            "lower_tri / [3 x 4] / diag = TRUE"
+        )
+
+        x <- matrix(rnorm(12), 4)
+
+        checkEquals(
+            LowerTri(x), lower.tri(x),
+            "lower_tri / [4 x 3] / diag = FALSE"
+        )
+
+        checkEquals(
+            LowerTri(x, TRUE), lower.tri(x, TRUE),
+            "lower_tri / [4 x 3] / diag = TRUE"
+        )
+
     }
 
 }


### PR DESCRIPTION
With these changes, 

```c++
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
LogicalMatrix UpperTri(NumericMatrix x, bool diag = false) {
    return upper_tri(x, diag);
}

// [[Rcpp::export]]
LogicalMatrix LowerTri(NumericMatrix x, bool diag = false) {
    return lower_tri(x, diag);
}

/*** R

x <- matrix(1:4, 4, 5)

all.equal(UpperTri(x), upper.tri(x))
# [1] TRUE

all.equal(UpperTri(x, TRUE), upper.tri(x, TRUE))
# [1] TRUE

all.equal(LowerTri(x), lower.tri(x))
# [1] TRUE

all.equal(LowerTri(x, TRUE), lower.tri(x, TRUE))
# [1] TRUE

*/
```