### PR TITLE
Use protect-unwind API and add Rcpp_fast_eval()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,44 @@
+
+2017-12-13  Lionel Henry  <lionel@rstudio.com>
+
+        * inst/include/Rcpp/api/meat/Rcpp_eval.h: Add Rcpp_fast_eval() for safe
+        and fast evaluation of R code using the new protect-unwind API in R 3.5.
+        Unlike Rcpp_eval(), this does not evaluate R code within tryCatch() in
+        order to avoid the catching overhead. R longjumps are now correctly
+        intercepted and rethrown. Following this change the C++ stack is now
+        safely unwound when a longjump is detected while calling into R code.
+        This includes the following cases: caught condition of any class, long
+        return, restart jump, debugger exit.
+
+        Rcpp_eval() also uses the protect-unwind API in order to gain safety.
+        To maintain compatibility it still catches errors and interrupts in
+        order to rethrow them as typed C++ exceptions. If you don't need to
+        catch those, consider using Rcpp_fast_eval() instead to avoid the
+        overhead.
+
+        These improvements are only available for R 3.5.0 and greater. When
+        compiled with old versions of R, Rcpp_fast_eval() falls back to
+        Rcpp_eval(). This is in contrast to internal::Rcpp_eval_impl() which
+        falls back to Rf_eval() and which is used in performance-sensititive
+        places.
+
+        Note that with this change, Rcpp_eval() now behaves like the C function
+        Rf_eval() whereas it used to behave like the R function base::eval().
+        This has subtle implications for control flow. For instance evaluating a
+        return() expression within a frame environment now returns from that
+        frame rather than from the Rcpp_eval() call. The old semantics were a
+        consequence of using evalq() internally and were not documented.
+
+        * inst/include/Rcpp/exceptions.h: Add LongjumpException and
+        resumeJump() to support Rcpp_fast_eval().
+
+        * inst/include/Rcpp/macros/macros.h: Catch LongjumpException and call
+        resumeJump(). If resumeJump() doesn't jump (on old R versions), throw an
+        R error (this normally should not happen).
+
+        * inst/include/RcppCommon.h: Add Rcpp_fast_eval() to the public API and
+        internal::Rcpp_eval_impl() to the private API.
+
 2017-12-05  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/Environment.h: Use public R APIs

--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,9 @@
         * inst/include/RcppCommon.h: Add Rcpp_fast_eval() to the public API and
         internal::Rcpp_eval_impl() to the private API.
 
+        * inst/include/Rcpp/Environment.h: Use safe evaluation
+        * inst/include/Rcpp/Language.h: idem
+
 2017-12-05  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/Environment.h: Use public R APIs

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,9 +16,10 @@
         catch those, consider using Rcpp_fast_eval() instead to avoid the
         overhead.
 
-        These improvements are only available for R 3.5.0 and greater. When
-        compiled with old versions of R, Rcpp_fast_eval() falls back to
-        Rcpp_eval(). This is in contrast to internal::Rcpp_eval_impl() which
+        These improvements are only available for R 3.5.0 and greater. You also
+        need to explicitly define `RCPP_PROTECTED_EVAL` before including Rcpp.h.
+        When compiled with old versions of R, Rcpp_fast_eval() always falls back
+        to Rcpp_eval(). This is in contrast to internal::Rcpp_eval_impl() which
         falls back to Rf_eval() and which is used in performance-sensititive
         places.
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,6 +11,20 @@
       set an initial format string (Dirk in \ghpr{777} fixing \ghit{776}).
       \item The 'new' Date and Datetime vectors now have \code{is_na} methods
       too. (Dirk in \ghpr{783} fixing \ghit{781}).
+
+      \item Evaluation of R code is now safer when compiled against R
+      3.5. Longjumps of all kinds (condition catching, returns,
+      restarts, debugger exit) are appropriately detected and handled,
+      e.g. the C++ stack unwinds correctly. The new function
+      \code{Rcpp_fast_eval()} can be used for performance-sensitive
+      evaluation of R code. Unlike \code{Rcpp_eval()}, it does not try
+      to catch errors with \code{tryEval} in order to avoid the catching
+      overhead. While this is safe thanks to the stack unwinding
+      protection, this also means that R errors are not transformed to
+      an \code{Rcpp::exception}. If you are relying on error rethrowing,
+      you have to use the slower \code{Rcpp_eval()}. On old R versions
+      \code{Rcpp_fast_eval()} falls back to \code{Rcpp_eval()} so it is
+      safe to use against any versions of R.
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,20 +11,21 @@
       set an initial format string (Dirk in \ghpr{777} fixing \ghit{776}).
       \item The 'new' Date and Datetime vectors now have \code{is_na} methods
       too. (Dirk in \ghpr{783} fixing \ghit{781}).
-
       \item Evaluation of R code is now safer when compiled against R
-      3.5. Longjumps of all kinds (condition catching, returns,
-      restarts, debugger exit) are appropriately detected and handled,
-      e.g. the C++ stack unwinds correctly. The new function
-      \code{Rcpp_fast_eval()} can be used for performance-sensitive
-      evaluation of R code. Unlike \code{Rcpp_eval()}, it does not try
-      to catch errors with \code{tryEval} in order to avoid the catching
-      overhead. While this is safe thanks to the stack unwinding
-      protection, this also means that R errors are not transformed to
-      an \code{Rcpp::exception}. If you are relying on error rethrowing,
-      you have to use the slower \code{Rcpp_eval()}. On old R versions
-      \code{Rcpp_fast_eval()} falls back to \code{Rcpp_eval()} so it is
-      safe to use against any versions of R.
+      3.5 (you also need to explicitly define \code{RCPP_PROTECTED_EVAL}
+      before including \code{Rcpp.h}). Longjumps of all kinds (condition
+      catching, returns, restarts, debugger exit) are appropriately
+      detected and handled, e.g. the C++ stack unwinds correctly.
+      \item The new function \code{Rcpp_fast_eval()} can be used for
+      performance-sensitive evaluation of R code. Unlike
+      \code{Rcpp_eval()}, it does not try to catch errors with
+      \code{tryEval} in order to avoid the catching overhead. While this
+      is safe thanks to the stack unwinding protection, this also means
+      that R errors are not transformed to an \code{Rcpp::exception}. If
+      you are relying on error rethrowing, you have to use the slower
+      \code{Rcpp_eval()}. On old R versions \code{Rcpp_fast_eval()}
+      falls back to \code{Rcpp_eval()} so it is safe to use against any
+      versions of R.
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -109,7 +109,7 @@ namespace Rcpp{
 
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
-                res = Rf_eval( res, env ) ;
+                res = internal::Rcpp_eval_impl( res, env ) ;
             }
             return res ;
         }
@@ -129,7 +129,7 @@ namespace Rcpp{
 
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
-                res = Rf_eval( res, env ) ;
+                res = internal::Rcpp_eval_impl( res, env ) ;
             }
             return res ;
         }
@@ -151,7 +151,7 @@ namespace Rcpp{
 
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
-                res = Rf_eval( res, env ) ;
+                res = internal::Rcpp_eval_impl( res, env ) ;
             }
             return res ;
         }
@@ -174,7 +174,7 @@ namespace Rcpp{
 
             /* We need to evaluate if it is a promise */
             if( TYPEOF(res) == PROMSXP){
-                res = Rf_eval( res, env ) ;
+                res = internal::Rcpp_eval_impl( res, env ) ;
             }
             return res ;
         }

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -145,10 +145,10 @@ namespace Rcpp{
         }
 
         SEXP fast_eval() const {
-            return Rf_eval( Storage::get__(), R_GlobalEnv) ;
+            return internal::Rcpp_eval_impl( Storage::get__(), R_GlobalEnv) ;
         }
         SEXP fast_eval(SEXP env ) const {
-            return Rf_eval( Storage::get__(), env) ;
+            return internal::Rcpp_eval_impl( Storage::get__(), env) ;
         }
 
         void update( SEXP x){

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -39,7 +39,15 @@ namespace internal {
 
     inline void Rcpp_maybe_throw(void* data, Rboolean jump) {
         if (jump) {
-            throw LongjumpException(static_cast<SEXP>(data));
+            SEXP token = static_cast<SEXP>(data);
+
+            // Keep the token protected while unwinding because R code might run
+            // in C++ destructors. Can't use PROTECT() for this because
+            // UNPROTECT() might be called in a destructor, for instance if a
+            // Shield<SEXP> is on the stack.
+            ::R_PreserveObject(token);
+
+            throw LongjumpException(token);
         }
     }
 

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -21,15 +21,15 @@
 #include <Rcpp/Interrupt.h>
 #include <Rversion.h>
 
-#if (defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
-#define R_HAS_UNWIND
+#if (defined(RCPP_PROTECTED_EVAL) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
+#define RCPP_USE_PROTECT_UNWIND
 #endif
 
 
 namespace Rcpp {
 namespace internal {
 
-#ifdef R_HAS_UNWIND
+#ifdef RCPP_USE_PROTECT_UNWIND
 
     struct EvalData {
         SEXP expr;
@@ -65,7 +65,7 @@ namespace internal {
 } // namespace internal
 
 
-#ifdef R_HAS_UNWIND
+#ifdef RCPP_USE_PROTECT_UNWIND
 
     inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
         internal::EvalData data(expr, env);

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -119,6 +119,7 @@ namespace Rcpp {
         };
 
         inline void resumeJump(SEXP token) {
+            ::R_ReleaseObject(token);
 #if (defined(RCPP_PROTECTED_EVAL) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
             ::R_ContinueUnwind(token);
 #endif

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -22,6 +22,9 @@
 #ifndef Rcpp__exceptions__h
 #define Rcpp__exceptions__h
 
+#include <Rversion.h>
+
+
 #define GET_STACKTRACE() stack_trace( __FILE__, __LINE__ )
 
 namespace Rcpp {
@@ -107,6 +110,21 @@ namespace Rcpp {
     inline void NORET stop(const std::string& message) {     // #nocov start
         throw Rcpp::exception(message.c_str());
     }                                                        // #nocov end
+
+    namespace internal {
+
+        struct LongjumpException {
+            SEXP token;
+            LongjumpException(SEXP token_) : token(token_) { }
+        };
+
+        inline void resumeJump(SEXP token) {
+#if (defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
+            ::R_ContinueUnwind(token);
+#endif
+        }
+
+    } // namespace internal
 
 } // namespace Rcpp
 

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -119,7 +119,7 @@ namespace Rcpp {
         };
 
         inline void resumeJump(SEXP token) {
-#if (defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
+#if (defined(RCPP_PROTECTED_EVAL) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
             ::R_ContinueUnwind(token);
 #endif
         }

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -41,6 +41,11 @@
     catch( Rcpp::internal::InterruptedException &__ex__) {                                       \
         rcpp_output_type = 1 ;                                                                   \
     }                                                                                            \
+    catch(Rcpp::internal::LongjumpException& __ex__) {                                           \
+        Rcpp::internal::resumeJump(__ex__.token);                                                \
+        rcpp_output_type = 2 ;                                                                   \
+        rcpp_output_condition = PROTECT(string_to_try_error("Unexpected LongjumpException")) ;   \
+    }                                                                                            \
     catch(Rcpp::exception& __ex__) {                                                             \
        rcpp_output_type = 2 ;                                                                    \
        rcpp_output_condition = PROTECT(rcpp_exception_to_r_condition(__ex__)) ;                  \
@@ -72,6 +77,10 @@
   }                                                                            \
   catch (Rcpp::internal::InterruptedException &__ex__) {                       \
     return Rcpp::internal::interruptedError();                                 \
+  }                                                                            \
+  catch (Rcpp::internal::LongjumpException& __ex__) {                          \
+    Rcpp::internal::resumeJump(__ex__.token);                                  \
+    return string_to_try_error("Unexpected LongjumpException") ;               \
   }                                                                            \
   catch (std::exception &__ex__) {                                             \
     return exception_to_try_error(__ex__);                                     \

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -74,7 +74,13 @@ namespace Rcpp {
 
 namespace Rcpp {
 
+    SEXP Rcpp_fast_eval(SEXP expr_, SEXP env = R_GlobalEnv);
     SEXP Rcpp_eval(SEXP expr_, SEXP env = R_GlobalEnv);
+
+    namespace internal {
+        SEXP Rcpp_eval_impl(SEXP expr, SEXP env = R_GlobalEnv);
+    }
+
     class Module;
 
     namespace traits {

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -250,12 +250,6 @@ SEXP testEvalUnwindImpl(RObject expr, Environment env, LogicalVector indicator) 
 }
 
 // [[Rcpp::export]]
-SEXP testLongjumpException() {
-    throw Rcpp::internal::LongjumpException(R_NilValue);
-    return R_NilValue;
-}
-
-// [[Rcpp::export]]
 SEXP testSendInterrupt() {
   Rf_onintr();
   return R_NilValue;

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -19,6 +19,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
+#define RCPP_PROTECTED_EVAL
+
 #include <Rcpp.h>
 using namespace Rcpp;
 using namespace std;

--- a/inst/unitTests/runit.misc.R
+++ b/inst/unitTests/runit.misc.R
@@ -214,4 +214,55 @@ if (.runThisTest) {
         checkTrue(nchar(Rcpp:::bib()) > 0, msg="bib file")
     }
 
+    test.stackUnwinds <- function() {
+        # On old versions of R, Rcpp_fast_eval() falls back to Rcpp_eval() and
+        # leaks on longjumps
+        hasUnwind <- getRversion() >= "3.5.0"
+        checkUnwound <- if (hasUnwind) checkTrue else function(x) checkTrue(!x)
+        testEvalUnwind <- function(expr, indicator) {
+            testEvalUnwindImpl(expr, parent.frame(), indicator)
+        }
+
+        # On errors - Always unwound
+        unwound <- FALSE
+        out <- tryCatch(testEvalUnwind(quote(stop("err")), unwound), error = identity)
+        checkTrue(unwound)
+        msg <- if (hasUnwind) "err" else "Evaluation error: err."
+        checkIdentical(out$message, msg)
+
+        # On interrupts - Always unwound
+        unwound <- FALSE
+        expr <- quote({
+            repeat testSendInterrupt()
+            "returned"
+        })
+        out <- tryCatch(testEvalUnwind(expr, unwound), interrupt = function(c) "onintr")
+        checkTrue(unwound)
+        checkIdentical(out, "onintr")
+
+        # On caught conditions
+        unwound <- FALSE
+        expr <- quote(signalCondition(simpleCondition("cnd")))
+        cnd <- tryCatch(testEvalUnwind(expr, unwound), condition = identity)
+        checkTrue(inherits(cnd, "simpleCondition"))
+        checkUnwound(unwound)
+
+        # On restart jumps
+        unwound <- FALSE
+        expr <- quote(invokeRestart("rst"))
+        out <- withRestarts(testEvalUnwind(expr, unwound), rst = function(...) "restarted")
+        checkIdentical(out, "restarted")
+        checkUnwound(unwound)
+
+        # On returns
+        unwound <- FALSE
+        expr <- quote(signalCondition(simpleCondition(NULL)))
+        out <- callCC(function(k)
+            withCallingHandlers(testEvalUnwind(expr, unwound),
+                simpleCondition = function(e) k("jumped")
+            )
+        )
+        checkIdentical(out, "jumped")
+        checkUnwound(unwound)
+    }
 }


### PR DESCRIPTION
* Use protected evaluation when compiling Rcpp against R 3.5 (see https://github.com/wch/r-source/commit/c8cc6084e40d737b2dc39b1857f7b3ae1850b451). This prevents leaks when R code jumps (caught condition, restart invokation, interrupt, return, error).

* Add `Rcpp_fast_eval()`. Unlike `Rcpp_eval()`, it doesn't wrap the code in `tryEval()` to avoid the catching overhead. It falls back to `Rcpp_eval()` when compiled against old versions of R so packages can use it without worrying about backward compatibility.

  Here are the differences between the new function and `Rcpp_eval()`:
    - Better performance.
    - R errors are not rethrown on the C++ stack as `Rcpp::condition`. Instead they are rethrown as `Rcpp::internal::LongjumpException` as with all other longjump causes.
    - It has the control flow semantics of the C function `Rf_eval()` rather than the R function `base::eval()`. E.g. you can return from a frame environment on the R stack.

These changes should be fully backward compatible. I have tested this branch on R oldrel, release and devel here: https://travis-ci.org/lionel-/Rcpp/builds/316466207 (without vignettes and with the binary package test disabled). I'm not sure how to adapt the current Travis config to use R devel.

I have checked this branch with dplyr (which calls into R a lot) on both R release and R devel. I have not run the reverse dependencies checks. Would it be possible to run those on your server Dirk?