### PR TITLE
Inteface change: accept R_xlen_t instead of int in no_init()

### DIFF
--- a/inst/include/Rcpp/vector/no_init.h
+++ b/inst/include/Rcpp/vector/no_init.h
@@ -66,7 +66,7 @@ private:
     int nc;
 } ;
 
-inline no_init_vector no_init(int size) {
+inline no_init_vector no_init(R_xlen_t size) {
     return no_init_vector(size);
 }
 

--- a/inst/include/Rcpp/vector/no_init.h
+++ b/inst/include/Rcpp/vector/no_init.h
@@ -2,7 +2,7 @@
 //
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //


### PR DESCRIPTION
This is one of the two changes necessary to compile RSQLite with `-Wconversion` without warnings.