### PR TITLE
Simplify is_na()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-01-11  Kirill Müller  <krlmlr@mailbox.org>
+
+        * inst/include/Rcpp/traits/is_na.h: Speed up Rcpp::is_na<double>()
+        (pull request #799)
+
 2018-01-09  Iñaki Ucar  <i.ucar86@gmail.com>
 
         * inst/include/Rcpp/vector/proxy.h: Improve support for NVCC, the CUDA

--- a/inst/include/Rcpp/traits/is_na.h
+++ b/inst/include/Rcpp/traits/is_na.h
@@ -39,7 +39,7 @@ namespace Rcpp{
 
         template <>
         inline bool is_na<REALSXP>(double x) {
-            return internal::Rcpp_IsNA(x) || internal::Rcpp_IsNaN(x);
+            return R_isnancpp(x);
         }
 
         template <>


### PR DESCRIPTION
This speeds up the check, because compilers aren't likely to be able to optimize two external functions that basically return `f(x) && g(x)` and `f(x) && !g(x)`. The first mention of the `R_isnancpp()` function dates back to 2005, wch/r-source@17443788ef.

Related: #790