### PR TITLE
Automatically register init functions for RcppModules (closes #704)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2017-06-02  JJ Allaire  <jj@rstudio.com>
 
         * src/attributes.cpp: Automatically register init functions for RcppModules
+        * R/Rcpp.package.skeleton.R: compileAttributes only after all code is generated
 
 2017-06-01  JJ Allaire  <jj@rstudio.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-06-02  JJ Allaire  <jj@rstudio.com>
+
+        * src/attributes.cpp: Automatically register init functions for RcppModules
+
 2017-06-01  JJ Allaire  <jj@rstudio.com>
 
         * src/attributes.cpp: Fix registration for exports with name attribute.

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -138,7 +138,6 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
             file.copy(file, src)
             message(" >> copied ", file, " to src directory" )
         }
-        compileAttributes(root)
     }
 
     if (example_code) {
@@ -146,10 +145,6 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
             file.copy(file.path( skeleton, "rcpp_hello_world_attributes.cpp"),
                       file.path( src, "rcpp_hello_world.cpp"))
             message(" >> added example src file using Rcpp attributes")
-            compileAttributes(root)
-            message(" >> compiled Rcpp attributes")
-            message(" >> do NOT modify by hand either RcppExports.cpp or ",
-                    "RcppExports.R")
         } else {
             header <- readLines(file.path(skeleton, "rcpp_hello_world.h"))
             header <- gsub("@PKG@", name, header, fixed = TRUE)
@@ -216,6 +211,11 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
 
     if (isTRUE(remove_hello_world)) {
         rm("rcpp_hello_world", envir = env)
+    }
+
+    if (attributes) {
+        compileAttributes(root)
+        message(" >> compiled Rcpp attributes ")
     }
 
     invisible(NULL)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,6 +17,7 @@
       or newer (Elias Pipping in \ghpr{698}).
       \item Fix native registration for exports with name attribute (\ghpr{703}
       addressing \ghit{702}).
+      \item Automatically register init functions for RcppModules.
     }
   }
 }


### PR DESCRIPTION
Addresses https://github.com/RcppCore/Rcpp/issues/704

RcppModules include a native routine "boot" function of the form `_rcpp_module_boot_*`. These functions are not discovered by `tools::package_native_routine_registration_skeleton` so generally need to be hand-added to `init.c`.

This also implies that our current auto-generation of native routine registrations for `RcppExports.cpp` won't register these functions and will therefore fail to create a loadable package. 2 alternatives here:

1) When we see an Rcpp module simply don't attempt to generate native routine registrations (sort of like we do now when we see `init.c`). 

2) Generate native routine registrations for the Rcpp modules.

Happily, we already parse for Rcpp module declarations (since `sourceCpp` supports exporting modules) so it's a very straightforward change to generate the `_rcpp_module_boot_*` functions, which is what we do in this PR.
