### PR TITLE
close #797: improve support for NVCC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-01-09  Iñaki Ucar  <i.ucar86@gmail.com>
+
+        * inst/include/Rcpp/vector/proxy.h: Improve support for NVCC, the CUDA
+        compiler (pull request #798, fixed issue #797)
+
 2018-01-06  Kendon Bell  <kmb56@berkeley.edu>
 
         * src/api.cpp: Allow for compilation on ANDROID

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -34,6 +34,8 @@
       \item Overly picky \emph{fall-through} warnings by gcc-7 regarding
       \code{switch} statements are now pre-empted (Kirill in \ghpr{792}).
       \item Permit compilation on ANDROID (Kenny Bell in \ghpr{796}).
+      \item Improve support for NVCC, the CUDA compiler (Iñaki Ucar in
+      \ghpr{798} addressing \ghit{797}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -100,11 +100,11 @@ namespace internal{
 			return *this ;
 		}
 
-		operator char* (){
+		operator char* () const {
 			 return get() ;
 		}
 
-		operator SEXP(){
+		operator SEXP() const {
 			return ::Rf_mkString(get()) ;
 		}
 
@@ -125,7 +125,7 @@ namespace internal{
 				parent.push_back( rhs, name );
 			}
 		}
-		char* get(){
+		char* get() const {
 			return parent[ parent.offset(name) ];
 		}
 


### PR DESCRIPTION
For the record, find attached a Dockerfile which verifies that nvcc no longer complains (apart from the warnings).

[Dockerfile](https://github.com/RcppCore/Rcpp/files/1616937/Dockerfile.txt)

