### PR TITLE
BEGIN_RCPP uses the variables it defines

### DIFF
--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -65,6 +65,11 @@
 #define END_RCPP VOID_END_RCPP return R_NilValue;
 #endif
 
+#ifndef BEGIN_RCPP_RETURN_ERROR
+#define BEGIN_RCPP_RETURN_ERROR                                                \
+    try {
+#endif
+
 #ifndef END_RCPP_RETURN_ERROR
 #define END_RCPP_RETURN_ERROR                                                  \
   }                                                                            \

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -29,7 +29,9 @@
 #ifndef BEGIN_RCPP
 #define BEGIN_RCPP                                                                               \
     int rcpp_output_type = 0 ;                                                                   \
+    (void)rcpp_output_type;                                                                      \
     SEXP rcpp_output_condition = R_NilValue ;                                                    \
+    (void)rcpp_output_condition;                                                                 \
     try {
 #endif
 
@@ -63,11 +65,6 @@
 
 #ifndef END_RCPP
 #define END_RCPP VOID_END_RCPP return R_NilValue;
-#endif
-
-#ifndef BEGIN_RCPP_RETURN_ERROR
-#define BEGIN_RCPP_RETURN_ERROR                                                \
-    try {
 #endif
 
 #ifndef END_RCPP_RETURN_ERROR

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2581,7 +2581,8 @@ namespace attributes {
             }
             std::string args = ostrArgs.str();
             ostr << args << ") {" << std::endl;
-            ostr << "BEGIN_RCPP" << std::endl;
+            ostr << (cppInterface ? "BEGIN_RCPP_RETURN_ERROR" : "BEGIN_RCPP")
+                 << std::endl;
             if (!function.type().isVoid())
                 ostr << "    Rcpp::RObject rcpp_result_gen;" << std::endl;
             if (!cppInterface && attribute.rng())

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2581,8 +2581,7 @@ namespace attributes {
             }
             std::string args = ostrArgs.str();
             ostr << args << ") {" << std::endl;
-            ostr << (cppInterface ? "BEGIN_RCPP_RETURN_ERROR" : "BEGIN_RCPP")
-                 << std::endl;
+            ostr << "BEGIN_RCPP" << std::endl;
             if (!function.type().isVoid())
                 ostr << "    Rcpp::RObject rcpp_result_gen;" << std::endl;
             if (!cppInterface && attribute.rng())


### PR DESCRIPTION
Will be used instead of `BEGIN_RCPP` for generated wrappers for C++ interfaces (`[[Rcpp::interfaces(cpp)]]`).