### PR TITLE
Refresh tinyformat with May 2016 header, retain local modifications (close #673)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-04-14  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/utils/tinyformat.h: Refreshed tinyformat.h against
+        May 13, 2016 upstream, retained local mods.
+
 2017-04-14  Kirill Müller <krlmlr@mailbox.org>
 
         * inst/include/Rcpp/macros/macros.h: Remove unused variable warning in

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,6 +11,8 @@
       Hester in \ghpr{663} addressing \ghit{664}).
       \item Somewhat spurious compiler messages under very verbose settings are
       now suppressed (Kirill Mueller in \ghpr{670}, \ghpr{671} and \ghpr{672}).
+      \item Refreshed the included \code{tinyformat} template library
+      (James Balamuta in \ghpr{674} addressing \ghit{673}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -152,15 +152,6 @@ namespace Rcpp {
 #   endif
 #endif
 
-#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
-#   include <array>
-#   if defined(_MSC_VER) && _MSC_VER <= 1800 // VS2013
-#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) (x)
-#   else
-#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) {x}
-#   endif
-#endif
-
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
 //  std::showpos is broken on old libstdc++ as provided with OSX.  See
 //  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
@@ -282,7 +273,7 @@ inline void formatTruncated(std::ostream& out, const T& value, int ntrunc)
     std::ostringstream tmp;
     tmp << value;
     std::string result = tmp.str();
-    out.write(result.c_str(), std::min(ntrunc, static_cast<int>(result.size())));
+    out.write(result.c_str(), (std::min)(ntrunc, static_cast<int>(result.size())));
 }
 #define TINYFORMAT_DEFINE_FORMAT_TRUNCATED_CSTR(type)       \
 inline void formatTruncated(std::ostream& out, type* value, int ntrunc) \
@@ -332,8 +323,8 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // void* respectively and format that instead of the value itself.  For the
     // %p conversion it's important to avoid dereferencing the pointer, which
     // could otherwise lead to a crash when printing a dangling (const char*).
-    bool canConvertToChar = detail::is_convertible<T,char>::value;
-    bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
+    const bool canConvertToChar = detail::is_convertible<T,char>::value;
+    const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
     if(canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
     else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')
@@ -566,14 +557,16 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
         switch(*c)
         {
             case '\0':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 return c;
             case '%':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 if(*(c+1) != '%')
                     return c;
                 // for "%%", tack trailing % onto next literal section.
                 fmt = ++c;
+                break;
+            default:
                 break;
         }
     }
@@ -644,6 +637,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
                 spacePadPositive = false;
                 widthExtra = 1;
                 continue;
+            default:
+                break;
         }
         break;
     }
@@ -757,6 +752,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
                              "terminated by end of string");
             return c;
+        default:
+            break;
     }
     if(intConversion && precisionSet && !widthSet)
     {
@@ -869,7 +866,7 @@ class FormatListN : public FormatList
         template<typename... Args>
         FormatListN(const Args&... args)
             : FormatList(&m_formatterStore[0], N),
-            m_formatterStore TINYFORMAT_BRACED_INIT_WORKAROUND({ FormatArg(args)... })
+            m_formatterStore { FormatArg(args)... }
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}
@@ -878,7 +875,7 @@ class FormatListN : public FormatList
         template<TINYFORMAT_ARGTYPES(n)>                       \
         FormatListN(TINYFORMAT_VARARGS(n))                     \
             : FormatList(&m_formatterStore[0], n)              \
-        {/*assert*n == N);*/init(0, TINYFORMAT_PASSARGS(n)); } \
+        {/*assert(n == N);*/init(0, TINYFORMAT_PASSARGS(n)); } \
                                                                \
         template<TINYFORMAT_ARGTYPES(n)>                       \
         void init(int i, TINYFORMAT_VARARGS(n))                \
@@ -892,11 +889,7 @@ class FormatListN : public FormatList
 #endif
 
     private:
-#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
-        std::array<FormatArg, N> m_formatterStore;
-#else // C++98 version
         FormatArg m_formatterStore[N];
-#endif
 };
 
 // Special 0-arg version - MSVC says zero-sized C array in struct is nonstandard


### PR DESCRIPTION
This is needed in order to enable variadic templates under C++11 for the exception message upgrade.