### PR TITLE
use pkg dir rather that getwd() for native routine registration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-05-23  JJ Allaire  <jj@rstudio.com>
+
+        * R/Attributes.R: Execute tools::package_native_routine_registration_skeleton
+          within package rather than current working directory.
+        * src/attributes.cpp: Execute tools::package_native_routine_registration_skeleton
+          within package rather than current working directory.
+
 2017-05-22  Dirk Eddelbuettel  <edd@debian.org>
 
         * R/inline.R (Rcpp.plugin.maker): Whitespace changes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.11
+Version: 0.12.11.1
 Date: 2017-05-20
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1154,7 +1154,7 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
     as.character(token)
 }
 
-.extraRoutineRegistrations <- function(routines) {
+.extraRoutineRegistrations <- function(targetFile, routines) {
 
     declarations = character()
     call_entries = character()
@@ -1163,11 +1163,14 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
     # to automatically discover additional native routines that require registration
     if (getRversion() >= "3.4") {
 
+        # determine the package directory
+        pkgdir <- dirname(dirname(targetFile))
+
         # get the generated code from R
         con <- textConnection(object = NULL, open = "w")
         on.exit(close(con), add = TRUE)
         tools::package_native_routine_registration_skeleton(
-            dir = ".",
+            dir = pkgdir,
             con = con,
             character_only = FALSE
         )

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,16 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
+\section{Changes in Rcpp version 0.12.12 (Unreleased)}{
+  \itemize{
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      \item Execute tools::package_native_routine_registration_skeleton
+      within package rather than current working directory.
+    }
+  }
+}
+
 \section{Changes in Rcpp version 0.12.11 (2017-05-20)}{
   \itemize{
     \item Changes in Rcpp API:

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1972,7 +1972,7 @@ namespace attributes {
 
             // see if there are additional registrations to perform
             Rcpp::Function extraRoutinesFunc = Environment::namespace_env("Rcpp")[".extraRoutineRegistrations"];
-            List extraRoutines = extraRoutinesFunc(routineNames);
+            List extraRoutines = extraRoutinesFunc(targetFile(), routineNames);
             std::vector<std::string> declarations = extraRoutines["declarations"];
             std::vector<std::string> callEntries = extraRoutines["call_entries"];
 


### PR DESCRIPTION
Execute tools::package_native_routine_registration_skeleton within package rather than current working directory.

Typically `compileAttributes` is called with the package directory as the current working directory. However, it can be invoked via e.g. `compileAttributes(pkgdir = "foo")`. In that case we were calling `tools::package_native_routine_registration_skeleton` in the current working directory rather than in the specified `pkgdir`. This would result in missing registrations (or over-registrations if the current directory happened to be another package).

The bug should not affect most normal uses of `compileAttributes` so there isn't a need to do a patch release for this fix.