### PR TITLE
Allow intel icc compilation of algorithm.h (closes 640)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,6 @@
-2017-02-01  Dirk Eddelbuettel  <edd@debian.org>
-
-        * inst/include/Rcpp/algorithm.h (RCPP_CONSTEXPR): Further refinement for
-        Intel compiler without C++11
-
 2017-01-31  Dirk Eddelbuettel  <edd@debian.org>
 
-        * DESCRIPTION (Date, Version): Roll minor version
+        * DESCRIPTION (Date, Version): Roll minor version 
 
         * inst/include/Rcpp/algorithm.h: Allow algorithm.h to be compiler under
         Intel's compiler, add copyright header and include guard

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
+2017-02-01  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/include/Rcpp/algorithm.h (RCPP_CONSTEXPR): Further refinement for
+        Intel compiler without C++11
+
 2017-01-31  Dirk Eddelbuettel  <edd@debian.org>
 
-        * DESCRIPTION (Date, Version): Roll minor version 
+        * DESCRIPTION (Date, Version): Roll minor version
 
         * inst/include/Rcpp/algorithm.h: Allow algorithm.h to be compiler under
         Intel's compiler, add copyright header and include guard

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-01-31  Dirk Eddelbuettel  <edd@debian.org>
+
+        * DESCRIPTION (Date, Version): Roll minor version 
+
+        * inst/include/Rcpp/algorithm.h: Allow algorithm.h to be compiler under
+        Intel's compiler, add copyright header and include guard
+
 2017-01-31  Nathan Russell  <russell.nr2012@gmail.com>
 
         * inst/include/Rcpp/sugar/matrix/upper_tri.h: Inherit from MatrixBase

--- a/ChangeLog
+++ b/ChangeLog
@@ -548,7 +548,7 @@
 
 2016-07-10  Nathan Russell <russell.nr2012@gmail.com>
 
-        * inst/include/Rcpp/algorithm.h: Accomdate clang compiler
+        * inst/include/Rcpp/algorithm.h: Accomodate clang compiler
 
 2016-07-03  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.9.1
-Date: 2017-01-17
+Version: 0.12.9.2
+Date: 2017-01-31
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp version 0.13.0 (2017-03-xx)}{
+\section{Changes in Rcpp version 0.12.10 (2017-03-xx)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
@@ -14,6 +14,8 @@
     \itemize{
       \item Fixed sugar functions \code{upper_tri()} and \code{lower_tri()}
       (Nathan Russell in \ghpr{642} addressing \ghit{641}).
+      \item The \code{algorithm.h} file now accomodates the Intel compiler
+      (Dirk in \ghpr{643} addressing isue \ghit{640})
     }
   }
 }

--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -24,6 +24,8 @@
 
 #if __cplusplus >= 201103L || __INTEL_CXX11_MODE__ == 1
 #    define RCPP_CONSTEXPR constexpr
+#elif defined(__INTEL_COMPILER) 
+#    define RCPP_CONSTEXPR
 #else
 #    define RCPP_CONSTEXPR const
 #endif

--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -1,4 +1,28 @@
-#if __cplusplus >= 201103L
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// algorithm.h: Rcpp R/C++ interface class library -- data frames
+//
+// Copyright (C) 2016 - 2017  Daniel C. Dillon
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__Algorithm_h
+#define Rcpp__Algorithm_h
+
+#if __cplusplus >= 201103L || __INTEL_CXX11_MODE__ == 1
 #    define RCPP_CONSTEXPR constexpr
 #else
 #    define RCPP_CONSTEXPR const
@@ -211,7 +235,7 @@ template< typename InputIterator >
 typename traits::enable_if< helpers::decays_to_ctype< typename std::iterator_traits< InputIterator >::value_type >::value,
     typename helpers::ctype< typename std::iterator_traits< InputIterator >::value_type >::type >::type
         sum(InputIterator begin, InputIterator end) {
-    
+
     typedef typename helpers::ctype< typename std::iterator_traits< InputIterator >::value_type >::type value_type;
     typedef typename helpers::rtype< value_type > rtype;
 
@@ -236,7 +260,7 @@ template< typename InputIterator >
 typename traits::enable_if< helpers::decays_to_ctype< typename std::iterator_traits< InputIterator >::value_type >::value,
     typename helpers::ctype< typename std::iterator_traits< InputIterator >::value_type >::type >::type
         sum_nona(InputIterator begin, InputIterator end) {
-    
+
     typedef typename helpers::ctype< typename std::iterator_traits< InputIterator >::value_type >::type value_type;
     typedef typename helpers::rtype< value_type > rtype;
 
@@ -465,3 +489,5 @@ void sqrt(InputIterator begin, InputIterator end, OutputIterator out) {
 } // namespace Rcpp
 
 #undef RCPP_CONSTEXPR
+
+#endif

--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -24,8 +24,6 @@
 
 #if __cplusplus >= 201103L || __INTEL_CXX11_MODE__ == 1
 #    define RCPP_CONSTEXPR constexpr
-#elif defined(__INTEL_COMPILER) 
-#    define RCPP_CONSTEXPR
 #else
 #    define RCPP_CONSTEXPR const
 #endif


### PR DESCRIPTION
Simple PR adding what #640 ended up with in conclusion

Comments welcome, in particular double-checking whether the `else` side of the `#if` should be empty or `const`. Per #640 empty did not work. 

Poking @kevinushey @nathan-russell @dcdillon @jjallaire @thirdwing 