### PR TITLE
Do not use dir.exists to retain backwards-compatibility

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1129,7 +1129,7 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
                            R.version$platform,
                            utils::packageVersion("Rcpp"),
                            sep = "-"))
-    if (!dir.exists(dir))
+    if (!utils::file_test("-d", dir))
         dir.create(dir, recursive = TRUE)
 
     dir


### PR DESCRIPTION
The file R/Attributes.R uses the function `dir.exists()` which
was only added in R 3.2.0. The relevant line was added to
R/Attributes.R between 0.12.5 and 0.12.6.