### PR TITLE
allow long long on 64bit windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-02-07  Kevin Ushey  <kevinushey@gmail.com>
+
+        * inst/include/Rcpp/longlong.h: Allow long long on 64bit Windows
+
 2018-01-21  Dirk Eddelbuettel  <edd@debian.org>
 
         * README.md: Added new section 'Support'

--- a/inst/include/Rcpp/longlong.h
+++ b/inst/include/Rcpp/longlong.h
@@ -38,4 +38,11 @@ __extension__ typedef unsigned long long int rcpp_ulong_long_type;
 #endif
 #endif
 
+// The Rtools toolchain provides long long on 64bit Windows
+#ifdef _WIN64
+typedef long long rcpp_long_long_type;
+typedef unsigned long long rcpp_ulong_long_type;
+#define RCPP_HAS_LONG_LONG_TYPES
+#endif
+
 #endif


### PR DESCRIPTION
Fixes https://github.com/RcppCore/Rcpp/issues/804. Because the compiler toolchain on Windows provides long long regardless of whether C++98 or a newer standard is requested, this usage should be permissible on CRAN.

In addition, because `R_xlen_t` and `std::size_t` are actually defines for `long long` and `unsigned long long` on 64bit Windows, those constructors now work 'for free'.