### PR TITLE
remove 'clever' NA checks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-12-19  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/Rcpp/internal/na.h: Remove 'clever' NA / NaN checks
+
 2017-12-16  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Date, Version): Updated minor version and date


### PR DESCRIPTION
This PR removes the 'clever' NA checking code I implemented some time ago (way back in 2014). I recall benchmarking these as a bit faster than R's own NA checking routines, but I either I was mistaken or compilers have matured such that the performance difference no longer exists:

````
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
LogicalVector is_na(NumericVector x)
{
    std::size_t n = x.size();
    LogicalVector output = no_init(n);
    for (std::size_t i = 0; i < n; i++)
        output[i] = Rcpp::internal::Rcpp_IsNA(x[i]);
    return output;
}

/*** R
library(microbenchmark)

rnd <- rnorm(1E6)
rnd[sample(1:1E6, 1E5)] <- NA
identical(is.na(rnd), is_na(rnd))
microbenchmark::microbenchmark(
    R = is.na(rnd),
    Rcpp = is_na(rnd)
)
*/
````

I see, using the current Rcpp `Rcpp_IsNA` implementation,

```
> microbenchmark::microbenchmark(
+     R = is.na(rnd),
+     Rcpp = is_na(rnd)
+ )
Unit: microseconds
 expr     min      lq     mean   median       uq      max neval cld
    R 551.458 649.605 1397.701  997.121 1179.275 5433.238   100   a
 Rcpp 626.599 767.000 1412.142 1031.284 1219.745 5157.141   100   a
```

So let's just get rid of the old Rcpp code and delegate back to R's own NA checkers.