### PR TITLE
Add argument to XPtr template to run finalizer on exit (fixes #655)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-03-15  Jeroen Ooms  <jeroenooms@gmail.com>
+
+        * inst/include/Rcpp/XPtr.h: added finalizeOnExit parameter
+
 2017-02-28  Dirk Eddelbuettel  <edd@debian.org>
 
         * src/Rcpp_init.cpp (R_init_Rcpp): Call R_useDynamicSymbols()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.9.4
-Date: 2017-02-28
+Version: 0.12.9.5
+Date: 2017-03-15
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,6 +11,8 @@
       DataFrame (James Balamuta in \ghpr{638} addressing \ghit{630}).
       \item Fixed single-character handling in \code{Rstreambuf} (Iñaki Ucar in
       \ghpr{649} addressing \ghit{647}).
+      \item XPtr gains a parameter \code{finalizeOnExit} to enable running the
+       finalizer when R quits (Jeroen Ooms in \ghpr{656} addressing \ghit{655}).
     }
     \item Changes in Rcpp Sugar:
     \itemize{

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -43,15 +43,16 @@ void finalizer_wrapper(SEXP p){
 template <
     typename T,
     template <class> class StoragePolicy = PreserveStorage,
-    void Finalizer(T*) = standard_delete_finalizer<T>
+    void Finalizer(T*) = standard_delete_finalizer<T>,
+    bool finalizeOnExit = false
 >
 class XPtr :
-    public StoragePolicy< XPtr<T,StoragePolicy, Finalizer> >,
-    public SlotProxyPolicy< XPtr<T,StoragePolicy, Finalizer> >,
-    public AttributeProxyPolicy< XPtr<T,StoragePolicy, Finalizer> >,
-    public TagProxyPolicy< XPtr<T,StoragePolicy, Finalizer> >,
-    public ProtectedProxyPolicy< XPtr<T,StoragePolicy, Finalizer> >,
-    public RObjectMethods< XPtr<T,StoragePolicy, Finalizer> >
+    public StoragePolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,
+    public SlotProxyPolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,
+    public AttributeProxyPolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,
+    public TagProxyPolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,
+    public ProtectedProxyPolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,
+    public RObjectMethods< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >
 {
 public:
 
@@ -148,7 +149,7 @@ public:
     }
 
     void setDeleteFinalizer() {
-        R_RegisterCFinalizerEx( Storage::get__(), finalizer_wrapper<T,Finalizer> , FALSE) ;
+        R_RegisterCFinalizerEx( Storage::get__(), finalizer_wrapper<T,Finalizer> , (Rboolean) finalizeOnExit) ;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/RcppCore/Rcpp/issues/655. This adds an additional parameter to `XPtr` which specifies if the finalizer should run on exit in the same spirit as the underlying `R_RegisterCFinalizerEx`.

I confirmed that this works. Default is still `FALSE` so the current behavior will be unchanged.