### PR TITLE
RObject size function

### DIFF
--- a/inst/include/Rcpp/proxy/RObjectMethods.h
+++ b/inst/include/Rcpp/proxy/RObjectMethods.h
@@ -40,6 +40,13 @@ namespace Rcpp{
             return Rf_isS4( static_cast<const Class&>(*this) ) ;
         }
 
+        inline R_xlen_t length() const {
+            return ::Rf_xlength( static_cast<const Class&>(*this) ) ;
+        }
+
+        inline R_xlen_t size() const {
+            return ::Rf_xlength( static_cast<const Class&>(*this) ) ;
+        }
     } ;
 
 }


### PR DESCRIPTION
Can I suggest adding the `size` function to `RObject`?  

Testing it out seemed to work fine:

```
// [[Rcpp::export]]
int testSize(RObject x) {
    return x.size();
}
--------------------------------------------------
x <- as.list(1:10)
testSize(x)

# "expression" object
x <- expression(paste(" AC50 (",mu,"M)",sep=""))
testSize(x)

# "call" object
assay <- "Some Assay"
x <- bquote(.(assay) ~ AC50 ~ (mu*M))
testSize(x)

# S4
setClass("Person", representation(name = "character", age = "numeric"))
setClass("Employee", representation(boss = "Person"), contains = "Person")
hadley <- new("Person", name = "Hadley", age = 31)

testSize(hadley)
```