### PR TITLE
Improved exception messages (close #184)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+2017-04-18  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/vector/Matrix.h: Corrected exception throws from
+        not_compatible to not_a_matrix.
+        * inst/include/Rcpp/S4.h: Fixed documentation detailing exception class
+        throw.
+        * inst/include/Rcpp/Environment.h: Improved error handling messages
+        * inst/include/Rcpp/Function.h: idem
+        * inst/include/Rcpp/Promise.h: idem
+        * inst/include/Rcpp/String.h: idem
+        * inst/include/Rcpp/Symbol.h: idem
+        * inst/include/Rcpp/XPtr.h: idem
+        * inst/include/Rcpp/as.h: idem
+        * inst/include/Rcpp/r_cast.h: idem
+        * inst/include/Rcpp/api/meat/DottedPairImpl.h: idem
+        * inst/include/Rcpp/internal/export.h: idem
+        * inst/include/Rcpp/proxy/DottedPairProxy.h: idem
+        * inst/include/Rcpp/proxy/SlotProxy.h: idem
+        * inst/include/Rcpp/vector/MatrixColumn.h: idem
+        * inst/include/Rcpp/vector/MatrixRow.h: idem
+        * inst/include/Rcpp/vector/Vector.h: idem
+
 2017-04-17  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/include/Rcpp/Rcpp/exceptions/cpp11/exceptions.h: Removed

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2017-04-20  James J Balamuta  <balamut2@illinois.edu>
+
+        * inst/include/Rcpp/api/meat/DottedPairImpl.h: Corrected format specifier
+        from '%s' to '%i'.
+
+
 2017-04-18  James J Balamuta  <balamut2@illinois.edu>
 
         * inst/include/Rcpp/vector/Matrix.h: Corrected exception throws from

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,7 +17,7 @@
       variadic templating for \code{Rcpp::stop} and \code{Rcpp::warning}
       (James Balamuta in \ghpr{676}).
       \item Exception messages have been rewritten to provide additional
-      information. (James Balamuta in \ghpr{676}, ?? addressing \ghit{184}).
+      information. (James Balamuta in \ghpr{676} and \ghpr{677} addressing \ghit{184}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -39,8 +39,10 @@ namespace Rcpp{
             try {
                 Shield<SEXP> res( Rcpp_eval( Rf_lang2( asEnvironmentSym, x ) ) );
                 return res ;
-            } catch( const eval_error& ex){
-                throw not_compatible( "cannot convert to environment"  ) ;
+            } catch( const eval_error& ex) {
+                const char* fmt = "Cannot convert object to an environment: "
+                                  "[type=%s; target=ENVSXP].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x)));
             }
         }
 
@@ -115,7 +117,7 @@ namespace Rcpp{
             }
             return res ;
         }
-        
+
         /**
         * Get an object from the environment
         *
@@ -126,16 +128,16 @@ namespace Rcpp{
         SEXP get(Symbol name) const {
             SEXP env = Storage::get__() ;
             SEXP res = Rf_findVarInFrame( env, name ) ;
-            
+
             if( res == R_UnboundValue ) return R_NilValue ;
-            
+
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
                 res = Rf_eval( res, env ) ;
             }
             return res ;
         }
-        
+
 
         /**
          * Get an object from the environment or one of its
@@ -157,7 +159,7 @@ namespace Rcpp{
             }
             return res ;
         }
-        
+
         /**
         * Get an object from the environment or one of its
         * parents
@@ -167,13 +169,13 @@ namespace Rcpp{
         SEXP find(Symbol name) const{
             SEXP env = Storage::get__() ;
             SEXP res = Rf_findVar( name, env ) ;
-            
+
             if( res == R_UnboundValue ) {
                 // Pass on the const char* to the RCPP_EXCEPTION_CLASS's
                 // const std::string& requirement
                 throw binding_not_found(name.c_str()) ;
             }
-            
+
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
                 res = Rf_eval( res, env ) ;

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -44,7 +44,10 @@ namespace Rcpp{
                 Storage::set__(x);
                 break;
             default:
-                throw not_compatible("cannot convert to function") ;
+                const char* fmt = "Cannot convert object to a function: "
+                                  "[type=%s; target=CLOSXP, SPECIALSXP, or "
+                                  "BUILTINSXP].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x)));
             }
         }
 
@@ -87,7 +90,7 @@ namespace Rcpp{
         SEXP environment() const {
             SEXP fun = Storage::get__() ;
             if( TYPEOF(fun) != CLOSXP ) {
-                throw not_a_closure() ;
+                throw not_a_closure(Rf_type2char(TYPEOF(fun)));
             }
             return CLOENV(fun) ;
         }

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -29,8 +29,11 @@ namespace Rcpp{
         RCPP_GENERATE_CTOR_ASSIGN(Promise_Impl)
 
         Promise_Impl( SEXP x){
-            if( TYPEOF(x) != PROMSXP)
-                throw not_compatible("not a promise") ;
+            if( TYPEOF(x) != PROMSXP) {
+                const char* fmt = "Not a promise: [type = %s].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x)));
+            }
+
             Storage::set__(x) ;
         }
 

--- a/inst/include/Rcpp/S4.h
+++ b/inst/include/Rcpp/S4.h
@@ -52,7 +52,7 @@ namespace Rcpp{
          * Creates an S4 object of the requested class.
          *
          * @param klass name of the target S4 class
-         * @throw not_s4 if klass does not map to a known S4 class
+         * @throw S4_creation_error if klass does not map to a known S4 class
          */
         S4_Impl( const std::string& klass ){
             Shield<SEXP> x( R_do_new_object(R_do_MAKE_CLASS(klass.c_str())) );
@@ -66,6 +66,9 @@ namespace Rcpp{
          */
         bool is( const std::string& clazz) const ;
 
+        /**
+         * @throw not_s4 if x is not an S4 class
+         */
         void update(SEXP x){
             if( ! ::Rf_isS4(x) ) throw not_s4() ;
         }

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -71,8 +71,13 @@ namespace Rcpp {
                 data = charsxp;
             }
 
-            if (::Rf_isString(data) && ::Rf_length(data) != 1)
-                throw ::Rcpp::not_compatible("expecting a single value");
+            if (::Rf_isString(data) && ::Rf_length(data) != 1) {
+                const char* fmt = "Expecting a single string value: "
+                                  "[type=%s; extent=%i].";
+                throw ::Rcpp::not_compatible(fmt,
+                                             Rf_type2char(TYPEOF(data)),
+                                             ::Rf_length(data));
+            }
 
             valid = true;
             buffer_ready = false;

--- a/inst/include/Rcpp/Symbol.h
+++ b/inst/include/Rcpp/Symbol.h
@@ -62,7 +62,9 @@ namespace Rcpp{
                 break ;
             }
             default:
-                throw not_compatible("cannot convert to symbol (SYMSXP)") ;
+                const char* fmt = "Cannot convert object to a symbol: "
+                                  "[type=%s; target=SYMSXP].";
+                throw not_compatible(fmt, Rf_type2char(TYPEOF(x)));
             }
         }
 

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -64,8 +64,11 @@ public:
      * @param xp external pointer to wrap
      */
     explicit XPtr(SEXP x, SEXP tag = R_NilValue, SEXP prot = R_NilValue) {
-        if( TYPEOF(x) != EXTPTRSXP )
-            throw ::Rcpp::not_compatible( "expecting an external pointer" ) ;
+        if( TYPEOF(x) != EXTPTRSXP ) {
+            const char* fmt = "Expecting an external pointer: [type=%s].";
+            throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
+        }
+
         Storage::set__(x) ;
         R_SetExternalPtrTag( x, tag ) ;
         R_SetExternalPtrProtected( x, prot ) ;

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -57,7 +57,7 @@ namespace Rcpp{
 
 			if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) {
 			    const char* fmt = "Dotted Pair index is out of bounds: "
-			                      "[index=%s; extent=%s].";
+			                      "[index=%i; extent=%i].";
 
 			    throw index_out_of_bounds(fmt,
                                           static_cast<R_xlen_t>(index),

--- a/inst/include/Rcpp/api/meat/DottedPairImpl.h
+++ b/inst/include/Rcpp/api/meat/DottedPairImpl.h
@@ -51,9 +51,18 @@ namespace Rcpp{
         if( index == 0 ) {
 			push_front( object ) ;
 		} else {
-			if( ref.isNULL( ) ) throw index_out_of_bounds() ;
+			if( ref.isNULL( ) ) {
+			    throw index_out_of_bounds("Object being inserted into Dotted Pair is null.");
+			}
 
-                        if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+			if( static_cast<R_xlen_t>(index) > ::Rf_xlength(ref.get__()) ) {
+			    const char* fmt = "Dotted Pair index is out of bounds: "
+			                      "[index=%s; extent=%s].";
+
+			    throw index_out_of_bounds(fmt,
+                                          static_cast<R_xlen_t>(index),
+                                          ::Rf_xlength(ref.get__()) ) ;
+			}
 
 			size_t i=1;
 			SEXP x = ref.get__() ;
@@ -70,7 +79,14 @@ namespace Rcpp{
     template <typename T>
 	void DottedPairImpl<CLASS>::replace( const int& index, const T& object ) {
 	    CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= ::Rf_xlength(ref.get__()) ) {
+            const char* fmt = "Dotted Pair index is out of bounds: "
+                              "[index=%i; extent=%i].";
+
+            throw index_out_of_bounds(fmt,
+                                      static_cast<R_xlen_t>(index),
+                                      ::Rf_xlength(ref.get__()) ) ;
+        }
 
         Shield<SEXP> x( pairlist( object ) );
         SEXP y = ref.get__() ;
@@ -84,7 +100,15 @@ namespace Rcpp{
 	template <typename CLASS>
     void DottedPairImpl<CLASS>::remove( const size_t& index ) {
         CLASS& ref = static_cast<CLASS&>(*this) ;
-        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) throw index_out_of_bounds() ;
+        if( static_cast<R_xlen_t>(index) >= Rf_xlength(ref.get__()) ) {
+            const char* fmt = "Dotted Pair index is out of bounds: "
+                              "[index=%i; extent=%i].";
+
+            throw index_out_of_bounds(fmt,
+                                      static_cast<R_xlen_t>(index),
+                                      ::Rf_xlength(ref.get__()) ) ;
+        }
+
         if( index == 0 ){
             ref.set__( CDR( ref.get__() ) ) ;
         } else{

--- a/inst/include/Rcpp/as.h
+++ b/inst/include/Rcpp/as.h
@@ -29,7 +29,10 @@ namespace Rcpp {
     namespace internal {
 
         template <typename T> T primitive_as(SEXP x) {
-            if (::Rf_length(x) != 1) throw ::Rcpp::not_compatible("expecting a single value");
+            if (::Rf_length(x) != 1) {
+                const char* fmt = "Expecting a single value: [extent=%i].";
+                throw ::Rcpp::not_compatible(fmt, ::Rf_length(x));
+            }
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<T>::rtype;
             Shield<SEXP> y(r_cast<RTYPE>(x));
             typedef typename ::Rcpp::traits::storage_type<RTYPE>::type STORAGE;
@@ -43,10 +46,14 @@ namespace Rcpp {
 
         inline const char* check_single_string(SEXP x) {
             if (TYPEOF(x) == CHARSXP) return CHAR(x);
-            if (! ::Rf_isString(x))
-                throw ::Rcpp::not_compatible("expecting a string");
-            if (Rf_length(x) != 1)
-                throw ::Rcpp::not_compatible("expecting a single value");
+            if (! ::Rf_isString(x) || Rf_length(x) != 1) {
+                const char* fmt = "Expecting a single string value: "
+                                  "[type=%s; extent=%i].";
+                throw ::Rcpp::not_compatible(fmt,
+                                             Rf_type2char(TYPEOF(x)),
+                                             Rf_length(x));
+            }
+
             return CHAR(STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0));
         }
 
@@ -66,10 +73,11 @@ namespace Rcpp {
 
         template <typename T> T as(SEXP x, ::Rcpp::traits::r_type_RcppString_tag) {
             if (! ::Rf_isString(x)) {
-                throw ::Rcpp::not_compatible("expecting a string");
-            }
-            if (Rf_length(x) != 1) {
-                throw ::Rcpp::not_compatible("expecting a single value");
+                const char* fmt = "Expecting a single string value: "
+                                  "[type=%s; extent=%i].";
+                throw ::Rcpp::not_compatible(fmt,
+                                             Rf_type2char(TYPEOF(x)),
+                                             Rf_length(x));
             }
             return STRING_ELT(::Rcpp::r_cast<STRSXP>(x), 0);
         }

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -79,7 +79,12 @@ namespace Rcpp{
 
 		template <typename InputIterator, typename value_type>
 		void export_range__dispatch( SEXP x, InputIterator first, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw ::Rcpp::not_compatible( "expecting a string vector" ) ;
+			if( ! ::Rf_isString( x) ) {
+			    const char* fmt = "Expecting a string vector: "
+			                      "[type=%s; required=STRSXP].";
+			    throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)) );
+			}
+
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++, ++first ){
 				*first = as_string_elt<typename std::iterator_traits<InputIterator>::value_type> ( x, i ) ;
@@ -133,7 +138,12 @@ namespace Rcpp{
 
 		template <typename T, typename value_type>
 		void export_indexing__dispatch( SEXP x, T& res, ::Rcpp::traits::r_type_string_tag ) {
-			if( ! ::Rf_isString( x) ) throw Rcpp::not_compatible( "expecting a string vector" ) ;
+			if( ! ::Rf_isString( x) ) {
+			    const char* fmt = "Expecting a string vector: "
+			                      "[type=%s; required=STRSXP].";
+			    throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)) );
+			}
+
 			R_xlen_t n = ::Rf_xlength(x) ;
 			for( R_xlen_t i=0; i<n; i++ ){
 				res[i] = as_string_elt< value_type >( x, i) ;

--- a/inst/include/Rcpp/proxy/DottedPairProxy.h
+++ b/inst/include/Rcpp/proxy/DottedPairProxy.h
@@ -27,7 +27,12 @@ public:
     	class DottedPairProxy : public GenericProxy<DottedPairProxy> {
 	public:
 		DottedPairProxy( CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds() ;
+            if( index_ >= v.length() ) {
+                const char* fmt = "Dotted Pair index is out of bounds: "
+                                  "[index=%i; extent=%i].";
+                throw index_out_of_bounds(fmt, index_, v.length());
+            }
+
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;
@@ -72,7 +77,12 @@ public:
 	class const_DottedPairProxy : public GenericProxy<const_DottedPairProxy>{
 	public:
 		const_DottedPairProxy( const CLASS& v, int index_ ): node(R_NilValue){
-            if( index_ >= v.length() ) throw index_out_of_bounds() ;
+            if( index_ >= v.length() )  {
+                const char* fmt = "Dotted Pair index is out of bounds: "
+                                  "[index=%i; extent=%i].";
+                throw index_out_of_bounds(fmt, index_, v.length());
+            }
+
             SEXP x = v ; /* implicit conversion */
             for( int i = 0; i<index_; i++, x = CDR(x) ) ;
             node = x ;

--- a/inst/include/Rcpp/proxy/SlotProxy.h
+++ b/inst/include/Rcpp/proxy/SlotProxy.h
@@ -28,7 +28,7 @@ public:
     public:
         SlotProxy( CLASS& v, const std::string& name) : parent(v), slot_name(Rf_install(name.c_str())) {
             if( !R_has_slot( v, slot_name) ){
-                throw no_such_slot() ;
+                throw no_such_slot(name);
             }
         }
 
@@ -60,7 +60,7 @@ public:
     public:
         const_SlotProxy( const CLASS& v, const std::string& name) : parent(v), slot_name(Rf_install(name.c_str())) {
             if( !R_has_slot( v, slot_name) ){
-                throw no_such_slot() ;
+                throw no_such_slot(name);
             }
         }
 

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -53,7 +53,7 @@ public:
     Matrix(SEXP x) : VECTOR( r_cast<RTYPE>( x ) ), nrows( VECTOR::dims()[0] ) {}
 
     Matrix( const Dimension& dims) : VECTOR( Rf_allocMatrix( RTYPE, dims[0], dims[1] ) ), nrows(dims[0]) {
-        if( dims.size() != 2 ) throw not_compatible("not a matrix") ;
+        if( dims.size() != 2 ) throw not_a_matrix();
         VECTOR::init() ;
     }
     Matrix( const int& nrows_, const int& ncols) : VECTOR( Dimension( nrows_, ncols ) ),
@@ -82,7 +82,7 @@ public:
 
     Matrix& operator=(const Matrix& other) {
         SEXP x = other.get__() ;
-        if( ! ::Rf_isMatrix(x) ) not_compatible("not a matrix") ;
+        if( ! ::Rf_isMatrix(x) ) throw not_a_matrix();
         VECTOR::set__( x ) ;
         nrows = other.nrows ;
         return *this ;

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -39,7 +39,11 @@ public:
         start(parent.begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(const_cast<const MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Column index is out of bounds: "
+                              "[index=%i; column extent=%i].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     MatrixColumn( const MATRIX& parent, int i ) :
@@ -47,7 +51,11 @@ public:
         start( const_cast<MATRIX&>(parent).begin() + static_cast<R_xlen_t>(i) * n ),
         const_start(parent.begin() + static_cast<R_xlen_t>(i) * n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Column index is out of bounds: "
+                              "[index=%i; column extent=%i].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     MatrixColumn( const MatrixColumn& other ) :
@@ -115,13 +123,17 @@ public:
         n(parent.nrow()),
         const_start(parent.begin() + i *n)
     {
-        if( i < 0 || i >= parent.ncol() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.ncol() ) {
+            const char* fmt = "Column index is out of bounds: "
+                              "[index=%i; column extent=%i].";
+            throw index_out_of_bounds(fmt, i, parent.ncol()) ;
+        }
     }
 
     ConstMatrixColumn( const ConstMatrixColumn& other ) :
         n(other.n),
         const_start(other.const_start) {}
-        
+
     inline const_Proxy operator[]( int i ) const {
         return const_start[i] ;
     }

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -107,7 +107,11 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.nrow() ) {
+            const char* fmt = "Row index is out of bounds: "
+                              "[index=%i; row extent=%i].";
+            throw index_out_of_bounds(fmt, i, parent.nrow()) ;
+        }
     }
 
     MatrixRow( const MatrixRow& other ) :
@@ -245,7 +249,7 @@ public:
         const ConstMatrixRow& row ;
         int index ;
     } ;
-    
+
     typedef const_iterator iterator;
 
     ConstMatrixRow( const MATRIX& object, int i ) :
@@ -254,7 +258,11 @@ public:
         parent_nrow(parent.nrow()),
         row(i)
     {
-        if( i < 0 || i >= parent.nrow() ) throw index_out_of_bounds() ;
+        if( i < 0 || i >= parent.nrow() ) {
+            const char* fmt = "Row index is out of bounds: "
+                              "[index=%i; row extent=%i].";
+            throw index_out_of_bounds(fmt, i, parent.nrow()) ;
+        }
     }
 
     ConstMatrixRow( const ConstMatrixRow& other ) :

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -116,15 +116,15 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, siz) ) ;
         std::generate( begin(), end(), gen );
     }
-    
+
     // Add template class T and then restict T to arithmetic.
     template <typename T>
-    Vector(T size, 
+    Vector(T size,
         typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
     }
-    
+
     Vector( const int& size ) {
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         init() ;
@@ -163,7 +163,7 @@ public:
         RCPP_DEBUG_2( "Vector<%d>( const VectorBase<RTYPE,NA,VEC>& ) [VEC = %s]", RTYPE, DEMANGLE(VEC) )
         import_sugar_expression( other, typename traits::same_type<Vector,VEC>::type() ) ;
     }
-    
+
     template <typename T, typename U>
     Vector( const T& size, const U& u,
         typename Rcpp::traits::enable_if<traits::is_arithmetic<T>::value, void>::type* = 0) {
@@ -171,7 +171,7 @@ public:
         Storage::set__( Rf_allocVector( RTYPE, size) ) ;
         fill_or_generate( u ) ;
     }
-    
+
     template <bool NA, typename T>
     Vector( const sugar::SingleLogicalResult<NA,T>& obj ) {
         Storage::set__( r_cast<RTYPE>( const_cast<sugar::SingleLogicalResult<NA,T>&>(obj).get_sexp() ) ) ;
@@ -285,7 +285,12 @@ public:
         const int* dim = dims() ;
         const int nrow = dim[0] ;
         const int ncol = dim[1] ;
-        if(i < 0|| i >= nrow || j < 0 || j >= ncol ) throw index_out_of_bounds() ;
+        if(i < 0|| i >= nrow || j < 0 || j >= ncol )  {
+            const char* fmt = "Location index is out of bounds: "
+                              "[row index=%i; row extent=%i; "
+                              "column index=%i; column extent=%i].";
+            throw index_out_of_bounds(fmt, i, nrow, j, ncol);
+        }
         return i + static_cast<R_xlen_t>(nrow)*j ;
     }
 
@@ -297,17 +302,22 @@ public:
         if(i < 0 || i >= ::Rf_xlength(Storage::get__()) ) throw index_out_of_bounds() ;
         return i ;
     }
-    
+
     R_xlen_t offset(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES( Storage::get__() ) ;
-        if( Rf_isNull(names) ) throw index_out_of_bounds();
+        if( Rf_isNull(names) ) {
+            throw index_out_of_bounds("Object was created without names.");
+        }
+
         R_xlen_t n=size() ;
         for( R_xlen_t i=0; i<n; ++i){
             if( ! name.compare( CHAR(STRING_ELT(names, i)) ) ){
                 return i ;
             }
         }
-        throw index_out_of_bounds() ;
+
+        const char* fmt = "Index out of bounds: [index='%s'].";
+        throw index_out_of_bounds(fmt, name);
         return -1 ; /* -Wall */
     }
 
@@ -389,21 +399,21 @@ public:
         // and is undefined for other types. Hence there will be a
         // compiler error when sorting List, RawVector or ExpressionVector.
         internal::Sort_is_not_allowed_for_this_type<RTYPE>::do_nothing();
-        
+
         typename traits::storage_type<RTYPE>::type* start = internal::r_vector_start<RTYPE>( Storage::get__() );
-        
+
         if (!decreasing) {
             std::sort(
                 start,
                 start + size(),
                 internal::NAComparator<typename traits::storage_type<RTYPE>::type>()
-            );            
+            );
         } else {
             std::sort(
                 start,
                 start + size(),
                 internal::NAComparatorGreater<typename traits::storage_type<RTYPE>::type>()
-            );     
+            );
         }
 
         return *this;
@@ -905,7 +915,21 @@ private:
     }
 
     iterator erase_single__impl( iterator position ) {
-              if( position < begin() || position > end() ) throw index_out_of_bounds( ) ;
+        if( position < begin() || position > end() ) {
+            R_xlen_t requested_loc;
+            R_xlen_t available_locs = std::distance(begin(), end());
+
+            if(position > end()){
+                requested_loc = std::distance(position, begin());
+            } else {
+                // This will be a negative number
+                requested_loc = std::distance(begin(), position);
+            }
+            const char* fmt = "Iterator index is out of bounds: "
+                              "[iterator index=%i; iterator extent=%i]";
+            throw index_out_of_bounds(fmt, requested_loc, available_locs ) ;
+        }
+
         R_xlen_t n = size() ;
         Vector target( n - 1 ) ;
         iterator target_it(target.begin()) ;
@@ -945,7 +969,24 @@ private:
 
     iterator erase_range__impl( iterator first, iterator last ) {
         if( first > last ) throw std::range_error("invalid range") ;
-        if( last > end() || first < begin() ) throw index_out_of_bounds() ;
+        if( last > end() || first < begin() ) {
+            R_xlen_t requested_loc;
+            R_xlen_t available_locs = std::distance(begin(), end());
+            std::string iter_problem;
+
+            if(last > end()){
+                requested_loc = std::distance(last, begin());
+                iter_problem = "last";
+            } else {
+                // This will be a negative number
+                requested_loc = std::distance(begin(), first);
+                iter_problem = "first";
+            }
+            const char* fmt = "Iterator index is out of bounds: "
+                              "[iterator=%s; index=%i; extent=%i]";
+            throw index_out_of_bounds(fmt, iter_problem,
+                                      requested_loc, available_locs ) ;
+        }
 
         iterator it = begin() ;
         iterator this_end = end() ;


### PR DESCRIPTION
This is PR 3 of 3.

The objective of this PR is to upgrade existing exception messages that were identified in #184 as being candidates for dynamic information. 

(PR 1 (#674) included the upstream refresh of the tinyformat library. PR 2 (#676) put in place the exception infrastructure used in this build.)

-------

Changes:

- Upgraded exceptions as highlighted by the table in #184
- Corrected exception throws from `not_compatible()` to `not_a_matrix()` in `Matrix.h` (one was missing a `throw`!)
- Corrected doxygen documentation in S4 regarding error thrown.