### PR TITLE
Fixing algorithm.h for icc (closes #640)

### DIFF
--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -23,9 +23,11 @@
 #define Rcpp__Algorithm_h
 
 #if __cplusplus >= 201103L || __INTEL_CXX11_MODE__ == 1
-#    define RCPP_CONSTEXPR constexpr
+#    define RCPP_CONSTEXPR_FUNC constexpr
+#    define RCPP_CONSTEXPR_VAR constexpr
 #else
-#    define RCPP_CONSTEXPR const
+#    define RCPP_CONSTEXPR_FUNC
+#    define RCPP_CONSTEXPR_VAR const
 #endif
 
 namespace Rcpp {
@@ -160,41 +162,34 @@ namespace helpers {
 
     template< typename T >
     struct rtype_helper {
-        /*
-	typedef T type;
-        static RCPP_CONSTEXPR int RTYPE = REALSXP;
-        static inline double NA() { return NA_REAL; }
-        static inline RCPP_CONSTEXPR double ZERO() { return 0.0; }
-        static inline RCPP_CONSTEXPR double ONE() { return 1.0; }
-        */
     };
 
     template<>
     struct rtype_helper< double > {
         typedef double type;
-        static RCPP_CONSTEXPR int RTYPE = REALSXP;
+        static RCPP_CONSTEXPR_VAR int RTYPE = REALSXP;
         static inline double NA() { return NA_REAL; }
-        static inline RCPP_CONSTEXPR double ZERO() { return 0.0; }
-        static inline RCPP_CONSTEXPR double ONE() { return 1.0; }
+        static inline RCPP_CONSTEXPR_FUNC double ZERO() { return 0.0; }
+        static inline RCPP_CONSTEXPR_FUNC double ONE() { return 1.0; }
     };
 
     template<>
     struct rtype_helper< int > {
         typedef int type;
-        static RCPP_CONSTEXPR int RTYPE = INTSXP;
+        static RCPP_CONSTEXPR_VAR int RTYPE = INTSXP;
         static inline int NA() { return NA_INTEGER; }
-        static inline RCPP_CONSTEXPR int ZERO() { return 0; }
-        static inline RCPP_CONSTEXPR int ONE() { return 1; }
+        static inline RCPP_CONSTEXPR_FUNC int ZERO() { return 0; }
+        static inline RCPP_CONSTEXPR_FUNC int ONE() { return 1; }
     };
 
     template< typename T >
     struct rtype {
         typedef typename rtype_helper< typename ctype< T >::type >::type type;
         typedef rtype_helper< typename ctype< T >::type > helper_type;
-        static RCPP_CONSTEXPR int RTYPE = helper_type::RTYPE;
+        static RCPP_CONSTEXPR_VAR int RTYPE = helper_type::RTYPE;
         static inline T NA() { return helper_type::NA(); }
-        static inline RCPP_CONSTEXPR T ZERO() { return helper_type::ZERO(); }
-        static inline RCPP_CONSTEXPR T ONE() { return helper_type::ONE(); }
+        static inline RCPP_CONSTEXPR_FUNC T ZERO() { return helper_type::ZERO(); }
+        static inline RCPP_CONSTEXPR_FUNC T ONE() { return helper_type::ONE(); }
     };
 
     struct log {
@@ -488,6 +483,7 @@ void sqrt(InputIterator begin, InputIterator end, OutputIterator out) {
 } // namespace algorithm
 } // namespace Rcpp
 
-#undef RCPP_CONSTEXPR
+#undef RCPP_CONSTEXPR_FUNC
+#undef RCPP_CONSTEXPR_VAR
 
 #endif


### PR DESCRIPTION
Now we have `RCPP_CONSTEXPR_VAR` and `RCPP_CONSTEXPR_FUNC` which are defined properly.