### PR TITLE
close #647: fixed single-character handling in Rstreambuf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-02-14  Iñaki Ucar  <i.ucar86@gmail.com>
+
+        * inst/include/Rcpp/iostream/Rstreambuf.h: Fixed single-character handling
+        (pull request #649, fixes issue #647)
+
 2017-02-13  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/Attributes.R (.plugins[["cpp17"]]): New plugin

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,8 @@
     \itemize{
       \item Added new size attribute aliases for number of rows and columns in
       DataFrame (James Balamuta in \ghpr{638} addressing \ghit{630}).
+      \item Fixed single-character handling in \code{Rstreambuf} (Iñaki Ucar in
+      \ghpr{649} addressing \ghit{647}).
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/include/Rcpp/iostream/Rstreambuf.h
+++ b/inst/include/Rcpp/iostream/Rstreambuf.h
@@ -35,7 +35,7 @@ namespace Rcpp {
     protected:
         virtual std::streamsize xsputn(const char *s, std::streamsize n );
 
-        virtual int overflow(int c = EOF );
+        virtual int overflow(int c = traits_type::eof() );
 
         virtual int sync()  ;
     };
@@ -67,12 +67,22 @@ namespace Rcpp {
     }
 
     template <> inline int Rstreambuf<true>::overflow(int c ) {
-      if (c != EOF) Rprintf( "%.1s", &c ) ;
-      return c ;
+        if (c == traits_type::eof())
+            return traits_type::eof();
+        else
+        {
+            char_type ch = traits_type::to_char_type(c);
+            return xsputn(&ch, 1) == 1 ? c : traits_type::eof();
+        }
     }
     template <> inline int Rstreambuf<false>::overflow(int c ) {
-      if (c != EOF) REprintf( "%.1s", &c ) ;
-      return c ;
+        if (c == traits_type::eof())
+            return traits_type::eof();
+        else
+        {
+            char_type ch = traits_type::to_char_type(c);
+            return xsputn(&ch, 1) == 1 ? c : traits_type::eof();
+        }
     }
 
     template <> inline int Rstreambuf<true>::sync(){

--- a/inst/include/Rcpp/iostream/Rstreambuf.h
+++ b/inst/include/Rcpp/iostream/Rstreambuf.h
@@ -67,22 +67,18 @@ namespace Rcpp {
     }
 
     template <> inline int Rstreambuf<true>::overflow(int c ) {
-        if (c == traits_type::eof())
-            return traits_type::eof();
-        else
-        {
+        if (c != traits_type::eof()) {
             char_type ch = traits_type::to_char_type(c);
             return xsputn(&ch, 1) == 1 ? c : traits_type::eof();
         }
+        return c;
     }
     template <> inline int Rstreambuf<false>::overflow(int c ) {
-        if (c == traits_type::eof())
-            return traits_type::eof();
-        else
-        {
+        if (c != traits_type::eof()) {
             char_type ch = traits_type::to_char_type(c);
             return xsputn(&ch, 1) == 1 ? c : traits_type::eof();
         }
+        return c;
     }
 
     template <> inline int Rstreambuf<true>::sync(){


### PR DESCRIPTION
I realised that this wasn't a problem with `std::endl`, but in general with the output of any single character, which is managed by `overflow()`. The new implementation of `overflow()` calls `xsputn()`, and it works correctly in SPARC too.