### PR TITLE
Added support for throwing exceptions without call stacks.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-04-03  Jim Hester  <james.f.hester@gmail.com>
+
+        * inst/include/Rcpp/exceptions.h: Added support for throwing
+        exceptions without call stacks.
+        * inst/include/Rcpp/macros/macros.h: Idem
+        * inst/unitTests/cpp/exceptions.cpp: Idem
+        * inst/unitTests/runit.exceptions.R: Idem
+
 2017-03-28  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/vignettes/Rcpp-FAQ.Rnw: Added "Known Issues" section to FAQ

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,6 +14,8 @@
       \item Added a Known Issues section to the Rcpp FAQ vignette
       (James Balamuta in \ghpr{661} addressing \ghit{628}, \ghit{563},
       \ghit{552}, \ghit{460}, \ghit{419}, and \ghit{251}).
+      \item Rcpp::exceptions can now be constructed without a call stack (Jim
+      Hester in \ghpr{663}).
     }
   }
 }

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -39,10 +39,15 @@
     catch( Rcpp::internal::InterruptedException &__ex__) {                                       \
         rcpp_output_type = 1 ;                                                                   \
     }                                                                                            \
+    catch(Rcpp::exception& __ex__) {                                                             \
+       rcpp_output_type = 2 ;                                                                    \
+       rcpp_output_condition = PROTECT(rcpp_exception_to_r_condition(__ex__)) ;                  \
+    }                                                                                            \
     catch( std::exception& __ex__ ){                                                             \
        rcpp_output_type = 2 ;                                                                    \
        rcpp_output_condition = PROTECT(exception_to_r_condition(__ex__)) ;                       \
-    } catch( ... ){                                                                              \
+    }                                                                                            \
+    catch( ... ){                                                                                \
        rcpp_output_type = 2 ;                                                                    \
        rcpp_output_condition = PROTECT(string_to_try_error("c++ exception (unknown reason)")) ;  \
     }                                                                                            \

--- a/inst/unitTests/cpp/exceptions.cpp
+++ b/inst/unitTests/cpp/exceptions.cpp
@@ -62,3 +62,8 @@ double f1(double val) {
 double takeLogNested(double val) {
     return f1(val);
 }
+
+// [[Rcpp::export]]
+void noCall() {
+    throw Rcpp::exception("Testing", false);
+}

--- a/inst/unitTests/runit.exceptions.R
+++ b/inst/unitTests/runit.exceptions.R
@@ -110,4 +110,14 @@ test.rcppExceptionLocation <- function() {
   checkEquals(nested$call, quote(takeLogNested(x)))
 }
 
+test.rcppExceptionNoCall <- function() {
+
+  # Can throw exceptions that don't include a call stack
+  e <- tryCatch(noCall(), error = identity)
+
+  checkIdentical(e$message, "Testing")
+  checkIdentical(e$call, NULL)
+  checkIdentical(e$cppstack, NULL)
+  checkIdentical(class(e), c("Rcpp::exception", "C++Error", "error", "condition"))
+}
 }


### PR DESCRIPTION
There is currently no way to generate an exception from Rcpp which does _not_ have an attached R (and cpp) call stacks. This extra information can be confusing for users, so it is useful to be able to disable it if desired (like `stop(call. = FALSE)` does in R code.

This could be implemented by providing overloaded `forward_exception_to_r()`and `exception_to_r_condition()` functions for `Rcpp::exceptions`, but I felt like it made the intention more clear to define new functions instead.