### PR TITLE
Improved exception infrastructure

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2017-04-17  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/exceptions.h: modified exceptions macros to support
+        a default string and removed generated stop, warning from file.
+        * inst/include/Rcpp/Rcpp/exceptions/cpp98/exceptions.h: Contains
+        generated RCPP_ADVANCED_EXCEPTION_CLASS macro, stop & warning.
+        * inst/include/Rcpp/Rcpp/exceptions/cpp11/exceptions.h: idem but
+        for variadic versions.
+        * inst/include/Rcpp/utils/tinyformat.h: Enabled ability to use variadic
+        tinyformat function if c++11 is detected.
+
 2017-04-14  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/include/Rcpp/utils/tinyformat.h: Refreshed tinyformat.h against

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 2017-04-17  James J Balamuta  <balamut2@illinois.edu>
 
-        * inst/include/Rcpp/exceptions.h: modified exceptions macros to support
+        * inst/include/Rcpp/Rcpp/exceptions/cpp11/exceptions.h: Removed
+        semicolons from RCPP_ADVANCED_EXCEPTION_CLASS to quiet 'extra ;' -Wpedantic
+
+        * inst/include/Rcpp/exceptions.h: Modified exceptions macros to support
         a default string and removed generated stop, warning from file.
         * inst/include/Rcpp/Rcpp/exceptions/cpp98/exceptions.h: Contains
         generated RCPP_ADVANCED_EXCEPTION_CLASS macro, stop & warning.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,6 +13,11 @@
       now suppressed (Kirill Mueller in \ghpr{670}, \ghpr{671} and \ghpr{672}).
       \item Refreshed the included \code{tinyformat} template library
       (James Balamuta in \ghpr{674} addressing \ghit{673}).
+      \item Added \code{printf}-like syntax support for exception classes and
+      variadic templating for \code{Rcpp::stop} and \code{Rcpp::warning}
+      (James Balamuta in \ghpr{675}).
+      \item Exception messages have been rewritten to provide additional
+      information. (James Balamuta in \ghpr{675}, ?? addressing \ghit{184}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,9 +15,9 @@
       (James Balamuta in \ghpr{674} addressing \ghit{673}).
       \item Added \code{printf}-like syntax support for exception classes and
       variadic templating for \code{Rcpp::stop} and \code{Rcpp::warning}
-      (James Balamuta in \ghpr{675}).
+      (James Balamuta in \ghpr{676}).
       \item Exception messages have been rewritten to provide additional
-      information. (James Balamuta in \ghpr{675}, ?? addressing \ghit{184}).
+      information. (James Balamuta in \ghpr{676}, ?? addressing \ghit{184}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/exceptions/cpp11/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp11/exceptions.h
@@ -1,0 +1,56 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// exceptions.h: Rcpp R/C++ interface class library -- exceptions
+//
+// Copyright (C) 2017 James J Balamuta
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__exceptionscpp11__h
+#define Rcpp__exceptionscpp11__h
+
+// Required for std::forward
+#include <utility>
+
+namespace Rcpp {
+
+#define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                        \
+class __CLASS__ : public std::exception{                                          \
+    public:                                                                       \
+        __CLASS__( ) throw() : message( std::string(__WHAT__) + "." ){} ;         \
+        __CLASS__( const std::string& message ) throw() :                         \
+		message( std::string(__WHAT__) + ": " + message + "."){} ;                \
+        template <typename... Args>                                               \
+        __CLASS__( const char* fmt, Args&&... args ) throw() :                    \
+            message(  tfm::format(fmt, std::forward<Args>(args)...) ){} ;         \
+        virtual ~__CLASS__() throw(){} ;                                          \
+        virtual const char* what() const throw() { return message.c_str() ; }     \
+        private:                                                                  \
+            std::string message ;                                                 \
+} ;
+
+template <typename... Args>
+inline void warning(const char* fmt, Args&&... args ) {
+    Rf_warning( tfm::format(fmt, std::forward<Args>(args)... ).c_str() );
+}
+
+template <typename... Args>
+inline void NORET stop(const char* fmt, Args&&... args) {
+    throw Rcpp::exception( tfm::format(fmt, std::forward<Args>(args)... ).c_str() );
+}
+
+} // namespace Rcpp
+#endif

--- a/inst/include/Rcpp/exceptions/cpp11/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp11/exceptions.h
@@ -28,19 +28,19 @@
 namespace Rcpp {
 
 #define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                        \
-class __CLASS__ : public std::exception{                                          \
+class __CLASS__ : public std::exception {                                         \
     public:                                                                       \
-        __CLASS__( ) throw() : message( std::string(__WHAT__) + "." ){} ;         \
+        __CLASS__( ) throw() : message( std::string(__WHAT__) + "." ){}           \
         __CLASS__( const std::string& message ) throw() :                         \
-		message( std::string(__WHAT__) + ": " + message + "."){} ;                \
+		message( std::string(__WHAT__) + ": " + message + "."){}                  \
         template <typename... Args>                                               \
         __CLASS__( const char* fmt, Args&&... args ) throw() :                    \
-            message(  tfm::format(fmt, std::forward<Args>(args)...) ){} ;         \
-        virtual ~__CLASS__() throw(){} ;                                          \
-        virtual const char* what() const throw() { return message.c_str() ; }     \
+            message(  tfm::format(fmt, std::forward<Args>(args)... ) ){}          \
+        virtual ~__CLASS__() throw(){}                                            \
+        virtual const char* what() const throw() { return message.c_str(); }      \
         private:                                                                  \
-            std::string message ;                                                 \
-} ;
+            std::string message;                                                  \
+};
 
 template <typename... Args>
 inline void warning(const char* fmt, Args&&... args ) {

--- a/inst/include/Rcpp/exceptions/cpp98/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp98/exceptions.h
@@ -1,0 +1,177 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
+//
+// exceptions.h: Rcpp R/C++ interface class library -- exceptions
+//
+// Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2017         Dirk Eddelbuettel, Romain Francois, and James J Balamuta
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef Rcpp__exceptionscpp98__h
+#define Rcpp__exceptionscpp98__h
+
+namespace Rcpp {
+
+#define RCPP_ADVANCED_EXCEPTION_CLASS(__CLASS__, __WHAT__)                                                                                                                                                         \
+class __CLASS__ : public std::exception{                                                                                                                                                                           \
+    public:                                                                                                                                                                                                        \
+        __CLASS__( ) throw() : message( std::string(__WHAT__) + "." ){} ;                                                                                                                                          \
+        __CLASS__( const std::string& message ) throw() : message( std::string(__WHAT__) + ": " + message + "." ){} ;                                                                                              \
+        template <typename T1>                                                                                                                                                                                     \
+        __CLASS__(const char* fmt, const T1& arg1) throw() :                                                                                                                                                       \
+            message( tfm::format(fmt, arg1 ) ){} ;                                                                                                                                                                 \
+        template <typename T1, typename T2>                                                                                                                                                                        \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2) throw() :                                                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2 ) ){} ;                                                                                                                                                           \
+        template <typename T1, typename T2, typename T3>                                                                                                                                                           \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) throw() :                                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3 ) ){} ;                                                                                                                                                     \
+        template <typename T1, typename T2, typename T3, typename T4>                                                                                                                                              \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) throw() :                                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4 ) ){} ;                                                                                                                                               \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5>                                                                                                                                 \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) throw() :                                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5 ) ){} ;                                                                                                                                         \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>                                                                                                                    \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) throw() :                                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6 ) ){} ;                                                                                                                                   \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>                                                                                                       \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) throw() :                                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7 ) ){} ;                                                                                                                             \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>                                                                                          \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) throw() :                                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 ) ){} ;                                                                                                                       \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>                                                                             \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) throw() :                       \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ) ){} ;                                                                                                                 \
+        template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>                                                               \
+        __CLASS__(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) throw() :     \
+            message( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 ) ){} ;                                                                                                          \
+        virtual ~__CLASS__() throw(){} ;                                                                                                                                                                           \
+        virtual const char* what() const throw() { return message.c_str() ; }                                                                                                                                      \
+        private:                                                                                                                                                                                                   \
+            std::string message ;                                                                                                                                                                                  \
+} ;                                                                                                                                                                                                                \
+
+// -- Start Rcpp::warning declaration
+
+template <typename T1>
+inline void warning(const char* fmt, const T1& arg1) {
+    Rf_warning( tfm::format(fmt, arg1 ).c_str() );
+}
+
+template <typename T1, typename T2>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2) {
+    Rf_warning( tfm::format(fmt, arg1, arg2 ).c_str() );
+}
+
+template <typename T1, typename T2, typename T3>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+    Rf_warning( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
+}
+
+// -- End Rcpp::warning declaration
+
+// -- Start Rcpp::stop declaration
+
+template <typename T1>
+inline void NORET stop(const char* fmt, const T1& arg1) {
+    throw Rcpp::exception( tfm::format(fmt, arg1 ).c_str() );
+}
+
+template <typename T1, typename T2>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2 ).c_str() );
+}
+
+template <typename T1, typename T2, typename T3>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str() );
+}
+
+template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
+    throw Rcpp::exception( tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str() );
+}
+
+// -- End Rcpp::stop declaration
+} // namespace Rcpp
+#endif

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -130,10 +130,12 @@ namespace Rcpp {
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
-// #define TINYFORMAT_USE_VARIADIC_TEMPLATES
-
-// don't use C++11 features (support older compilers)
+#if __cplusplus >= 201103L
+#define TINYFORMAT_USE_VARIADIC_TEMPLATES
+#else
+// Don't use C++11 features (support older compilers)
 #define TINYFORMAT_NO_VARIADIC_TEMPLATES
+#endif
 
 //------------------------------------------------------------------------------
 // Implementation details.


### PR DESCRIPTION
This is PR 2 of 3.

Contained within this PR is the necessary upgrade to the exception infrastructure to proceed with improving internal exception messages.

The third PR aims to provide the improved internal exception messages based on the proposal table in #184.

(The first PR was the upstream refresh of the tinyformat library.)

----

Changes:
- Added local mod in tinyformat to enable variadic templates if C++11 is detected.
- Created a C++11 exception message version using variadic templates for `Rcpp::stop`, `Rcpp::warning`, and `RCPP_ADVANCED_EXCEPTION_CLASS`
- Added C++98 exception message version using generated macro arguments.
- Extracted generated `Rcpp::stop` and `Rcpp::warning` functions from `exception.h` and moved them into C++98 exception header
- Modified `RCPP_EXCEPTION_CLASS` macro to have a default ctor that returns a default constructed string to allow for promotion without breaking present use.
- Promoted `no_such_slot` and `not_a_closure` to use `RCPP_EXCEPTION_CLASS` from `RCPP_SIMPLE_EXCEPTION_CLASS`.
- Promoted `index_out_of_bounds` and `not_compatible` to use `RCPP_ADVANCED_EXCEPTION_CLASS`.
- Flagged `no_such_field` and `reference_creation_class` for potential removal.