### PR TITLE
Generate .Call(...) instead of .Primitive(.Call)(...) for cppFunction

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-02-14  Kirill Müller  <krlmlr@mailbox.org>
+
+        * R/Attributes.R: Code compiled with cppFunction() uses .Call instead
+        of .Primitive(".Call"), #795
+
 2018-02-07  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/longlong.h: Allow long long on 64bit Windows

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -539,7 +539,7 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
     for (i in seq(along.with = args))
         body[[i+2]] <- as.symbol(args[i])
 
-    body[[1L]] <- .Call
+    body[[1L]] <- quote(.Call)
     body[[2L]] <- getNativeSymbolInfo(symbol, dll)$address
 
     if (isVoid)


### PR DESCRIPTION
Closes #795.