### PR TITLE
Remove dynamic exception specification (closes #689)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 
         * DESCRIPTION (Version, Date): Roll minor version again
 
+        * inst/include/Rcpp/module/Module_Property.h: Remove two typed exception
+        specifications which upset g++ 7.1 or higher
+
 2017-05-05  Kirill Müller <krlmlr@mailbox.org>
 
         * inst/include/Rcpp/date_datetime/Date.h: Suppress -Wconversion warnings

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -23,6 +23,9 @@
       collection (Dirk in \ghpr{684} addressing \ghit{683}).
       \item Several compiler warnings for \code{-Wconversions} are no longer
       generated (Kirill Mueller in \ghpr{687} and \ghpr{688})
+      \item Two exception specification that are no longer tolerated by
+      \code{g++-7.1} or later were removed (Dirk in \ghpr{690} addressing
+      \ghit{689})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/module/Module_Property.h
+++ b/inst/include/Rcpp/module/Module_Property.h
@@ -2,7 +2,7 @@
 //
 // Module_Property.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -100,7 +100,7 @@ public:
     SEXP get(Class* object) {
         return Rcpp::wrap( (object->*getter)() ) ;
     }
-    void set(Class* object, SEXP value) throw(std::range_error,Rcpp::not_compatible){
+    void set(Class* object, SEXP value) {
         (object->*setter)(
                           Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
                            ) ;
@@ -158,7 +158,7 @@ public:
     SEXP get(Class* object) {
         return Rcpp::wrap( (object->*getter)() ) ;
     }
-    void set(Class* object, SEXP value) throw(std::range_error,Rcpp::not_compatible){
+    void set(Class* object, SEXP value) {
         setter( object,
                 Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
                 ) ;

--- a/inst/include/Rcpp/module/Module_Property.h
+++ b/inst/include/Rcpp/module/Module_Property.h
@@ -26,120 +26,116 @@
 template <typename Class, typename PROP>
 class CppProperty_GetMethod : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetMethod( GetMethod getter_, const char* doc = 0 ) :
+    CppProperty_GetMethod(GetMethod getter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), class_name(DEMANGLE(PROP)){}
 
-    SEXP get(Class* object) { return Rcpp::wrap( (object->*getter)() ) ; }
-    void set(Class*, SEXP) { throw std::range_error("property is read only") ; }
-    bool is_readonly(){ return true ; }
+    SEXP get(Class* object) { return Rcpp::wrap((object->*getter)()); }
+    void set(Class*, SEXP) { throw std::range_error("property is read only"); }
+    bool is_readonly(){ return true; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    std::string class_name ;
+    GetMethod getter;
+    std::string class_name;
 
-} ;
+};
 
 // getter through a const member function
 template <typename Class, typename PROP>
 class CppProperty_GetConstMethod : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) const ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void) const;
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetConstMethod( GetMethod getter_ , const char* doc = 0) :
+    CppProperty_GetConstMethod(GetMethod getter_ , const char* doc = 0) :
         prop_class(doc), getter(getter_), class_name(DEMANGLE(PROP)){}
 
-    SEXP get(Class* object) { return Rcpp::wrap( (object->*getter)() ) ; }
-    void set(Class*, SEXP) { throw std::range_error("property is read only") ; }
-    bool is_readonly(){ return true ; }
+    SEXP get(Class* object) { return Rcpp::wrap((object->*getter)()); }
+    void set(Class*, SEXP) { throw std::range_error("property is read only"); }
+    bool is_readonly(){ return true; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    std::string class_name ;
+    GetMethod getter;
+    std::string class_name;
 
-} ;
+};
 
 
 // getter through a free function taking a pointer to Class
 template <typename Class, typename PROP>
 class CppProperty_GetPointerMethod : public CppProperty<Class> {
 public:
-    typedef PROP (*GetMethod)(Class*) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (*GetMethod)(Class*);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetPointerMethod( GetMethod getter_ , const char* doc = 0) :
+    CppProperty_GetPointerMethod(GetMethod getter_ , const char* doc = 0) :
         prop_class(doc), getter(getter_), class_name(DEMANGLE(PROP)){}
 
-    SEXP get(Class* object) { return Rcpp::wrap( getter(object) ) ; }
-    void set(Class*, SEXP) { throw std::range_error("property is read only") ; }
-    bool is_readonly(){ return true ; }
+    SEXP get(Class* object) { return Rcpp::wrap(getter(object)); }
+    void set(Class*, SEXP) { throw std::range_error("property is read only"); }
+    bool is_readonly(){ return true; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    std::string class_name ;
-} ;
+    GetMethod getter;
+    std::string class_name;
+};
 
 
 // getter and setter through member functions
 template <typename Class, typename PROP>
 class CppProperty_GetMethod_SetMethod : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) ;
-    typedef void (Class::*SetMethod)(PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void);
+    typedef void (Class::*SetMethod)(PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetMethod_SetMethod( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetMethod_SetMethod(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( (object->*getter)() ) ;
+        return Rcpp::wrap((object->*getter)());
     }
     void set(Class* object, SEXP value) {
-        (object->*setter)(
-                          Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                           ) ;
+        (object->*setter)(Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
-} ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
+};
 template <typename Class, typename PROP>
 class CppProperty_GetConstMethod_SetMethod : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) const ;
-    typedef void (Class::*SetMethod)(PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void) const;
+    typedef void (Class::*SetMethod)(PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetConstMethod_SetMethod( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetConstMethod_SetMethod(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( (object->*getter)() ) ;
+        return Rcpp::wrap((object->*getter)());
     }
     void set(Class* object, SEXP value) {
-        (object->*setter)(
-                          Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                           ) ;
+        (object->*setter)(Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
 
-} ;
+};
 
 
 
@@ -148,116 +144,108 @@ private:
 template <typename Class, typename PROP>
 class CppProperty_GetMethod_SetPointer : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) ;
-    typedef void (*SetMethod)(Class*,PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void);
+    typedef void (*SetMethod)(Class*,PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetMethod_SetPointer( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetMethod_SetPointer(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( (object->*getter)() ) ;
+        return Rcpp::wrap((object->*getter)());
     }
     void set(Class* object, SEXP value) {
-        setter( object,
-                Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                ) ;
+        setter(object, Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
 
-} ;
+};
 template <typename Class, typename PROP>
 class CppProperty_GetConstMethod_SetPointer : public CppProperty<Class> {
 public:
-    typedef PROP (Class::*GetMethod)(void) const ;
-    typedef void (*SetMethod)(Class*,PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (Class::*GetMethod)(void) const;
+    typedef void (*SetMethod)(Class*,PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetConstMethod_SetPointer( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetConstMethod_SetPointer(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( (object->*getter)() ) ;
+        return Rcpp::wrap((object->*getter)());
     }
     void set(Class* object, SEXP value) {
-        setter( object,
-                Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                ) ;
+        setter(object, Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
 
-} ;
+};
 
 // getter through pointer function, setter through member function
 template <typename Class, typename PROP>
 class CppProperty_GetPointer_SetMethod : public CppProperty<Class> {
 public:
-    typedef PROP (*GetMethod)(Class*) ;
-    typedef void (Class::*SetMethod)(PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (*GetMethod)(Class*);
+    typedef void (Class::*SetMethod)(PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetPointer_SetMethod( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetPointer_SetMethod(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( getter(object) ) ;
+        return Rcpp::wrap(getter(object));
     }
     void set(Class* object, SEXP value) {
-        (object->*setter)(
-                          Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                           ) ;
+        (object->*setter)(Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
 
-} ;
+};
 
 // getter and setter through pointer functions
 // getter through pointer function, setter through member function
 template <typename Class, typename PROP>
 class CppProperty_GetPointer_SetPointer : public CppProperty<Class> {
 public:
-    typedef PROP (*GetMethod)(Class*) ;
-    typedef void (*SetMethod)(Class*,PROP) ;
-    typedef CppProperty<Class> prop_class ;
+    typedef PROP (*GetMethod)(Class*);
+    typedef void (*SetMethod)(Class*,PROP);
+    typedef CppProperty<Class> prop_class;
 
-    CppProperty_GetPointer_SetPointer( GetMethod getter_, SetMethod setter_, const char* doc = 0) :
+    CppProperty_GetPointer_SetPointer(GetMethod getter_, SetMethod setter_, const char* doc = 0) :
         prop_class(doc), getter(getter_), setter(setter_), class_name(DEMANGLE(PROP)){}
 
     SEXP get(Class* object) {
-        return Rcpp::wrap( getter(object) ) ;
+        return Rcpp::wrap(getter(object));
     }
     void set(Class* object, SEXP value) {
-        setter( object,
-                Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >( value )
-                ) ;
+        setter(object, Rcpp::as< typename Rcpp::traits::remove_const_and_reference< PROP >::type >(value));
     }
-    bool is_readonly(){ return false ; }
+    bool is_readonly(){ return false; }
     std::string get_class(){ return class_name; }
 
 private:
-    GetMethod getter ;
-    SetMethod setter ;
-    std::string class_name ;
+    GetMethod getter;
+    SetMethod setter;
+    std::string class_name;
 
-} ;
+};
 
 
 #endif


### PR DESCRIPTION
Two commits in here: 
- the first is narrow and just removes the dynamic exception mechanism as discussed in #689 
- the second looks invasive but just removes a bunch of spaces.