### PR TITLE
[WIP] Feature improve exception message details (closes #184)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,28 @@
         * inst/include/Rcpp/macros/macros.h: Idem
         * inst/unitTests/cpp/exceptions.cpp: Idem
         * inst/unitTests/runit.exceptions.R: Idem
+2017-04-10  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/exceptions.h: Added new exception class generation
+        macro, reworked existing macros, and removed two exceptions not used.
+        * inst/include/Rcpp/Environment.h: Improved error handling messages
+        * inst/include/Rcpp/Function.h: idem
+        * inst/include/Rcpp/Promise.h: idem
+        * inst/include/Rcpp/S4.h: idem
+        * inst/include/Rcpp/String.h: idem
+        * inst/include/Rcpp/Symbol.h: idem
+        * inst/include/Rcpp/XPtr.h: idem
+        * inst/include/Rcpp/as.h: idem
+        * inst/include/Rcpp/exceptions.h: idem
+        * inst/include/Rcpp/r_cast.h: idem
+        * inst/include/Rcpp/api/meat/DottedPairImpl.h: idem
+        * inst/include/Rcpp/internal/export.h: idem
+        * inst/include/Rcpp/proxy/DottedPairProxy.h: idem
+        * inst/include/Rcpp/proxy/SlotProxy.h: idem
+        * inst/include/Rcpp/vector/Matrix.h: idem
+        * inst/include/Rcpp/vector/MatrixColumn.h: idem
+        * inst/include/Rcpp/vector/MatrixRow.h: idem
+        * inst/include/Rcpp/vector/Vector.h: idem
 
 2017-03-28  James J Balamuta  <balamut2@illinois.edu>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2017-04-14  James J Balamuta  <balamut2@illinois.edu>
 
+        * inst/include/Rcpp/proxy/SlotProxy.h: Passed slot name to exception
+        throw.
+
         * inst/include/Rcpp/utils/tinyformat.h: Refreshed tinyformat.h against
         May 13, 2016 upstream, retained local mods.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2017-04-14  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/Environment.h: Modified formatting of new exception
+        messages to be more concise.
+        * inst/include/Rcpp/exceptions.h: idem
+        * inst/include/Rcpp/Function.h: idem
+        * inst/include/Rcpp/Promise.h: idem
+        * inst/include/Rcpp/String.h: idem
+        * inst/include/Rcpp/Symbol.h: idem
+        * inst/include/Rcpp/XPtr.h: idem
+        * inst/include/Rcpp/as.h: idem
+        * inst/include/Rcpp/r_cast.h: idem
+        * inst/include/Rcpp/api/meat/DottedPairImpl.h: idem
+        * inst/include/Rcpp/internal/export.h: idem
+        * inst/include/Rcpp/proxy/DottedPairProxy.h: idem
+        * inst/include/Rcpp/vector/MatrixColumn.h: idem
+        * inst/include/Rcpp/vector/MatrixRow.h: idem
+        * inst/include/Rcpp/vector/Vector.h: idem
+
 2017-04-11  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/inst/unitTests/testRcppClass/src/init.c (R_init_testRcppClass): Call
@@ -43,6 +62,7 @@
         * inst/include/Rcpp/macros/macros.h: Idem
         * inst/unitTests/cpp/exceptions.cpp: Idem
         * inst/unitTests/runit.exceptions.R: Idem
+
 2017-04-10  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/include/Rcpp/exceptions.h: Added new exception class generation
@@ -55,7 +75,6 @@
         * inst/include/Rcpp/Symbol.h: idem
         * inst/include/Rcpp/XPtr.h: idem
         * inst/include/Rcpp/as.h: idem
-        * inst/include/Rcpp/exceptions.h: idem
         * inst/include/Rcpp/r_cast.h: idem
         * inst/include/Rcpp/api/meat/DottedPairImpl.h: idem
         * inst/include/Rcpp/internal/export.h: idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-04-03  Jim Hester  <james.f.hester@gmail.com>
+
+        * inst/include/Rcpp/exceptions.h: Added support for throwing
+        exceptions without call stacks.
+        * inst/include/Rcpp/macros/macros.h: Idem
+        * inst/unitTests/cpp/exceptions.cpp: Idem
+        * inst/unitTests/runit.exceptions.R: Idem
+
 2017-03-28  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/vignettes/Rcpp-FAQ.Rnw: Added "Known Issues" section to FAQ

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2017-04-14  James J Balamuta  <balamut2@illinois.edu>
 
+        * inst/include/Rcpp/utils/tinyformat.h: Refreshed tinyformat.h against
+        May 13, 2016 upstream, retained local mods.
+
         * inst/include/Rcpp/Environment.h: Modified formatting of new exception
         messages to be more concise.
         * inst/include/Rcpp/exceptions.h: idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,41 @@
+2017-04-11  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/inst/unitTests/testRcppClass/src/init.c (R_init_testRcppClass): Call
+        R_registerRoutines() and R_useDynamicSymbols(); also ensure
+        _rcpp_module_boot_* is registered for each module
+        * inst/unitTests/testRcppClass/NAMESPACE: Added registration
+
+        * inst/unitTests/testRcppClass/DESCRIPTION (Title): Title case
+
+        * inst/unitTests/testRcppClass/R/rcpp_hello_world.R (rcpp_hello_world):
+        Call the renamed C++ function
+        * inst/unitTests/testRcppClass/src/rcpp_hello_world.cpp (rcpp_hello_world_cpp):
+        Renamed C++ function to be distinct from R function calling it
+        * inst/unitTests/testRcppClass/src/rcpp_hello_world.h: Ditto
+        * inst/unitTests/testRcppClass/man/rcpp_hello_world.Rd: Alias renamed
+        C++ function
+
+2017-04-09  Dirk Eddelbuettel  <edd@debian.org>
+
+        * inst/unitTests/testRcppModule/src/init.c (R_init_testRcppModule): Call
+        R_registerRoutines() and R_useDynamicSymbols(); also ensure
+        _rcpp_module_boot_* is registered for each module
+        * inst/unitTests/testRcppModule/NAMESPACE: Added registration
+
+        * inst/unitTests/testRcppModule/DESCRIPTION (Title): Title case
+
+        * inst/unitTests/testRcppModule/R/rcpp_hello_world.R (rcpp_hello_world):
+        Call the renamed C++ function
+        * inst/unitTests/testRcppModule/src/rcpp_hello_world.cpp (rcpp_hello_world_cpp):
+        Renamed C++ function to be distinct from R function calling it
+        * inst/unitTests/testRcppModule/src/rcpp_hello_world.h: Ditto
+        * inst/unitTests/testRcppModule/man/rcpp_hello_world.Rd: Alias renamed
+        C++ function
+
+        * inst/unitTests/testRcppModule/man/Rcpp_modules_examples.Rd: Alias
+        renamed modules
+        * inst/unitTests/testRcppModule/tests/modules.R: Call renamed module
+
 2017-04-03  Jim Hester  <james.f.hester@gmail.com>
 
         * inst/include/Rcpp/exceptions.h: Added support for throwing
@@ -9,6 +47,11 @@
 2017-03-28  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/vignettes/Rcpp-FAQ.Rnw: Added "Known Issues" section to FAQ
+
+2017-03-25  Dirk Eddelbuettel  <edd@debian.org>
+
+        * LICENSE: Added
+        * .Rbuildignore: Do not include LICENSE in package
 
 2017-03-17  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2017-04-14  James J Balamuta  <balamut2@illinois.edu>
 
+        * inst/include/Rcpp/exceptions.h: Split off macro generation and
+        variadic function into two separate headers.
+        * inst/include/Rcpp/Rcpp/exceptions/cpp98/exceptions.h: Contains
+        generated RCPP_ADVANCED_EXCEPTION_CLASS macro, stop & warning
+        * inst/include/Rcpp/Rcpp/exceptions/cpp11/exceptions.h: idem but
+        for variadic versions
+        * inst/include/Rcpp/utils/tinyformat.h: Enabled ability to use variadic
+        tinyformat function.
+
         * inst/include/Rcpp/proxy/SlotProxy.h: Passed slot name to exception
         throw.
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,6 +14,8 @@
       \item Added a Known Issues section to the Rcpp FAQ vignette
       (James Balamuta in \ghpr{661} addressing \ghit{628}, \ghit{563},
       \ghit{552}, \ghit{460}, \ghit{419}, and \ghit{251}).
+      \item Rcpp::exceptions can now be constructed without a call stack (Jim
+      Hester in \ghpr{663}).
     }
   }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,7 +7,8 @@
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
-      \item ...
+      \item Error messages are now more informative
+      (James Balamuta in \ghpr{667} addressing \ghit{184}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -40,7 +40,7 @@ namespace Rcpp{
                 Shield<SEXP> res( Rcpp_eval( Rf_lang2( asEnvironmentSym, x ) ) );
                 return res ;
             } catch( const eval_error& ex){
-                throw not_compatible( "cannot convert to environment"  ) ;
+                throw not_compatible( "Cannot convert to environment (%s -> ENVSXP).", Rf_type2char(TYPEOF(x))) ;
             }
         }
 
@@ -115,7 +115,7 @@ namespace Rcpp{
             }
             return res ;
         }
-        
+
         /**
         * Get an object from the environment
         *
@@ -126,16 +126,16 @@ namespace Rcpp{
         SEXP get(Symbol name) const {
             SEXP env = Storage::get__() ;
             SEXP res = Rf_findVarInFrame( env, name ) ;
-            
+
             if( res == R_UnboundValue ) return R_NilValue ;
-            
+
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
                 res = Rf_eval( res, env ) ;
             }
             return res ;
         }
-        
+
 
         /**
          * Get an object from the environment or one of its
@@ -157,7 +157,7 @@ namespace Rcpp{
             }
             return res ;
         }
-        
+
         /**
         * Get an object from the environment or one of its
         * parents
@@ -167,13 +167,13 @@ namespace Rcpp{
         SEXP find(Symbol name) const{
             SEXP env = Storage::get__() ;
             SEXP res = Rf_findVar( name, env ) ;
-            
+
             if( res == R_UnboundValue ) {
                 // Pass on the const char* to the RCPP_EXCEPTION_CLASS's
                 // const std::string& requirement
                 throw binding_not_found(name.c_str()) ;
             }
-            
+
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
                 res = Rf_eval( res, env ) ;

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -40,7 +40,10 @@ namespace Rcpp{
                 Shield<SEXP> res( Rcpp_eval( Rf_lang2( asEnvironmentSym, x ) ) );
                 return res ;
             } catch( const eval_error& ex){
-                throw not_compatible( "Cannot convert to environment (%s -> ENVSXP).", Rf_type2char(TYPEOF(x))) ;
+                const char* fmt =
+                    "Cannot convert object to an environment: "
+                    "[type:%s; target=ENVSXP].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x))) ;
             }
         }
 

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -44,7 +44,7 @@ namespace Rcpp{
                 Storage::set__(x);
                 break;
             default:
-                throw not_compatible("cannot convert to function") ;
+                throw not_compatible("cannot convert %s object to function", Rf_type2char(TYPEOF(x))) ;
             }
         }
 
@@ -87,7 +87,7 @@ namespace Rcpp{
         SEXP environment() const {
             SEXP fun = Storage::get__() ;
             if( TYPEOF(fun) != CLOSXP ) {
-                throw not_a_closure() ;
+                throw not_a_closure(Rf_type2char(TYPEOF(fun))) ;
             }
             return CLOENV(fun) ;
         }

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -44,7 +44,10 @@ namespace Rcpp{
                 Storage::set__(x);
                 break;
             default:
-                throw not_compatible("cannot convert %s object to function", Rf_type2char(TYPEOF(x))) ;
+                const char* fmt =
+                    "Cannot convert object to a function:"
+                    "[type=%s; target=CLOSXP, SPECIALSXP, or BUILTINSXP].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x))) ;
             }
         }
 

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -29,8 +29,10 @@ namespace Rcpp{
         RCPP_GENERATE_CTOR_ASSIGN(Promise_Impl)
 
         Promise_Impl( SEXP x){
-            if( TYPEOF(x) != PROMSXP)
-                throw not_compatible("Not a promise. Object is of type %s instead of PROMSXP.", Rf_type2char(TYPEOF(x))) ;
+            if( TYPEOF(x) != PROMSXP){
+                const char* fmt = "Not a promise: [type = %s].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x))) ;
+            }
             Storage::set__(x) ;
         }
 

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -30,7 +30,7 @@ namespace Rcpp{
 
         Promise_Impl( SEXP x){
             if( TYPEOF(x) != PROMSXP)
-                throw not_compatible("not a promise") ;
+                throw not_compatible("Not a promise. Object is of type %s instead of PROMSXP.", Rf_type2char(TYPEOF(x))) ;
             Storage::set__(x) ;
         }
 

--- a/inst/include/Rcpp/S4.h
+++ b/inst/include/Rcpp/S4.h
@@ -48,11 +48,10 @@ namespace Rcpp{
             return *this ;
         }
 
-        /**
-         * Creates an S4 object of the requested class.
-         *
-         * @param klass name of the target S4 class
-         * @throw not_s4 if klass does not map to a known S4 class
+        /*!
+          Creates an S4 object of the requested class.
+          @param klass name of the target S4 class
+          @throw S4_creation_error if klass does not map to a known S4 class
          */
         S4_Impl( const std::string& klass ){
             Shield<SEXP> x( R_do_new_object(R_do_MAKE_CLASS(klass.c_str())) );
@@ -66,6 +65,9 @@ namespace Rcpp{
          */
         bool is( const std::string& clazz) const ;
 
+        /*!
+           @throw not_s4 if x is not an S4 class
+         */
         void update(SEXP x){
             if( ! ::Rf_isS4(x) ) throw not_s4() ;
         }

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -72,7 +72,7 @@ namespace Rcpp {
             }
 
             if (::Rf_isString(data) && ::Rf_length(data) != 1)
-                throw ::Rcpp::not_compatible("expecting a single value");
+                throw ::Rcpp::not_compatible("Expecting a single string value. Received %s object with length %i.", Rf_type2char(TYPEOF(data)), ::Rf_length(data));
 
             valid = true;
             buffer_ready = false;

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -71,8 +71,14 @@ namespace Rcpp {
                 data = charsxp;
             }
 
-            if (::Rf_isString(data) && ::Rf_length(data) != 1)
-                throw ::Rcpp::not_compatible("Expecting a single string value. Received %s object with length %i.", Rf_type2char(TYPEOF(data)), ::Rf_length(data));
+            if (::Rf_isString(data) && ::Rf_length(data) != 1){
+                const char* fmt =
+                    "Expecting a single string value: [type=%s; extent=%i].";
+                throw ::Rcpp::not_compatible(fmt,
+                                             Rf_type2char(TYPEOF(data)),
+                                             ::Rf_length(data));
+
+            }
 
             valid = true;
             buffer_ready = false;

--- a/inst/include/Rcpp/Symbol.h
+++ b/inst/include/Rcpp/Symbol.h
@@ -62,7 +62,9 @@ namespace Rcpp{
                 break ;
             }
             default:
-                throw not_compatible("Cannot object convert to symbol (%s -> SYMSXP)", Rf_type2char(type)) ;
+                const char* fmt =
+                    "Cannot convert object to a symbol (%s -> SYMSXP).";
+                throw not_compatible(fmt, Rf_type2char(type)) ;
             }
         }
 

--- a/inst/include/Rcpp/Symbol.h
+++ b/inst/include/Rcpp/Symbol.h
@@ -62,7 +62,7 @@ namespace Rcpp{
                 break ;
             }
             default:
-                throw not_compatible("cannot convert to symbol (SYMSXP)") ;
+                throw not_compatible("Cannot object convert to symbol (%s -> SYMSXP)", Rf_type2char(type)) ;
             }
         }
 

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -64,8 +64,10 @@ public:
      * @param xp external pointer to wrap
      */
     explicit XPtr(SEXP x, SEXP tag = R_NilValue, SEXP prot = R_NilValue) {
-        if( TYPEOF(x) != EXTPTRSXP )
-            throw ::Rcpp::not_compatible( "Expecting an external pointer. Object was a %s instead of EXTPTRSXP", Rf_type2char(TYPEOF(x)) ) ;
+        if( TYPEOF(x) != EXTPTRSXP ) {
+            const char* fmt = "Expecting an external pointer: [type=%s].";
+            throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)) ) ;
+        }
         Storage::set__(x) ;
         R_SetExternalPtrTag( x, tag ) ;
         R_SetExternalPtrProtected( x, prot ) ;

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -65,7 +65,7 @@ public:
      */
     explicit XPtr(SEXP x, SEXP tag = R_NilValue, SEXP prot = R_NilValue) {
         if( TYPEOF(x) != EXTPTRSXP )
-            throw ::Rcpp::not_compatible( "expecting an external pointer" ) ;
+            throw ::Rcpp::not_compatible( "Expecting an external pointer. Object was a %s instead of EXTPTRSXP", Rf_type2char(TYPEOF(x)) ) ;
         Storage::set__(x) ;
         R_SetExternalPtrTag( x, tag ) ;
         R_SetExternalPtrProtected( x, prot ) ;
@@ -128,7 +128,7 @@ public:
     inline T* checked_get() const {
         T* ptr = get();
         if (ptr == NULL)
-            throw ::Rcpp::exception("external pointer is not valid" ) ;
+            throw ::Rcpp::exception("External pointer is not valid." ) ;
         return ptr;
     }
 

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -53,7 +53,7 @@ namespace Rcpp{
 		} else {
 			if( ref.isNULL( ) ) throw index_out_of_bounds() ;
 
-                        if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+			if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
 
 			size_t i=1;
 			SEXP x = ref.get__() ;
@@ -70,7 +70,7 @@ namespace Rcpp{
     template <typename T>
 	void DottedPairImpl<CLASS>::replace( const int& index, const T& object ) {
 	    CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
 
         Shield<SEXP> x( pairlist( object ) );
         SEXP y = ref.get__() ;
@@ -84,7 +84,7 @@ namespace Rcpp{
 	template <typename CLASS>
     void DottedPairImpl<CLASS>::remove( const size_t& index ) {
         CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
         if( index == 0 ){
             ref.set__( CDR( ref.get__() ) ) ;
         } else{

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -53,7 +53,12 @@ namespace Rcpp{
 		} else {
 			if( ref.isNULL( ) ) throw index_out_of_bounds() ;
 
-			if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
+			if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) {
+			    const char* fmt = "Index is out of bounds: [index=%s; extent=%s].";
+			    throw index_out_of_bounds(fmt,
+                                          static_cast<R_xlen_t>(index),
+                                          ::Rf_xlength(ref.get__()) ) ;
+			}
 
 			size_t i=1;
 			SEXP x = ref.get__() ;
@@ -70,7 +75,12 @@ namespace Rcpp{
     template <typename T>
 	void DottedPairImpl<CLASS>::replace( const int& index, const T& object ) {
 	    CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
+        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) {
+            const char* fmt = "Index is out of bounds: [index=%s; extent=%s].";
+            throw index_out_of_bounds(fmt,
+                                      static_cast<R_xlen_t>(index),
+                                      ::Rf_xlength(ref.get__()) ) ;
+        }
 
         Shield<SEXP> x( pairlist( object ) );
         SEXP y = ref.get__() ;
@@ -84,7 +94,13 @@ namespace Rcpp{
 	template <typename CLASS>
     void DottedPairImpl<CLASS>::remove( const size_t& index ) {
         CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) throw index_out_of_bounds("index is out of bounds. Requested %i with %i available", static_cast<R_xlen_t>(index), ::Rf_xlength(ref.get__()) ) ;
+        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) {
+            const char* fmt = "Index is out of bounds: [index=%s; extent=%s].";
+            throw index_out_of_bounds(fmt,
+                                      static_cast<R_xlen_t>(index),
+                                      ::Rf_xlength(ref.get__()) ) ;
+        }
+
         if( index == 0 ){
             ref.set__( CDR( ref.get__() ) ) ;
         } else{

--- a/inst/include/Rcpp/as.h
+++ b/inst/include/Rcpp/as.h
@@ -29,7 +29,10 @@ namespace Rcpp {
     namespace internal {
 
         template <typename T> T primitive_as(SEXP x) {
-            if (::Rf_length(x) != 1) throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
+            if (::Rf_length(x) != 1) {
+                const char* fmt = "Expecting a single value: [extent=%i].";
+                throw ::Rcpp::not_compatible(fmt, ::Rf_length(x));
+            }
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<T>::rtype;
             Shield<SEXP> y(r_cast<RTYPE>(x));
             typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE;
@@ -43,10 +46,14 @@ namespace Rcpp {
 
         inline const char* check_single_string(SEXP x) {
             if (TYPEOF(x) == CHARSXP) return CHAR(x);
-            if (! ::Rf_isString(x))
-                throw ::Rcpp::not_compatible("Expecting a string. Received %s instead of CHARSXP or STRSXP.", Rf_type2char(TYPEOF(x)));
-            if (Rf_length(x) != 1)
-                throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
+            if (! ::Rf_isString(x)) {
+                const char* fmt = "Expecting a string: [type=%s].";
+                throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
+            }
+            if (Rf_length(x) != 1) {
+                const char* fmt = "Expecting a single value: [extent=%i].";
+                throw ::Rcpp::not_compatible(fmt, ::Rf_length(x));
+            }
             return CHAR(STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0));
         }
 
@@ -66,10 +73,12 @@ namespace Rcpp {
 
         template <typename T> T as(SEXP x, ::Rcpp::traits::r_type_RcppString_tag) {
             if (! ::Rf_isString(x)) {
-                throw ::Rcpp::not_compatible("Expecting a string. Received %s instead of STRSXP.", Rf_type2char(TYPEOF(x)));
+                const char* fmt = "Expecting a string: [type=%s].";
+                throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
             }
             if (Rf_length(x) != 1) {
-                throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
+                const char* fmt = "Expecting a single value: [extent=%i].";
+                throw ::Rcpp::not_compatible(fmt, ::Rf_length(x));
             }
             return STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0);
         }

--- a/inst/include/Rcpp/as.h
+++ b/inst/include/Rcpp/as.h
@@ -29,7 +29,7 @@ namespace Rcpp {
     namespace internal {
 
         template <typename T> T primitive_as(SEXP x) {
-            if (::Rf_length(x) != 1) throw ::Rcpp::not_compatible("expecting a single value");
+            if (::Rf_length(x) != 1) throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<T>::rtype;
             Shield<SEXP> y(r_cast<RTYPE>(x));
             typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE;
@@ -44,9 +44,9 @@ namespace Rcpp {
         inline const char* check_single_string(SEXP x) {
             if (TYPEOF(x) == CHARSXP) return CHAR(x);
             if (! ::Rf_isString(x))
-                throw ::Rcpp::not_compatible("expecting a string");
+                throw ::Rcpp::not_compatible("Expecting a string. Received %s instead of CHARSXP or STRSXP.", Rf_type2char(TYPEOF(x)));
             if (Rf_length(x) != 1)
-                throw ::Rcpp::not_compatible("expecting a single value");
+                throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
             return CHAR(STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0));
         }
 
@@ -66,10 +66,10 @@ namespace Rcpp {
 
         template <typename T> T as(SEXP x, ::Rcpp::traits::r_type_RcppString_tag) {
             if (! ::Rf_isString(x)) {
-                throw ::Rcpp::not_compatible("expecting a string");
+                throw ::Rcpp::not_compatible("Expecting a string. Received %s instead of STRSXP.", Rf_type2char(TYPEOF(x)));
             }
             if (Rf_length(x) != 1) {
-                throw ::Rcpp::not_compatible("expecting a single value");
+                throw ::Rcpp::not_compatible("Expecting a single value. Object contained %i values.", ::Rf_length(x));
             }
             return STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0);
         }

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -97,47 +97,13 @@ namespace Rcpp {
             file_io_error("file already exists", file) {}	// #nocov end
     };
 
-    #define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                                                                                                                                                     \
-    class __CLASS__ : public std::exception{                                                                                                                                                                       \
-        public:                                                                                                                                                                                                    \
-            __CLASS__( ) throw() : message( __WHAT__ ){} ;                                                                                                                                                         \
-            __CLASS__( const std::string& message ) throw() : message( message ){} ;                                                                                                                               \
-            template <typename T1>                                                                                                                                                                                 \
-            __CLASS__(const char* fmt, const T1& arg1) throw() :                                                                                                                                                   \
-             message( tfm::format(fmt, arg1 ) ){} ;                                                                                                                                                                \
-            template <typename T1, typename T2>                                                                                                                                                                    \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2) throw() :                                                                                                                                   \
-             message( tfm::format(fmt, arg1, arg2 ) ){} ;                                                                                                                                                          \
-            template <typename T1, typename T2, typename T3>                                                                                                                                                       \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) throw() :                                                                                                                   \
-             message( tfm::format(fmt, arg1, arg2, arg3 ) ){} ;                                                                                                                                                    \
-            template <typename T1, typename T2, typename T3, typename T4>                                                                                                                                          \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) throw() :                                                                                                   \
-             message( tfm::format(fmt, arg1, arg2, arg3, arg4 ) ){} ;                                                                                                                                              \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5>                                                                                                                             \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) throw() :                                                                                   \
-             message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5 ) ){} ;                                                                                                                                        \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>                                                                                                                \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) throw() :                                                                   \
-                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6 ) ){} ;                                                                                                                               \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>                                                                                                   \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) throw() :                                                   \
-            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7 ) ){} ;                                                                                                                             \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>                                                                                      \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) throw() :                                   \
-                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 ) ){} ;                                                                                                                   \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>                                                                         \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) throw() :                   \
-                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ) ){} ;                                                                                                             \
-            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>                                                           \
-            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) throw() : \
-                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 ) ){} ;                                                                                                      \
-            virtual ~__CLASS__() throw(){} ;                                                                                                                                                                       \
-            virtual const char* what() const throw() { return message.c_str() ; }                                                                                                                                  \
-            private:                                                                                                                                                                                               \
-                std::string message ;                                                                                                                                                                              \
-    } ;
-
+    // Determine whether to use varadic templated RCPP_ADVANCED_EXCEPTION_CLASS
+    // or to use the generated argument macro.
+    #if __cplusplus >= 201103L
+    # include <Rcpp/exceptions/cpp11/exceptions.h>
+    #else
+    # include <Rcpp/exceptions/cpp98/exceptions.h>
+    #endif
 
     #define RCPP_EXCEPTION_CLASS(__CLASS__,__WHAT__)                               \
     class __CLASS__ : public std::exception{                                       \
@@ -157,9 +123,9 @@ namespace Rcpp {
         virtual const char* what() const throw() { return __MESSAGE__ ; }          \
     } ;
 
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_a_matrix, "Not a matrix.")
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_a_matrix, "Not a matrix.")      // #nocov start
     RCPP_SIMPLE_EXCEPTION_CLASS(parse_error, "Parse error.")
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_s4, "Not an S4 object.")	// #nocov start
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_s4, "Not an S4 object.")
     RCPP_SIMPLE_EXCEPTION_CLASS(not_reference, "Not an S4 object of a reference class.")
     RCPP_SIMPLE_EXCEPTION_CLASS(not_initialized, "C++ object not initialized. (Missing default constructor?)")
     RCPP_SIMPLE_EXCEPTION_CLASS(no_such_function, "No such function.")
@@ -326,121 +292,16 @@ std::string demangle( const std::string& name) ;
 
 namespace Rcpp{
 
-    // --- Start Rcpp::warning declaration
+    // Vardiac / code generated version of the warning and stop functions
+    // can be found within the respective C++11 or C++98 exceptions.h
 
     inline void warning(const std::string& message) {      // #nocov start
         Rf_warning(message.c_str());
     }                                                      // #nocov end
 
-    template <typename T1>
-    inline void warning(const char* fmt, const T1& arg1) {
-        Rf_warning( tfm::format(fmt, arg1 ).c_str() );
-    }
-
-    template <typename T1, typename T2>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2) {
-        Rf_warning( tfm::format(fmt, arg1, arg2 ).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
-    inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
-        Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
-    }
-
-    // --- End Rcpp::warning declaration
-
-    // --- Start Rcpp::stop declaration
-
-    inline void NORET stop(const std::string& message) {	// #nocov start
+    inline void NORET stop(const std::string& message) {   // #nocov start
         throw Rcpp::exception(message.c_str());
-    }								// #nocov end
-
-    template <typename T1>
-    inline void NORET stop(const char* fmt, const T1& arg1) {
-        throw Rcpp::exception( tfm::format(fmt, arg1 ).c_str() );
-    }
-
-    template <typename T1, typename T2>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2 ).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
-    }
-
-    template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
-    inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
-        throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
-    }
-
-    // -- End Rcpp::stop declaration
+    }								                       // #nocov end
 
 }
 

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -157,27 +157,27 @@ namespace Rcpp {
         virtual const char* what() const throw() { return __MESSAGE__ ; }          \
     } ;
 
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_a_matrix, "not a matrix")
-    RCPP_SIMPLE_EXCEPTION_CLASS(parse_error, "parse error")
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_s4, "not an S4 object")	// #nocov start
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_reference, "not an S4 object of a reference class")
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_initialized, "C++ object not initialized (missing default constructor?)")
-    RCPP_SIMPLE_EXCEPTION_CLASS(no_such_function, "no such function")
-    RCPP_SIMPLE_EXCEPTION_CLASS(unevaluated_promise, "promise not yet evaluated")
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_a_matrix, "Not a matrix.")
+    RCPP_SIMPLE_EXCEPTION_CLASS(parse_error, "Parse error.")
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_s4, "Not an S4 object.")	// #nocov start
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_reference, "Not an S4 object of a reference class.")
+    RCPP_SIMPLE_EXCEPTION_CLASS(not_initialized, "C++ object not initialized. (Missing default constructor?)")
+    RCPP_SIMPLE_EXCEPTION_CLASS(no_such_function, "No such function.")
+    RCPP_SIMPLE_EXCEPTION_CLASS(unevaluated_promise, "Promise not yet evaluated.")
 
-    RCPP_EXCEPTION_CLASS(no_such_slot, std::string("no such slot: ") + message )
-    RCPP_EXCEPTION_CLASS(S4_creation_error, std::string("error creating object of S4 class: ") + message )
-    RCPP_EXCEPTION_CLASS(reference_creation_error, std::string("error creating object of reference class: ") + message )
-    RCPP_EXCEPTION_CLASS(no_such_binding, std::string("no such binding: '") + message + "'" )
-    RCPP_EXCEPTION_CLASS(binding_not_found, std::string("binding not found: '") + message + "'" )
-    RCPP_EXCEPTION_CLASS(binding_is_locked, std::string("binding is locked: '") + message + "'" )
-    RCPP_EXCEPTION_CLASS(no_such_namespace, std::string("no such namespace: '") + message + "'" )
-    RCPP_EXCEPTION_CLASS(function_not_exported, std::string("function not exported: ") + message)
+    RCPP_EXCEPTION_CLASS(no_such_slot, std::string("No such slot: ") + message + "." )
+    RCPP_EXCEPTION_CLASS(S4_creation_error, std::string("Error creating object of S4 class: ") + message + "." )
+    RCPP_EXCEPTION_CLASS(reference_creation_error, std::string("Error creating object of reference class: ") + message + ".")
+    RCPP_EXCEPTION_CLASS(no_such_binding, std::string("No such binding: '") + message + "'." )
+    RCPP_EXCEPTION_CLASS(binding_not_found, std::string("Binding not found: '") + message + "'." )
+    RCPP_EXCEPTION_CLASS(binding_is_locked, std::string("Binding is locked: '") + message + "'." )
+    RCPP_EXCEPTION_CLASS(no_such_namespace, std::string("No such namespace: '") + message + "'." )
+    RCPP_EXCEPTION_CLASS(function_not_exported, std::string("Function not exported: ") + message + "." )
     RCPP_EXCEPTION_CLASS(eval_error, message )
-    RCPP_EXCEPTION_CLASS(not_a_closure, std::string("not a closure. Object is of type ") + message + "." )
+    RCPP_EXCEPTION_CLASS(not_a_closure, std::string("Not a closure: [type=") + message + "]." )
 
-    RCPP_ADVANCED_EXCEPTION_CLASS(not_compatible, "not compatible")
-    RCPP_ADVANCED_EXCEPTION_CLASS(index_out_of_bounds, "index out of bounds") // #nocov end
+    RCPP_ADVANCED_EXCEPTION_CLASS(not_compatible, "Not compatible.")
+    RCPP_ADVANCED_EXCEPTION_CLASS(index_out_of_bounds, "Index out of bounds.") // #nocov end
 
     #undef RCPP_SIMPLE_EXCEPTION_CLASS
     #undef RCPP_EXCEPTION_CLASS

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -97,6 +97,48 @@ namespace Rcpp {
             file_io_error("file already exists", file) {}	// #nocov end
     };
 
+    #define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                                                                                                                                                     \
+    class __CLASS__ : public std::exception{                                                                                                                                                                       \
+        public:                                                                                                                                                                                                    \
+            __CLASS__( ) throw() : message( __WHAT__ ){} ;                                                                                                                                                         \
+            __CLASS__( const std::string& message ) throw() : message( message ){} ;                                                                                                                               \
+            template <typename T1>                                                                                                                                                                                 \
+            __CLASS__(const char* fmt, const T1& arg1) throw() :                                                                                                                                                   \
+             message( tfm::format(fmt, arg1 ) ){} ;                                                                                                                                                                \
+            template <typename T1, typename T2>                                                                                                                                                                    \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2) throw() :                                                                                                                                   \
+             message( tfm::format(fmt, arg1, arg2 ) ){} ;                                                                                                                                                          \
+            template <typename T1, typename T2, typename T3>                                                                                                                                                       \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) throw() :                                                                                                                   \
+             message( tfm::format(fmt, arg1, arg2, arg3 ) ){} ;                                                                                                                                                    \
+            template <typename T1, typename T2, typename T3, typename T4>                                                                                                                                          \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) throw() :                                                                                                   \
+             message( tfm::format(fmt, arg1, arg2, arg3, arg4 ) ){} ;                                                                                                                                              \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5>                                                                                                                             \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) throw() :                                                                                   \
+             message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5 ) ){} ;                                                                                                                                        \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>                                                                                                                \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) throw() :                                                                   \
+                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6 ) ){} ;                                                                                                                               \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>                                                                                                   \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) throw() :                                                   \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7 ) ){} ;                                                                                                                             \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>                                                                                      \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) throw() :                                   \
+                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 ) ){} ;                                                                                                                   \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>                                                                         \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) throw() :                   \
+                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ) ){} ;                                                                                                             \
+            template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>                                                           \
+            __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) throw() : \
+                message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 ) ){} ;                                                                                                      \
+            virtual ~__CLASS__() throw(){} ;                                                                                                                                                                       \
+            virtual const char* what() const throw() { return message.c_str() ; }                                                                                                                                  \
+            private:                                                                                                                                                                                               \
+                std::string message ;                                                                                                                                                                              \
+    } ;
+
+
     #define RCPP_EXCEPTION_CLASS(__CLASS__,__WHAT__)                               \
     class __CLASS__ : public std::exception{                                       \
     public:                                                                        \
@@ -116,29 +158,30 @@ namespace Rcpp {
     } ;
 
     RCPP_SIMPLE_EXCEPTION_CLASS(not_a_matrix, "not a matrix")
-    RCPP_SIMPLE_EXCEPTION_CLASS(index_out_of_bounds, "index out of bounds")
     RCPP_SIMPLE_EXCEPTION_CLASS(parse_error, "parse error")
     RCPP_SIMPLE_EXCEPTION_CLASS(not_s4, "not an S4 object")	// #nocov start
     RCPP_SIMPLE_EXCEPTION_CLASS(not_reference, "not an S4 object of a reference class")
     RCPP_SIMPLE_EXCEPTION_CLASS(not_initialized, "C++ object not initialized (missing default constructor?)")
-    RCPP_SIMPLE_EXCEPTION_CLASS(no_such_slot, "no such slot")
-    RCPP_SIMPLE_EXCEPTION_CLASS(no_such_field, "no such field")
-    RCPP_SIMPLE_EXCEPTION_CLASS(not_a_closure, "not a closure")
     RCPP_SIMPLE_EXCEPTION_CLASS(no_such_function, "no such function")
     RCPP_SIMPLE_EXCEPTION_CLASS(unevaluated_promise, "promise not yet evaluated")
 
-    RCPP_EXCEPTION_CLASS(not_compatible, message )
-    RCPP_EXCEPTION_CLASS(S4_creation_error, std::string("error creating object of S4 class : ") + message )
-    RCPP_EXCEPTION_CLASS(reference_creation_error, std::string("error creating object of reference class : ") + message )
-    RCPP_EXCEPTION_CLASS(no_such_binding, std::string("no such binding : '") + message + "'" )
+    RCPP_EXCEPTION_CLASS(no_such_slot, std::string("no such slot: ") + message )
+    RCPP_EXCEPTION_CLASS(S4_creation_error, std::string("error creating object of S4 class: ") + message )
+    RCPP_EXCEPTION_CLASS(reference_creation_error, std::string("error creating object of reference class: ") + message )
+    RCPP_EXCEPTION_CLASS(no_such_binding, std::string("no such binding: '") + message + "'" )
     RCPP_EXCEPTION_CLASS(binding_not_found, std::string("binding not found: '") + message + "'" )
     RCPP_EXCEPTION_CLASS(binding_is_locked, std::string("binding is locked: '") + message + "'" )
     RCPP_EXCEPTION_CLASS(no_such_namespace, std::string("no such namespace: '") + message + "'" )
     RCPP_EXCEPTION_CLASS(function_not_exported, std::string("function not exported: ") + message)
-    RCPP_EXCEPTION_CLASS(eval_error, message )			// #nocov end
+    RCPP_EXCEPTION_CLASS(eval_error, message )
+    RCPP_EXCEPTION_CLASS(not_a_closure, std::string("not a closure. Object is of type ") + message + "." )
 
-    #undef RCPP_EXCEPTION_CLASS
+    RCPP_ADVANCED_EXCEPTION_CLASS(not_compatible, "not compatible")
+    RCPP_ADVANCED_EXCEPTION_CLASS(index_out_of_bounds, "index out of bounds") // #nocov end
+
     #undef RCPP_SIMPLE_EXCEPTION_CLASS
+    #undef RCPP_EXCEPTION_CLASS
+    #undef RCPP_ADVANCED_EXCEPTION_CLASS
 
 
 namespace internal {
@@ -283,9 +326,11 @@ std::string demangle( const std::string& name) ;
 
 namespace Rcpp{
 
-    inline void warning(const std::string& message) {
+    // --- Start Rcpp::warning declaration
+
+    inline void warning(const std::string& message) {      // #nocov start
         Rf_warning(message.c_str());
-    }
+    }                                                      // #nocov end
 
     template <typename T1>
     inline void warning(const char* fmt, const T1& arg1) {
@@ -336,6 +381,10 @@ namespace Rcpp{
     inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
         Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
     }
+
+    // --- End Rcpp::warning declaration
+
+    // --- Start Rcpp::stop declaration
 
     inline void NORET stop(const std::string& message) {	// #nocov start
         throw Rcpp::exception(message.c_str());
@@ -390,6 +439,9 @@ namespace Rcpp{
     inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
         throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
     }
+
+    // -- End Rcpp::stop declaration
+
 }
 
 inline void forward_exception_to_r(const std::exception& ex){

--- a/inst/include/Rcpp/exceptions/cpp11/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp11/exceptions.h
@@ -1,0 +1,52 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// exceptions.h: Rcpp R/C++ interface class library -- exceptions
+//
+// Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__exceptionscpp11__h
+#define Rcpp__exceptionscpp11__h
+
+// Required for std::forward
+#include <utility>
+
+#define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                             \
+class __CLASS__ : public std::exception{                                               \
+    public:                                                                            \
+        __CLASS__( ) throw() : message( __WHAT__ ){} ;                                 \
+        __CLASS__( const std::string& message ) throw() : message( message ){} ;       \
+        template <typename... Args>                                                    \
+        __CLASS__( const char* fmt, Args&&... args ) throw() :                         \
+            message(  tfm::format(fmt, std::forward<Args>(args)...) ){} ;              \
+        virtual ~__CLASS__() throw(){} ;                                               \
+        virtual const char* what() const throw() { return message.c_str() ; }          \
+        private:                                                                       \
+            std::string message ;                                                      \
+} ;
+
+template <typename... Args>
+inline void warning(const char* fmt, Args&&... args ) {
+    Rf_warning( tfm::format(fmt, std::forward<Args>(args)... ).c_str() );
+}
+
+template <typename... Args>
+inline void NORET stop(const char* fmt, Args&&... args) {
+    throw Rcpp::exception( tfm::format(fmt, std::forward<Args>(args)... ).c_str() );
+}
+
+#endif

--- a/inst/include/Rcpp/exceptions/cpp98/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp98/exceptions.h
@@ -1,0 +1,175 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// exceptions.h: Rcpp R/C++ interface class library -- exceptions
+//
+// Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__exceptionscpp98__h
+#define Rcpp__exceptionscpp98__h
+
+
+#define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                                                                                                                                                         \
+class __CLASS__ : public std::exception{                                                                                                                                                                           \
+    public:                                                                                                                                                                                                        \
+        __CLASS__( ) throw() : message( __WHAT__ ){} ;                                                                                                                                                             \
+        __CLASS__( const std::string& message ) throw() : message( message ){} ;                                                                                                                                   \
+        template <typename T1>                                                                                                                                                                                     \
+        __CLASS__(const char* fmt, const T1& arg1) throw() :                                                                                                                                                       \
+            message( tfm::format(fmt, arg1 ) ){} ;                                                                                                                                                                 \
+        template <typename T1, typename T2>                                                                                                                                                                        \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2) throw() :                                                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2 ) ){} ;                                                                                                                                                           \
+        template <typename T1, typename T2, typename T3>                                                                                                                                                           \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) throw() :                                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3 ) ){} ;                                                                                                                                                     \
+        template <typename T1, typename T2, typename T3, typename T4>                                                                                                                                              \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) throw() :                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4 ) ){} ;                                                                                                                                               \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5>                                                                                                                                 \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) throw() :                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5 ) ){} ;                                                                                                                                         \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>                                                                                                                    \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) throw() :                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6 ) ){} ;                                                                                                                                   \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>                                                                                                       \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) throw() :                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7 ) ){} ;                                                                                                                             \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>                                                                                          \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) throw() :                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 ) ){} ;                                                                                                                       \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>                                                                             \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) throw() :                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ) ){} ;                                                                                                                 \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>                                                               \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) throw() :     \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 ) ){} ;                                                                                                          \
+        virtual ~__CLASS__() throw(){} ;                                                                                                                                                                           \
+        virtual const char* what() const throw() { return message.c_str() ; }                                                                                                                                      \
+        private:                                                                                                                                                                                                   \
+            std::string message ;                                                                                                                                                                                  \
+} ;                                                            \
+
+// -- Start Rcpp::warning declaration
+
+template <typename T1>
+inline void warning(const char* fmt, const T1& arg1) {
+    Rf_warning( tfm::format(fmt, arg1 ).c_str() );
+}
+
+template <typename T1, typename T2>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2) {
+    Rf_warning( tfm::format(fmt, arg1, arg2 ).c_str() );
+}
+
+template <typename T1, typename T2, typename T3>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
+}
+
+// -- End Rcpp::warning declaration
+
+// -- Start Rcpp::stop declaration
+
+template <typename T1>
+inline void NORET stop(const char* fmt, const T1& arg1) {
+    throw Rcpp::exception( tfm::format(fmt, arg1 ).c_str() );
+}
+
+template <typename T1, typename T2>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2 ).c_str() );
+}
+
+template <typename T1, typename T2, typename T3>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
+}
+
+// -- End Rcpp::stop declaration
+
+#endif

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -79,7 +79,7 @@ namespace Rcpp{
 
 		template <typename InputIterator, typename value_type>
 		void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "expecting a string vector" ) ;
+			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "Expecting a string vector. Object was of type %s instead of STRXP.", Rf_type2char(TYPEOF(x)) ) ;
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++, ++first ){
 				*first = as_string_elt<typename std::iterator_traits<InputIterator>::value_type> ( x, i ) ;
@@ -133,7 +133,7 @@ namespace Rcpp{
 
 		template <typename T, typename value_type>
 		void export_indexing__dispatch( SEXP x, T& res, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "expecting a string vector" ) ;
+			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "Expecting a string vector. Object was of type %s instead of STRXP.", Rf_type2char(TYPEOF(x)) ) ;
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++ ){
 				res[i] = as_string_elt< value_type >( x, i) ;

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -79,7 +79,12 @@ namespace Rcpp{
 
 		template <typename InputIterator, typename value_type>
 		void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "Expecting a string vector. Object was of type %s instead of STRXP.", Rf_type2char(TYPEOF(x)) ) ;
+			if( ! ::Rf_isString( x) ) {
+			    const char* fmt = "Expecting a string vector: "
+			                      "[type=%s; required=STRSXP].";
+			    throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)) ) ;
+			}
+
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++, ++first ){
 				*first = as_string_elt<typename std::iterator_traits<InputIterator>::value_type> ( x, i ) ;
@@ -133,7 +138,11 @@ namespace Rcpp{
 
 		template <typename T, typename value_type>
 		void export_indexing__dispatch( SEXP x, T& res, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "Expecting a string vector. Object was of type %s instead of STRXP.", Rf_type2char(TYPEOF(x)) ) ;
+			if( ! ::Rf_isString( x) ) {
+			    const char* fmt = "Expecting a string vector: "
+			                      "[type=%s; required=STRSXP].";
+			    throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)) ) ;
+			}
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++ ){
 				res[i] = as_string_elt< value_type >( x, i) ;

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -39,10 +39,15 @@
     catch( Rcpp::internal::InterruptedException &__ex__) {                                       \
         rcpp_output_type = 1 ;                                                                   \
     }                                                                                            \
+    catch(Rcpp::exception& __ex__) {                                                             \
+       rcpp_output_type = 2 ;                                                                    \
+       rcpp_output_condition = PROTECT(rcpp_exception_to_r_condition(__ex__)) ;                  \
+    }                                                                                            \
     catch( std::exception& __ex__ ){                                                             \
        rcpp_output_type = 2 ;                                                                    \
        rcpp_output_condition = PROTECT(exception_to_r_condition(__ex__)) ;                       \
-    } catch( ... ){                                                                              \
+    }                                                                                            \
+    catch( ... ){                                                                                \
        rcpp_output_type = 2 ;                                                                    \
        rcpp_output_condition = PROTECT(string_to_try_error("c++ exception (unknown reason)")) ;  \
     }                                                                                            \

--- a/inst/include/Rcpp/proxy/DottedPairProxy.h
+++ b/inst/include/Rcpp/proxy/DottedPairProxy.h
@@ -27,7 +27,7 @@ public:
     	class DottedPairProxy : public GenericProxy<DottedPairProxy> {
 	public:
 		DottedPairProxy( CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds() ;
+            if( index_ >= v.length() ) throw index_out_of_bounds("index out of bounds. Requested element %i when object has %i elements.", index_, v.length() ) ;
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;
@@ -72,7 +72,7 @@ public:
 	class const_DottedPairProxy : public GenericProxy<const_DottedPairProxy>{
 	public:
 		const_DottedPairProxy( const CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds() ;
+            if( index_ >= v.length() ) throw index_out_of_bounds("index out of bounds. Requested element %i when object has %i elements.", index_, v.length() ) ;
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;

--- a/inst/include/Rcpp/proxy/DottedPairProxy.h
+++ b/inst/include/Rcpp/proxy/DottedPairProxy.h
@@ -27,7 +27,11 @@ public:
     	class DottedPairProxy : public GenericProxy<DottedPairProxy> {
 	public:
 		DottedPairProxy( CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds("index out of bounds. Requested element %i when object has %i elements.", index_, v.length() ) ;
+            if( index_ >= v.length() ) {
+                const char* fmt = "Index is out of bounds: "
+                                  "[index=%s; extent=%s].";
+                throw index_out_of_bounds(fmt, index_, v.length() ) ;
+            }
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;
@@ -72,7 +76,11 @@ public:
 	class const_DottedPairProxy : public GenericProxy<const_DottedPairProxy>{
 	public:
 		const_DottedPairProxy( const CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds("index out of bounds. Requested element %i when object has %i elements.", index_, v.length() ) ;
+            if( index_ >= v.length() ) {
+                const char* fmt = "Index is out of bounds: "
+                                  "[index=%s; extent=%s].";
+                throw index_out_of_bounds(fmt, index_, v.length() ) ;
+            }
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;

--- a/inst/include/Rcpp/proxy/SlotProxy.h
+++ b/inst/include/Rcpp/proxy/SlotProxy.h
@@ -28,7 +28,7 @@ public:
     public:
         SlotProxy( CLASS& v, const std::string& name) : parent(v), slot_name(Rf_install(name.c_str())) {
             if( !R_has_slot( v, slot_name) ){
-                throw no_such_slot() ;
+                throw no_such_slot(name) ;
             }
         }
 

--- a/inst/include/Rcpp/proxy/SlotProxy.h
+++ b/inst/include/Rcpp/proxy/SlotProxy.h
@@ -60,7 +60,7 @@ public:
     public:
         const_SlotProxy( const CLASS& v, const std::string& name) : parent(v), slot_name(Rf_install(name.c_str())) {
             if( !R_has_slot( v, slot_name) ){
-                throw no_such_slot() ;
+                throw no_such_slot(name) ;
             }
         }
 

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -33,7 +33,8 @@ namespace Rcpp {
                 SEXP funSym = Rf_install(fun);
                 res = Rcpp_eval(Rf_lang2(funSym, x));
             } catch( eval_error& e){
-                throw not_compatible("Could not convert using R function: %s.",  fun);
+                const char* fmt = "Could not convert using R function: %s.";
+                throw not_compatible(fmt, fun);
             }
             return res;								// #nocov end
         }
@@ -42,7 +43,9 @@ namespace Rcpp {
         // is different from the SEXP type of x
         template <int TARGET>
         SEXP r_true_cast( SEXP x) {
-            throw not_compatible( "Not compatible target with SEXP (%s -> %s).", Rf_type2char(TYPEOF(x)), Rf_type2char(TARGET));
+            const char* fmt = "Not compatible conversion to target: "
+                              "[type=%s; target=%s].";
+            throw not_compatible(fmt, Rf_type2char(TYPEOF(x)), Rf_type2char(TARGET));
             return x; // makes solaris happy
         }
 
@@ -57,7 +60,9 @@ namespace Rcpp {
             case INTSXP:
                 return Rf_coerceVector(x, RTYPE);
             default:
-                throw ::Rcpp::not_compatible("Not compatible with requested type (%s -> %s).", Rf_type2char(TYPEOF(x)), Rf_type2char(RTYPE));
+                const char* fmt = "Not compatible with requested type: "
+                                  "[type=%s; target=%s].";
+                throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)), Rf_type2char(RTYPE));
             }							// #nocov end
             return R_NilValue; /* -Wall */
         }
@@ -103,7 +108,8 @@ namespace Rcpp {
             case SYMSXP:
                 return Rf_ScalarString( PRINTNAME( x ) );
             default:
-                throw ::Rcpp::not_compatible("Not compatible requested type (%s -> STRSXP).", Rf_type2char(TYPEOF(x)));
+                const char* fmt = "Not compatible with STRSXP: [type=%s].";
+                throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
             }
             return R_NilValue; /* -Wall */
         }

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -33,16 +33,16 @@ namespace Rcpp {
                 SEXP funSym = Rf_install(fun);
                 res = Rcpp_eval(Rf_lang2(funSym, x));
             } catch( eval_error& e){
-                throw not_compatible(std::string("could not convert using R function : ") + fun);
+                throw not_compatible("Could not convert using R function: %s.",  fun);
             }
-            return res;								// #nocov end 
+            return res;								// #nocov end
         }
 
         // r_true_cast is only meant to be used when the target SEXP type
         // is different from the SEXP type of x
         template <int TARGET>
         SEXP r_true_cast( SEXP x) {
-            throw not_compatible( "not compatible" );
+            throw not_compatible( "Not compatible target with SEXP (%s -> %s).", Rf_type2char(TYPEOF(x)), Rf_type2char(TARGET));
             return x; // makes solaris happy
         }
 
@@ -57,8 +57,8 @@ namespace Rcpp {
             case INTSXP:
                 return Rf_coerceVector(x, RTYPE);
             default:
-                throw ::Rcpp::not_compatible("not compatible with requested type");
-            }							// #nocov end 
+                throw ::Rcpp::not_compatible("Not compatible with requested type (%s -> %s).", Rf_type2char(TYPEOF(x)), Rf_type2char(RTYPE));
+            }							// #nocov end
             return R_NilValue; /* -Wall */
         }
 
@@ -72,7 +72,7 @@ namespace Rcpp {
         }
         template<>
         inline SEXP r_true_cast<RAWSXP>(SEXP x){
-            return  basic_cast<RAWSXP>(x);
+            return basic_cast<RAWSXP>(x);
         }
         template<>
         inline SEXP r_true_cast<CPLXSXP>(SEXP x){
@@ -103,13 +103,13 @@ namespace Rcpp {
             case SYMSXP:
                 return Rf_ScalarString( PRINTNAME( x ) );
             default:
-                throw ::Rcpp::not_compatible("not compatible with STRSXP");
+                throw ::Rcpp::not_compatible("Not compatible requested type (%s -> STRSXP).", Rf_type2char(TYPEOF(x)));
             }
             return R_NilValue; /* -Wall */
         }
         template<>
         inline SEXP r_true_cast<VECSXP>(SEXP x) {
-            return convert_using_rfunction(x, "as.list");	// #nocov end 
+            return convert_using_rfunction(x, "as.list");	// #nocov end
         }
         template<>
         inline SEXP r_true_cast<EXPRSXP>(SEXP x) {
@@ -141,9 +141,9 @@ namespace Rcpp {
         } else {
             #ifdef RCPP_WARN_ON_COERCE
             Shield<SEXP> result( internal::r_true_cast<TARGET>(x) );
-            Rf_warning("coerced object from '%s' to '%s'",
-                CHAR(Rf_type2str(TYPEOF(x))),
-                CHAR(Rf_type2str(TARGET))
+            ::Rcpp::warning("Coerced object from '%s' to '%s'.",
+                Rf_type2str(TYPEOF(x)),
+                Rf_type2str(TARGET)
             );
             return result;
             #else

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -152,15 +152,6 @@ namespace Rcpp {
 #   endif
 #endif
 
-#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
-#   include <array>
-#   if defined(_MSC_VER) && _MSC_VER <= 1800 // VS2013
-#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) (x)
-#   else
-#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) {x}
-#   endif
-#endif
-
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
 //  std::showpos is broken on old libstdc++ as provided with OSX.  See
 //  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
@@ -282,7 +273,7 @@ inline void formatTruncated(std::ostream& out, const T& value, int ntrunc)
     std::ostringstream tmp;
     tmp << value;
     std::string result = tmp.str();
-    out.write(result.c_str(), std::min(ntrunc, static_cast<int>(result.size())));
+    out.write(result.c_str(), (std::min)(ntrunc, static_cast<int>(result.size())));
 }
 #define TINYFORMAT_DEFINE_FORMAT_TRUNCATED_CSTR(type)       \
 inline void formatTruncated(std::ostream& out, type* value, int ntrunc) \
@@ -332,8 +323,8 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // void* respectively and format that instead of the value itself.  For the
     // %p conversion it's important to avoid dereferencing the pointer, which
     // could otherwise lead to a crash when printing a dangling (const char*).
-    bool canConvertToChar = detail::is_convertible<T,char>::value;
-    bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
+    const bool canConvertToChar = detail::is_convertible<T,char>::value;
+    const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
     if(canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
     else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')
@@ -566,14 +557,16 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
         switch(*c)
         {
             case '\0':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 return c;
             case '%':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 if(*(c+1) != '%')
                     return c;
                 // for "%%", tack trailing % onto next literal section.
                 fmt = ++c;
+                break;
+            default:
                 break;
         }
     }
@@ -644,6 +637,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
                 spacePadPositive = false;
                 widthExtra = 1;
                 continue;
+            default:
+                break;
         }
         break;
     }
@@ -757,6 +752,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
                              "terminated by end of string");
             return c;
+        default:
+            break;
     }
     if(intConversion && precisionSet && !widthSet)
     {
@@ -869,7 +866,7 @@ class FormatListN : public FormatList
         template<typename... Args>
         FormatListN(const Args&... args)
             : FormatList(&m_formatterStore[0], N),
-            m_formatterStore TINYFORMAT_BRACED_INIT_WORKAROUND({ FormatArg(args)... })
+            m_formatterStore { FormatArg(args)... }
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}
@@ -878,7 +875,7 @@ class FormatListN : public FormatList
         template<TINYFORMAT_ARGTYPES(n)>                       \
         FormatListN(TINYFORMAT_VARARGS(n))                     \
             : FormatList(&m_formatterStore[0], n)              \
-        {/*assert*n == N);*/init(0, TINYFORMAT_PASSARGS(n)); } \
+        {/*assert(n == N);*/init(0, TINYFORMAT_PASSARGS(n)); } \
                                                                \
         template<TINYFORMAT_ARGTYPES(n)>                       \
         void init(int i, TINYFORMAT_VARARGS(n))                \
@@ -892,11 +889,7 @@ class FormatListN : public FormatList
 #endif
 
     private:
-#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
-        std::array<FormatArg, N> m_formatterStore;
-#else // C++98 version
         FormatArg m_formatterStore[N];
-#endif
 };
 
 // Special 0-arg version - MSVC says zero-sized C array in struct is nonstandard

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -130,10 +130,12 @@ namespace Rcpp {
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
-// #define TINYFORMAT_USE_VARIADIC_TEMPLATES
-
+#if __cplusplus >= 201103L
+#define TINYFORMAT_USE_VARIADIC_TEMPLATES
+#else
 // don't use C++11 features (support older compilers)
 #define TINYFORMAT_NO_VARIADIC_TEMPLATES
+#endif
 
 //------------------------------------------------------------------------------
 // Implementation details.
@@ -367,6 +369,7 @@ TINYFORMAT_DEFINE_FORMATVALUE_CHAR(unsigned char)
 // Tools for emulating variadic templates in C++98.  The basic idea here is
 // stolen from the boost preprocessor metaprogramming library and cut down to
 // be just general enough for what we need.
+#ifdef TINYFORMAT_NO_VARIADIC_TEMPLATES
 
 #define TINYFORMAT_ARGTYPES(n) TINYFORMAT_ARGTYPES_ ## n
 #define TINYFORMAT_VARARGS(n) TINYFORMAT_VARARGS_ ## n
@@ -480,7 +483,7 @@ cog.outl('#define TINYFORMAT_FOREACH_ARGNUM(m) \\\n    ' +
 #define TINYFORMAT_FOREACH_ARGNUM(m) \
     m(1) m(2) m(3) m(4) m(5) m(6) m(7) m(8) m(9) m(10) m(11) m(12) m(13) m(14) m(15) m(16)
 //[[[end]]]
-
+#endif // macros for C++98 code
 
 
 namespace detail {

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -53,7 +53,7 @@ public:
     Matrix(SEXP x) : VECTOR( r_cast<RTYPE>( x ) ), nrows( VECTOR::dims()[0] ) {}
 
     Matrix( const Dimension& dims) : VECTOR( Rf_allocMatrix( RTYPE, dims[0], dims[1] ) ), nrows(dims[0]) {
-        if( dims.size() != 2 ) throw not_compatible("not a matrix") ;
+        if( dims.size() != 2 ) throw not_a_matrix() ;
         VECTOR::init() ;
     }
     Matrix( const int& nrows_, const int& ncols) : VECTOR( Dimension( nrows_, ncols ) ),
@@ -82,7 +82,7 @@ public:
 
     Matrix& operator=(const Matrix& other) {
         SEXP x = other.get__() ;
-        if( ! ::Rf_isMatrix(x) ) not_compatible("not a matrix") ;
+        if( ! ::Rf_isMatrix(x) ) throw not_a_matrix() ;
         VECTOR::set__( x ) ;
         nrows = other.nrows ;
         return *this ;

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -39,7 +39,7 @@ public:
         start(parent.begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(const_cast<const MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() )  throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
     }
 
     MatrixColumn( const MATRIX& parent, int i ) :
@@ -47,7 +47,7 @@ public:
         start( const_cast<MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(parent.begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
     }
 
     MatrixColumn( const MatrixColumn& other ) :
@@ -115,13 +115,13 @@ public:
         n(parent.nrow()),
         const_start(parent.begin() + i *n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
     }
 
     ConstMatrixColumn( const ConstMatrixColumn& other ) :
         n(other.n),
         const_start(other.const_start) {}
-        
+
     inline const_Proxy operator[]( int i ) const {
         return const_start[i] ;
     }

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -39,7 +39,11 @@ public:
         start(parent.begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(const_cast<const MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() )  throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Index is out of bounds: "
+                              "[index=%s; column extent=%s].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     MatrixColumn( const MATRIX& parent, int i ) :
@@ -47,7 +51,11 @@ public:
         start( const_cast<MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(parent.begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Index is out of bounds: "
+                              "[index=%s; column extent=%s].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     MatrixColumn( const MatrixColumn& other ) :
@@ -115,7 +123,11 @@ public:
         n(parent.nrow()),
         const_start(parent.begin() + i *n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds("index out of bounds. Requested column %i out of %i columns.", i, parent.ncol()) ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Index is out of bounds: "
+                              "[index=%s; column extent=%s].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     ConstMatrixColumn( const ConstMatrixColumn& other ) :

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -107,7 +107,7 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds("index out of bounds. Requested row %i out of %i rows.", i, parent.nrow()) ;
     }
 
     MatrixRow( const MatrixRow& other ) :
@@ -245,7 +245,7 @@ public:
         const ConstMatrixRow& row ;
         int index ;
     } ;
-    
+
     typedef const_iterator iterator;
 
     ConstMatrixRow( const MATRIX& object, int i ) :
@@ -254,7 +254,7 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds("index out of bounds. Requested row %i out of %i rows.", i, parent.nrow()) ;
     }
 
     ConstMatrixRow( const ConstMatrixRow& other ) :

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -107,7 +107,11 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds("index out of bounds. Requested row %i out of %i rows.", i, parent.nrow()) ;
+        if( i < 0 || i >= parent.nrow() ){
+            const char* fmt = "Index is out of bounds: "
+                              "[index=%s; row extent=%s].";
+            throw index_out_of_bounds(fmt, i, parent.nrow()) ;
+        }
     }
 
     MatrixRow( const MatrixRow& other ) :
@@ -254,7 +258,11 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds("index out of bounds. Requested row %i out of %i rows.", i, parent.nrow()) ;
+        if( i < 0 || i >= parent.nrow() ) {
+            const char* fmt = "Index is out of bounds: "
+                              "[index=%s; row extent=%s].";
+            throw index_out_of_bounds(fmt, i, parent.nrow()) ;
+        }
     }
 
     ConstMatrixRow( const ConstMatrixRow& other ) :

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -285,7 +285,12 @@ public:
         const int* dim = dims() ;
         const int nrow = dim[0] ;
         const int ncol = dim[1] ;
-        if(i < 0|| i >= nrow || j < 0 || j >= ncol ) throw index_out_of_bounds("index out of bounds. Requested row %i out of %i rows and %i column out of %i columns.", i, nrow, j, ncol) ;
+        if(i < 0|| i >= nrow || j < 0 || j >= ncol ) {
+            const char* fmt = "Index out of bounds: "
+                              "[row index=%s; row extent=%s; "
+                              "column index=%s; column extent=%s].";
+            throw index_out_of_bounds(fmt, i, nrow, j, ncol) ;
+        }
         return i + static_cast<R_xlen_t>(nrow)*j ;
     }
 
@@ -294,20 +299,28 @@ public:
      * it is valid
      */
     R_xlen_t offset(const R_xlen_t& i) const {
-        if(i < 0 || i >= ::Rf_xlength(Storage::get__()) ) throw index_out_of_bounds("index out of bounds. Requested element %i out of %i elements.", i, ::Rf_xlength(Storage::get__()) ) ;
+        if(i < 0 || i >= ::Rf_xlength(Storage::get__()) ) {
+            const char* fmt = "Index out of bounds: [index=%s; extent=%s].";
+            throw index_out_of_bounds(fmt, i, ::Rf_xlength(Storage::get__()) ) ;
+        }
         return i ;
     }
 
     R_xlen_t offset(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES( Storage::get__() ) ;
-        if( Rf_isNull(names) ) throw index_out_of_bounds("index out of bounds. Object was created without names.");
+        if( Rf_isNull(names) ) {
+            const char* fmt = "Index out of bounds: "
+                              "Object was created without names.";
+            throw index_out_of_bounds(fmt);
+        }
         R_xlen_t n=size() ;
         for( R_xlen_t i=0; i<n; ++i){
             if( ! name.compare( CHAR(STRING_ELT(names, i)) ) ){
                 return i ;
             }
         }
-        throw index_out_of_bounds("index out of bounds. Unable to locate '%s'.", name) ;
+        const char* fmt = "Index out of bounds: [index='%s'].";
+        throw index_out_of_bounds(fmt, name) ;
         return -1 ; /* -Wall */
     }
 
@@ -915,8 +928,9 @@ private:
                 // This will be a negative number
                 requested_loc = std::distance(begin(), position);
             }
-
-            throw index_out_of_bounds("index out of bounds. The iterator was set to begin at position %i with %i available.", requested_loc, available_locs ) ;
+            const char* fmt = "Index is out of bounds: "
+                              "[iterator index=%s; iterator extent=%s]";
+            throw index_out_of_bounds(fmt, requested_loc, available_locs ) ;
         }
 
         R_xlen_t n = size() ;
@@ -971,8 +985,10 @@ private:
                 requested_loc = std::distance(begin(), first);
                 iter_problem = "first";
             }
-
-            throw index_out_of_bounds("index out of bounds. The '%s' iterator started at position %i with %i available.", iter_problem, requested_loc, available_locs ) ;
+            const char* fmt = "Index is out of bounds: "
+                              "[iterator=%s; index=%s; extent=%s]";
+            throw index_out_of_bounds(fmt, iter_problem,
+                                      requested_loc, available_locs ) ;
         }
 
         iterator it = begin() ;

--- a/inst/unitTests/cpp/exceptions.cpp
+++ b/inst/unitTests/cpp/exceptions.cpp
@@ -62,3 +62,8 @@ double f1(double val) {
 double takeLogNested(double val) {
     return f1(val);
 }
+
+// [[Rcpp::export]]
+void noCall() {
+    throw Rcpp::exception("Testing", false);
+}

--- a/inst/unitTests/runit.exceptions.R
+++ b/inst/unitTests/runit.exceptions.R
@@ -110,4 +110,14 @@ test.rcppExceptionLocation <- function() {
   checkEquals(nested$call, quote(takeLogNested(x)))
 }
 
+test.rcppExceptionNoCall <- function() {
+
+  # Can throw exceptions that don't include a call stack
+  e <- tryCatch(noCall(), error = identity)
+
+  checkIdentical(e$message, "Testing")
+  checkIdentical(e$call, NULL)
+  checkIdentical(e$cppstack, NULL)
+  checkIdentical(class(e), c("Rcpp::exception", "C++Error", "error", "condition"))
+}
 }

--- a/inst/unitTests/testRcppClass/DESCRIPTION
+++ b/inst/unitTests/testRcppClass/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testRcppClass
 Type: Package
-Title: Some examples using Rcpp classes and loadModule()
+Title: Some Examples using Rcpp Classes and loadModule()
 Version: 0.1
 Date: 2012-04-06
 Author: John Chambers
@@ -14,4 +14,4 @@ Depends: R (>= 2.15.0)
 Imports: Rcpp (>= 0.8.5), methods
 LinkingTo: Rcpp
 Packaged: 2012-04-14 18:42:28 UTC; jmc
-
+NeedsCompilation: yes

--- a/inst/unitTests/testRcppClass/NAMESPACE
+++ b/inst/unitTests/testRcppClass/NAMESPACE
@@ -1,4 +1,4 @@
-useDynLib(testRcppClass)
+useDynLib(testRcppClass, .registration=TRUE)
 import(Rcpp,methods)
 
 export(genWorld, stdNumeric, rcpp_hello_world,

--- a/inst/unitTests/testRcppClass/R/rcpp_hello_world.R
+++ b/inst/unitTests/testRcppClass/R/rcpp_hello_world.R
@@ -1,5 +1,5 @@
 
 rcpp_hello_world <- function(){
-    .Call("rcpp_hello_world", PACKAGE = "testRcppClass")
+    .Call("rcpp_hello_world_cpp", PACKAGE = "testRcppClass")
 }
 

--- a/inst/unitTests/testRcppClass/src/init.c
+++ b/inst/unitTests/testRcppClass/src/init.c
@@ -1,0 +1,27 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/* FIXME: 
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .Call calls */
+extern SEXP rcpp_hello_world_cpp();
+extern SEXP _rcpp_module_boot_NumEx();
+extern SEXP _rcpp_module_boot_RcppClassModule();
+extern SEXP _rcpp_module_boot_stdVector();
+
+static const R_CallMethodDef CallEntries[] = {
+    {"rcpp_hello_world_cpp", (DL_FUNC) &rcpp_hello_world_cpp, 0},
+    {"_rcpp_module_boot_NumEx", (DL_FUNC) &_rcpp_module_boot_NumEx, 0},
+    {"_rcpp_module_boot_RcppClassModule", (DL_FUNC) &_rcpp_module_boot_RcppClassModule, 0},
+    {"_rcpp_module_boot_stdVector", (DL_FUNC) &_rcpp_module_boot_stdVector, 0},
+    {NULL, NULL, 0}
+};
+
+void R_init_testRcppModule(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/inst/unitTests/testRcppClass/src/rcpp_hello_world.cpp
+++ b/inst/unitTests/testRcppClass/src/rcpp_hello_world.cpp
@@ -1,6 +1,6 @@
 #include "rcpp_hello_world.h"
 
-SEXP rcpp_hello_world(){
+SEXP rcpp_hello_world_cpp(){
     using namespace Rcpp ;
 
     CharacterVector x = CharacterVector::create( "foo", "bar" )  ;

--- a/inst/unitTests/testRcppClass/src/rcpp_hello_world.h
+++ b/inst/unitTests/testRcppClass/src/rcpp_hello_world.h
@@ -3,6 +3,6 @@
 
 #include <Rcpp.h>
 
-RcppExport SEXP rcpp_hello_world() ;
+RcppExport SEXP rcpp_hello_world_cpp() ;
 
 #endif

--- a/inst/unitTests/testRcppModule/DESCRIPTION
+++ b/inst/unitTests/testRcppModule/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testRcppModule
 Type: Package
-Title: Some test examples using Rcpp with the Module feature
+Title: Some Test Examples using Rcpp with the Module Feature
 Version: 0.1
 Date: 2010-09-06
 Author: John Chambers

--- a/inst/unitTests/testRcppModule/NAMESPACE
+++ b/inst/unitTests/testRcppModule/NAMESPACE
@@ -1,4 +1,4 @@
-useDynLib(testRcppModule)
+useDynLib(testRcppModule, .registration=TRUE)
 exportPattern("^[[:alpha:]]+")
 import(Rcpp,methods)
 

--- a/inst/unitTests/testRcppModule/R/rcpp_hello_world.R
+++ b/inst/unitTests/testRcppModule/R/rcpp_hello_world.R
@@ -1,5 +1,5 @@
 
 rcpp_hello_world <- function(){
-    .Call( "rcpp_hello_world", PACKAGE = "testRcppModule" )
+    .Call( "rcpp_hello_world_cpp", PACKAGE = "testRcppModule" )
 }
 

--- a/inst/unitTests/testRcppModule/man/Rcpp_modules_examples.Rd
+++ b/inst/unitTests/testRcppModule/man/Rcpp_modules_examples.Rd
@@ -1,6 +1,6 @@
 \name{Rcpp Modules Examples}
-\alias{Num}
-\alias{World}
+\alias{RcppModuleNum}
+\alias{RcppModuleWorld}
 \alias{bar}
 \alias{bla}
 \alias{bla1}
@@ -8,8 +8,8 @@
 \alias{foo}
 \alias{vec}
 \alias{hello}
-\alias{Rcpp_Num-class}
-\alias{Rcpp_World-class}
+\alias{Rcpp_RcppModuleNum-class}
+\alias{Rcpp_RcppModuleWorld-class}
 \alias{Rcpp_vec-class}
 \alias{C++Object-class}
 \title{

--- a/inst/unitTests/testRcppModule/man/rcpp_hello_world.Rd
+++ b/inst/unitTests/testRcppModule/man/rcpp_hello_world.Rd
@@ -1,5 +1,6 @@
 \name{rcpp_hello_world}
 \alias{rcpp_hello_world}
+\alias{rcpp_hello_world_cpp}
 \docType{package}
 \title{
 Simple function using Rcpp

--- a/inst/unitTests/testRcppModule/src/init.c
+++ b/inst/unitTests/testRcppModule/src/init.c
@@ -1,0 +1,27 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/* FIXME: 
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .Call calls */
+extern SEXP rcpp_hello_world_cpp();
+extern SEXP _rcpp_module_boot_RcppModuleNumEx();
+extern SEXP _rcpp_module_boot_RcppModuleWorld();
+extern SEXP _rcpp_module_boot_stdVector();
+
+static const R_CallMethodDef CallEntries[] = {
+    {"rcpp_hello_world_cpp", (DL_FUNC) &rcpp_hello_world_cpp, 0},
+    {"_rcpp_module_boot_RcppModuleNumEx", (DL_FUNC) &_rcpp_module_boot_RcppModuleNumEx, 0},
+    {"_rcpp_module_boot_RcppModuleWorld", (DL_FUNC) &_rcpp_module_boot_RcppModuleWorld, 0},
+    {"_rcpp_module_boot_stdVector", (DL_FUNC) &_rcpp_module_boot_stdVector, 0},
+    {NULL, NULL, 0}
+};
+
+void R_init_testRcppModule(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/inst/unitTests/testRcppModule/src/rcpp_hello_world.cpp
+++ b/inst/unitTests/testRcppModule/src/rcpp_hello_world.cpp
@@ -1,6 +1,6 @@
 #include "rcpp_hello_world.h"
 
-SEXP rcpp_hello_world(){
+SEXP rcpp_hello_world_cpp(){
     using namespace Rcpp ;
 
     CharacterVector x = CharacterVector::create( "foo", "bar" )  ;

--- a/inst/unitTests/testRcppModule/src/rcpp_hello_world.h
+++ b/inst/unitTests/testRcppModule/src/rcpp_hello_world.h
@@ -3,6 +3,6 @@
 
 #include <Rcpp.h>
 
-RcppExport SEXP rcpp_hello_world() ;
+RcppExport SEXP rcpp_hello_world_cpp() ;
 
 #endif

--- a/inst/unitTests/testRcppModule/tests/modules.R
+++ b/inst/unitTests/testRcppModule/tests/modules.R
@@ -15,9 +15,6 @@ stopifnot(all.equal(bar(2), 4))
 stopifnot(all.equal(foo(2,3), 6))
 
 ## properties (at one stage this seqfaulted, so beware)
-nn <- new(Num)
+nn <- new(RcppModuleNum)
 nn$x <- pi
 stopifnot(all.equal(nn$x, pi))
-
-
-


### PR DESCRIPTION
### Overview

This is a work in progress (WIP) PR to upgrade the exception messages found in Rcpp. 

For details on the contents of the PR, please see #184. (The issue ticket contains GitHub search URL for each Rcpp exception message.)

### Changes:

- Added `RCPP_ADVANCED_EXCEPTION_CLASS` macro that mimics the structure of the `Rcpp::stop()` / `Rcpp::warning()` implementations.
- Removed `no_such_field` 
- Changed throw type from `not_compatible` to `not_a_matrix` in `inst\include\Rcpp\vector\Matrix.h` (FYI, a `throw` was missing on one of the statements).

Presently, I've held off on removing  `reference_creation_error` as it is not used but it is referenced within the documentation.

### Misc

This branch will likely need to be rebased after @jimhester's #663 PR.