### PR TITLE
Protect function argument to rcpp_set_stack_trace()

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,7 @@
     \item Changes in Rcpp API:
     \itemize{
       \item The \code{tinyformat.h} header now ends in a newline (\ghit{701}).
+      \item Fixed rare protection error that occurred when fetching stack traces during the construction of an Rcpp exception (Kirill Müller in \ghit{706}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -31,12 +31,12 @@ namespace Rcpp {
         explicit exception(const char* message_, bool include_call = true) :	// #nocov start
             message(message_),
             include_call_(include_call){
-            rcpp_set_stack_trace(stack_trace());
+            rcpp_set_stack_trace(Shield<SEXP>(stack_trace()));
         }
         exception(const char* message_, const char* file, int line, bool include_call = true) :
             message(message_),
             include_call_(include_call){
-            rcpp_set_stack_trace(stack_trace(file,line));
+            rcpp_set_stack_trace(Shield<SEXP>(stack_trace()));
         }
         bool include_call() const {
             return include_call_;

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -121,7 +121,6 @@ SEXP rcpp_get_stack_trace() {
 
 // [[Rcpp::register]]
 SEXP rcpp_set_stack_trace(SEXP e) {
-    Rcpp::Shield<SEXP> ep(e);
     SET_VECTOR_ELT(get_rcpp_cache(), 3, e);
     return R_NilValue;
 }

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -121,6 +121,7 @@ SEXP rcpp_get_stack_trace() {
 
 // [[Rcpp::register]]
 SEXP rcpp_set_stack_trace(SEXP e) {
+    Rcpp::Shield<SEXP> ep(e);
     SET_VECTOR_ELT(get_rcpp_cache(), 3, e);
     return R_NilValue;
 }


### PR DESCRIPTION
which *may* be gc-ed otherwise.

I was unable to create a reproducible example for this problem, but I have [two stack traces](https://gist.github.com/krlmlr/501043e57573abe9d47d13be69fb88ff) from test runs for dplyr with valgrind and gctorture enabled that indicate that this may be the source of a problem. I'm not seeing these errors anymore after applying this fix.