### PR TITLE
Explicitly call parent constructor

### DIFF
--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -43,7 +43,7 @@ namespace Rcpp{
         DataFrame_Impl(SEXP x) : Parent(x) {
             set__(x);
         }
-        DataFrame_Impl( const DataFrame_Impl& other){
+        DataFrame_Impl( const DataFrame_Impl& other) : Parent() {
             set__(other) ;
         }
 


### PR DESCRIPTION
for copy constructor, to avoid warning in `-Wextra`.