### PR TITLE
remove unused variable warning

### DIFF
--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -100,7 +100,7 @@ namespace Rcpp{
         typedef Rcpp::XPtr<Class> XP ;
 
         CppMethod() {}
-        virtual SEXP operator()(Class* object, SEXP* args) { return R_NilValue ; }
+        virtual SEXP operator()(Class* /*object*/, SEXP* /*args*/) { return R_NilValue ; }
         virtual ~CppMethod(){}
         virtual int nargs(){ return 0 ; }
         virtual bool is_void(){ return false ; }

--- a/inst/include/Rcpp/module/Module_generated_Constructor.h
+++ b/inst/include/Rcpp/module/Module_generated_Constructor.h
@@ -33,7 +33,7 @@ public:
 template <typename Class>
 class Constructor_0 : public Constructor_Base<Class>{
 public:
-    virtual Class* get_new( SEXP* args, int nargs ){
+    virtual Class* get_new( SEXP* /*args*/, int /*nargs*/ ){
         return new Class() ;
     }
     virtual int nargs(){ return 0 ; }


### PR DESCRIPTION
Just a quick one to remove some compiler warnings of the form:
```shell
warning: unused parameter ‘object’ [-Wunused-parameter]
         virtual SEXP operator()(Class* object, SEXP* args) { return R_NilValue ; }
                                        ^~~~~~
```

Thanks!