### PR TITLE
create src/init.c for skeleton

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-05-09  Dirk Eddelbuettel  <edd@debian.org>
+
+        * R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Under R 3.4.0, run
+        tools::package_native_routine_registration_skeleton to create src/init.c
+
 2017-05-07  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version again

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -41,6 +41,11 @@
       later expects; a plugin for C++98 was added (Dirk in \ghpr{684} addressing
       \ghit{683}).
     }
+    \item Changes in Rcpp support functions:
+    \itemize{
+      \item The \code{Rcpp.package.skeleton()} function now create a package
+      registration file provided R 3.4.0 or later is used
+    }
   }
 }
 


### PR DESCRIPTION
This lets `Rcpp.package.skeleton()` create `src/init.c` (by making the required call).

Should `compileAttributes()` do that too?