### PR TITLE
Remove name for unused arguments

### DIFF
--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -54,6 +54,7 @@ public:
         Rep_Single( const T& x_, R_xlen_t n_) : x(x_), n(n_){}
 
         inline T operator[]( R_xlen_t i ) const {
+		(void)i;
 		return x;
 	}
         inline R_xlen_t size() const { return n ; }

--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -53,8 +53,7 @@ class Rep_Single : public Rcpp::VectorBase<
 public:
         Rep_Single( const T& x_, R_xlen_t n_) : x(x_), n(n_){}
 
-        inline T operator[]( R_xlen_t i ) const {
-		(void)i;
+        inline T operator[]( R_xlen_t ) const {
 		return x;
 	}
         inline R_xlen_t size() const { return n ; }

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -121,8 +121,7 @@ void registerFunctions(){
 }
 
 
-extern "C" void R_unload_Rcpp(DllInfo *info) {  // #nocov start
-    (void)info;
+extern "C" void R_unload_Rcpp(DllInfo *) {  // #nocov start
     // Release resources
 } 						// #nocov end
 

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -122,6 +122,7 @@ void registerFunctions(){
 
 
 extern "C" void R_unload_Rcpp(DllInfo *info) {  // #nocov start
+    (void)info;
     // Release resources
 } 						// #nocov end
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -696,11 +696,7 @@ namespace attributes {
         virtual bool commit(const std::vector<std::string>& includes);
 
     private:
-        virtual void doWriteFunctions(const SourceFileAttributes& attributes,
-                                      bool verbose) {
-            (void)attributes;
-            (void)verbose;
-        }
+        virtual void doWriteFunctions(const SourceFileAttributes&, bool) {}
         std::string getHeaderGuard() const;
 
     private:
@@ -2005,8 +2001,7 @@ namespace attributes {
 
     void CppExportsIncludeGenerator::doWriteFunctions(
                                     const SourceFileAttributes& attributes,
-                                    bool verbose) {
-        (void)verbose;
+                                    bool) {
 
         // don't write anything if there is no C++ interface
         if (!attributes.hasInterface(kInterfaceCpp))
@@ -2184,10 +2179,7 @@ namespace attributes {
         }
     }
 
-    bool CppPackageIncludeGenerator::commit(
-                                const std::vector<std::string>& includes) {
-        (void)includes;
-
+    bool CppPackageIncludeGenerator::commit(const std::vector<std::string>&) {
         if (hasCppInterface()) {
 
             // create the include dir if necessary
@@ -2217,9 +2209,7 @@ namespace attributes {
 
     void RExportsGenerator::doWriteFunctions(
                                         const SourceFileAttributes& attributes,
-                                        bool verbose) {
-        (void)verbose;
-
+                                        bool) {
         // write standalone roxygen chunks
         const std::vector<std::vector<std::string> >& roxygenChunks =
                                                     attributes.roxygenChunks();
@@ -2288,8 +2278,7 @@ namespace attributes {
         }
     }
 
-    bool RExportsGenerator::commit(const std::vector<std::string>& includes) {
-        (void)includes;
+    bool RExportsGenerator::commit(const std::vector<std::string>&) {
         return ExportsGenerator::commit();
     }
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -697,7 +697,10 @@ namespace attributes {
 
     private:
         virtual void doWriteFunctions(const SourceFileAttributes& attributes,
-                                      bool verbose) {}
+                                      bool verbose) {
+            (void)attributes;
+            (void)verbose;
+        }
         std::string getHeaderGuard() const;
 
     private:
@@ -2003,6 +2006,7 @@ namespace attributes {
     void CppExportsIncludeGenerator::doWriteFunctions(
                                     const SourceFileAttributes& attributes,
                                     bool verbose) {
+        (void)verbose;
 
         // don't write anything if there is no C++ interface
         if (!attributes.hasInterface(kInterfaceCpp))
@@ -2182,6 +2186,7 @@ namespace attributes {
 
     bool CppPackageIncludeGenerator::commit(
                                 const std::vector<std::string>& includes) {
+        (void)includes;
 
         if (hasCppInterface()) {
 
@@ -2213,6 +2218,7 @@ namespace attributes {
     void RExportsGenerator::doWriteFunctions(
                                         const SourceFileAttributes& attributes,
                                         bool verbose) {
+        (void)verbose;
 
         // write standalone roxygen chunks
         const std::vector<std::vector<std::string> >& roxygenChunks =
@@ -2283,6 +2289,7 @@ namespace attributes {
     }
 
     bool RExportsGenerator::commit(const std::vector<std::string>& includes) {
+        (void)includes;
         return ExportsGenerator::commit();
     }
 


### PR DESCRIPTION
~~with `(void)arg;` in the function's body.~~