### PR TITLE
Fixed missing Rcpp namespace in export interface generation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-11-30  James J Balamuta  <balamut2@illinois.edu>
+
+        * src/attributes.cpp: Fixed missing Rcpp namespace in export interface
+        generation
+
 2017-11-25  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,12 @@
     \itemize{
       \item Calls from exception handling to `Rf_warning()` now correctly set an
       initial format string (Dirk in \ghpr{777} fixing \ghit{776}).
+    }
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      \item Addressed a missing Rcpp namespace prefix when generating a C++
+      interface (James Balamuta in \ghpr{779}).
+    }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The Rcpp FAQ now shows \code{Rcpp::Rcpp.plugin.maker()}m not the

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2192,7 +2192,7 @@ namespace attributes {
                        << std::endl;
                 ostr() << "        if (rcpp_result_gen.inherits(\"try-error\"))"
                        << std::endl
-                       << "            throw Rcpp::exception(as<std::string>("
+                       << "            throw Rcpp::exception(Rcpp::as<std::string>("
                        << "rcpp_result_gen).c_str());"
                        << std::endl;
                 if (!function.type().isVoid()) {


### PR DESCRIPTION
This PR adds the `Rcpp::` namespace prefix to an `as<>()` call in the Rcpp Attributes generation procedure for a C++ interface. e.g.,

```
// [[Rcpp::interfaces(r, cpp)]]
```

In particular, appending `Rcpp::`, fixes the following errors:

```
error: expected '(' for function-style cast or type construction
            throw Rcpp::exception(as<std::string>(rcpp_result_gen).c_str());
                                     ~~~~~~~~~~~^
error: no member named 'c_str' in 'Rcpp::RObject_Impl<PreserveStorage>'
            throw Rcpp::exception(as<std::string>(rcpp_result_gen).c_str());
                                                 ~~~~~~~~~~~~~~~~~ ^
```