### PR TITLE
use public R APIs for new_env

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-12-05  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/Rcpp/Environment.h: Use public R APIs
+        * inst/include/Rcpp/api/meat/Environment.h: Idem
+
 2017-12-03  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): New minor version

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -23,10 +23,6 @@
 #ifndef Rcpp_Environment_h
 #define Rcpp_Environment_h
 
-// From 'R/Defn.h'
-// NOTE: can't include header directly as it checks for some C99 features
-extern "C" SEXP R_NewHashedEnv(SEXP, SEXP);
-
 namespace Rcpp{
 
     RCPP_API_CLASS(Environment_Impl),
@@ -401,21 +397,6 @@ namespace Rcpp{
     };
 
 typedef Environment_Impl<PreserveStorage> Environment ;
-
-inline Environment new_env(int size = 29) {
-    Shield<SEXP> sizeSEXP(Rf_ScalarInteger(size));
-    return R_NewHashedEnv(R_EmptyEnv, sizeSEXP);
-}
-
-inline Environment new_env(SEXP parent, int size = 29) {
-    Shield<SEXP> sizeSEXP(Rf_ScalarInteger(size));
-    Shield<SEXP> parentSEXP(parent);
-    if (!Rf_isEnvironment(parentSEXP)) {
-        stop("parent is not an environment");
-    }
-    return R_NewHashedEnv(parentSEXP, sizeSEXP);
-}
-
 
 } // namespace Rcpp
 

--- a/inst/include/Rcpp/api/meat/Environment.h
+++ b/inst/include/Rcpp/api/meat/Environment.h
@@ -44,6 +44,15 @@ Environment_Impl<StoragePolicy>::Environment_Impl( int pos ){
    Storage::set__(env) ;
 }
 
+inline Environment new_env(int size = 29) {
+    Function newEnv("new.env");
+    return newEnv(_["size"] = size, _["parent"] = R_EmptyEnv);
+}
+
+inline Environment new_env(SEXP parent, int size = 29) {
+    Function newEnv("new.env");
+    return newEnv(_["size"] = size, _["parent"] = parent);
+}
 
 } // namespace Rcpp
 


### PR DESCRIPTION
Closes https://github.com/RcppCore/Rcpp/issues/771. We use `Rcpp::Function` + `new.env()` instead of an (unfortunately) unexported R API for constructing environments.