### PR TITLE
Improve support for -Wall -Wextra

### DIFF
--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -43,7 +43,7 @@ namespace Rcpp{
         DataFrame_Impl(SEXP x) : Parent(x) {
             set__(x);
         }
-        DataFrame_Impl( const DataFrame_Impl& other){
+        DataFrame_Impl( const DataFrame_Impl& other) : Parent() {
             set__(other) ;
         }
 

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -65,6 +65,11 @@
 #define END_RCPP VOID_END_RCPP return R_NilValue;
 #endif
 
+#ifndef BEGIN_RCPP_RETURN_ERROR
+#define BEGIN_RCPP_RETURN_ERROR                                                \
+    try {
+#endif
+
 #ifndef END_RCPP_RETURN_ERROR
 #define END_RCPP_RETURN_ERROR                                                  \
   }                                                                            \

--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -54,6 +54,7 @@ public:
         Rep_Single( const T& x_, R_xlen_t n_) : x(x_), n(n_){}
 
         inline T operator[]( R_xlen_t i ) const {
+		(void)i;
 		return x;
 	}
         inline R_xlen_t size() const { return n ; }

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -122,6 +122,7 @@ void registerFunctions(){
 
 
 extern "C" void R_unload_Rcpp(DllInfo *info) {  // #nocov start
+    (void)info;
     // Release resources
 } 						// #nocov end
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2581,7 +2581,8 @@ namespace attributes {
             }
             std::string args = ostrArgs.str();
             ostr << args << ") {" << std::endl;
-            ostr << "BEGIN_RCPP" << std::endl;
+            ostr << (cppInterface ? "BEGIN_RCPP_RETURN_ERROR" : "BEGIN_RCPP")
+                 << std::endl;
             if (!function.type().isVoid())
                 ostr << "    Rcpp::RObject rcpp_result_gen;" << std::endl;
             if (!cppInterface && attribute.rng())

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -697,7 +697,10 @@ namespace attributes {
 
     private:
         virtual void doWriteFunctions(const SourceFileAttributes& attributes,
-                                      bool verbose) {}
+                                      bool verbose) {
+            (void)attributes;
+            (void)verbose;
+        }
         std::string getHeaderGuard() const;
 
     private:
@@ -2003,6 +2006,7 @@ namespace attributes {
     void CppExportsIncludeGenerator::doWriteFunctions(
                                     const SourceFileAttributes& attributes,
                                     bool verbose) {
+        (void)verbose;
 
         // don't write anything if there is no C++ interface
         if (!attributes.hasInterface(kInterfaceCpp))
@@ -2182,6 +2186,7 @@ namespace attributes {
 
     bool CppPackageIncludeGenerator::commit(
                                 const std::vector<std::string>& includes) {
+        (void)includes;
 
         if (hasCppInterface()) {
 
@@ -2213,6 +2218,7 @@ namespace attributes {
     void RExportsGenerator::doWriteFunctions(
                                         const SourceFileAttributes& attributes,
                                         bool verbose) {
+        (void)verbose;
 
         // write standalone roxygen chunks
         const std::vector<std::vector<std::string> >& roxygenChunks =
@@ -2283,6 +2289,7 @@ namespace attributes {
     }
 
     bool RExportsGenerator::commit(const std::vector<std::string>& includes) {
+        (void)includes;
         return ExportsGenerator::commit();
     }
 


### PR DESCRIPTION
- `DataFrame` copy constructor
- Code generated for C++ interfaces
- Unused arguments

This may be far from comprehensive, it fixes just the errors that I noticed when trying to compile dplyr with  `-Wall -Wextra`. Please let me know if you prefer a different annotation for unused arguments.