### PR TITLE
Register native routines automatically within compileAttributes 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-05-16  JJ Allaire  <jj@rstudio.com>
+
+        * R/Attributes.R: Automatically generate native routine registrations.
+        * src/attributes.cpp: Automatically generate native routine registrations.
+        * R/Rcpp.package.skeleton.R: Don't generate native routines when creating
+        a package using attributes.
+
 2017-05-09  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Under R 3.4.0, run

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.10.4
+Version: 0.12.10.5
 Date: 2017-05-07
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -404,6 +404,13 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
     depends <- unique(.splitDepends(depends))
     depends <- depends[depends != "R"]
 
+    # check the NAMESPACE file to see if dynamic registration is enabled
+    namespaceFile <- file.path(pkgdir, "NAMESPACE")
+    if (!file.exists(namespaceFile))
+        stop("pkgdir must refer to the directory containing an R package")
+    pkgNamespace <- readLines(namespaceFile, warn = FALSE)
+    registration <- any(grepl("^\\s*useDynLib.*\\.registration\\s*=\\s*TRUE.*$", pkgNamespace))
+
     # determine source directory
     srcDir <- file.path(pkgdir, "src")
     if (!file.exists(srcDir))
@@ -449,7 +456,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
 
     # generate exports
     invisible(.Call("compileAttributes", PACKAGE="Rcpp",
-                    pkgdir, pkgname, depends, cppFiles, cppFileBasenames,
+                    pkgdir, pkgname, depends, registration, cppFiles, cppFileBasenames,
                     includes, verbose, .Platform))
 }
 

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -422,7 +422,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
         dir.create(rDir)
 
     # get a list of all source files
-    cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp))|(h(pp)?))$")
+    cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp)?)|(h(pp)?))$")
 
     # derive base names (will be used for modules)
     cppFileBasenames <- tools::file_path_sans_ext(cppFiles)

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -185,7 +185,9 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
         message(" >> copied the example module file ")
     }
 
-    if (getRversion() >= "3.4.0") {
+    # generate native routines if we aren't using attributes (which already generate
+    # them automatically) and we have at least R 3.4
+    if (!attributes && getRversion() >= "3.4.0") {
         con <- file(file.path(src, "init.c"), "wt")
         tools::package_native_routine_registration_skeleton(root, con=con)
         close(con)

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -187,13 +187,15 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
 
     # generate native routines if we aren't using attributes (which already generate
     # them automatically) and we have at least R 3.4
-    if (!attributes && getRversion() >= "3.4.0") {
-        con <- file(file.path(src, "init.c"), "wt")
-        tools::package_native_routine_registration_skeleton(root, con=con)
-        close(con)
-        message(" >> created init.c for package registration")
-    } else {
-        message(" >> R version older than 3.4.0 detected, so NO file init.c created.")
+    if (!attributes) {
+        if (getRversion() >= "3.4.0") {
+            con <- file(file.path(src, "init.c"), "wt")
+            tools::package_native_routine_registration_skeleton(root, con=con)
+            close(con)
+            message(" >> created init.c for package registration")
+        } else {
+            message(" >> R version older than 3.4.0 detected, so NO file init.c created.")
+        }
     }
 
     lines <- readLines(package.doc <- file.path( root, "man", sprintf("%s-package.Rd", name)))

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -40,6 +40,7 @@
     }
     \item Changes in Rcpp Attributes:
     \itemize{
+      \item Automatically generate native routine registrations.
       \item The plugins for C++11, C++14, C++17 now set the values R 3.4.0 or
       later expects; a plugin for C++98 was added (Dirk in \ghpr{684} addressing
       \ghit{683}).

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1958,6 +1958,11 @@ namespace attributes {
          if (!hasPackageInit && !nativeRoutines_.empty()) {
             ostr() << std::endl;
             ostr() << "static const R_CallMethodDef CallEntries[] = {" << std::endl;
+            if (hasCppInterface()) {
+                ostr() << "    {\"" << registerCCallableExportedName() << "\", " <<
+                    "(DL_FUNC) &" << registerCCallableExportedName()  << ", " <<
+                    0 <<  "}," << std::endl;
+            }
             for (std::size_t i=0;i<nativeRoutines_.size(); i++) {
                 const Attribute& attr = nativeRoutines_[i];
                 std::string routine = package() + "_" + attr.exportedName();


### PR DESCRIPTION
There are two main components here:

1. Use the metadata that we already have within `compileAttributes` to automatically emit a package init function that registers all exported C++ functions with R via `R_registerRoutines`.

    Note that users have been doing this manually for several months and some packages may already have an init function for other reasons. Consequently, we only do automatic registration if no existing package init function is found.

2. Registering native functions and calling `useDynLib(foo, .registration = TRUE)` is actually not sufficient to have R wrappers *bind to* the registered routines. To do that we actually need to generate this code:

    ```r
    .Call(reticulate_py_is_none, x)
    ```

    Rather than this code:

     ```r
     .Call('reticulate_py_is_none', PACKAGE = 'reticulate', x)
     ```

     Note that we only want to generate the former code when the user has included `.registration = TRUE` (otherwise the routines won't be present in the package namespace). As a result, we scan the `NAMESPACE` file for `useDynLib(pkgname, .registration = TRUE)` and only generate R wrappers of that form if it's found.

Relevant documentation from *Writing R Extensions* is here: https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Registering-native-routines

Of particular interest is the bit about `R_useDynamicSymbols(info, FALSE)`. My reading of this is that by calling this you are saying that it still okay to to use this syntax:

```r
.Call('reticulate_py_is_none', PACKAGE = 'reticulate', x)
```

However, *only if* the symbol has been registered. This is important for us because we are now going to always pass `FALSE` to `R_useDynamicSymbols`, and we don't want that to break packages that in turn neglect to pass `.registration = TRUE` to `useDynLib`. Since we register all the Rcpp exported functions they will work using either the character based or symbol based `.Call` lookup.

This branch of the reticulate package demonstrates the change in code generation that occurs:

https://github.com/rstudio/reticulate/compare/feature/register-native-routines

Note that we've changed our `@useDynLib` roxygen to:

```
#' @useDynLib reticulate, .registration=TRUE
```

And that we've removed entirely the `init.cpp` file previously provided as a stub to pass CRAN tests.





     
