### PR TITLE
explicitly make exported functions visible

### DIFF
--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -126,7 +126,7 @@ namespace Rcpp {
 #include <Rcpp/complex.h>
 #include <Rcpp/barrier.h>
 
-#define RcppExport extern "C"
+#define RcppExport extern "C" attribute_visible
 
 #include <Rcpp/exceptions.h>
 


### PR DESCRIPTION
Marks exported Rcpp functions as visible, on supported platforms. The `attribute_visible ` macro is defined in `<R_ext/Visibility.h>`. If the compiler supports visibility it is defined as 

```c
 __attribute__ ((visibility ("default")))
```
And otherwise it is blank. The idea is that we can compile packages with `-fvisibility=hidden` as defined in `make` variable `$(C_VISIBILITY)` on supported platforms. So pkg authors can do:

```make
PKG_CXXFLAGS=$(C_VISIBILITY)
```

Limiting visibility to exported functions reduces the chances of symbol conflicts like we saw in https://github.com/ropensci/hunspell/issues/21. Here both rstudio and the hunspell package include a copy of libhunspell but different versions. Apparently their C++ classes start conflicting under certain circumstances. Hiding the `libhunspell` symbols from the dll solved the problem. 