### PR TITLE
unconditionally get/put RNG state

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-02-26  Kevin Ushey  <kevinushey@gmail.com>
+
+        * src/api.cpp: Always set / put RNG state when calling Rcpp function
+
+
 2018-02-25  Dirk Eddelbuettel  <edd@debian.org>
 
         * vignettes/Rcpp.bib: Updated

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,11 @@
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
+      \item Rcpp now sets and puts the RNG state upon each entry to an Rcpp
+      function, ensuring that nested invocations of Rcpp functions manage the
+      RNG state as expected
+    }
+    \itemize{
       \item The \code{long long} type can now be used on 64-bit Windows (Kevin
       in \ghpr{811})
     }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -70,7 +70,7 @@ namespace Rcpp {
 
         // [[Rcpp::register]]
         unsigned long enterRNGScope() {
-            if (RNGScopeCounter == 0) GetRNGstate();
+            GetRNGstate();
             RNGScopeCounter++;
             return RNGScopeCounter;
         }
@@ -78,7 +78,7 @@ namespace Rcpp {
         // [[Rcpp::register]]
         unsigned long exitRNGScope() {
             RNGScopeCounter--;
-            if (RNGScopeCounter == 0) PutRNGstate();
+            PutRNGstate();
             return RNGScopeCounter;
         }
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -64,22 +64,17 @@ using namespace Rcpp;
 namespace Rcpp {
 
     namespace internal {
-        namespace {
-            unsigned long RNGScopeCounter = 0;
-        }
 
         // [[Rcpp::register]]
         unsigned long enterRNGScope() {
             GetRNGstate();
-            RNGScopeCounter++;
-            return RNGScopeCounter;
+            return 0;
         }
 
         // [[Rcpp::register]]
         unsigned long exitRNGScope() {
-            RNGScopeCounter--;
             PutRNGstate();
-            return RNGScopeCounter;
+            return 0;
         }
 
         // [[Rcpp::register]]


### PR DESCRIPTION
Resolves https://github.com/RcppCore/Rcpp/issues/823. With this PR, we ensure that Rcpp functions called by other Rcpp functions synchronize the RNG state.

Although @wch's example showed this through the use of `Rcpp::Function`, in theory this could occur if an Rcpp function were to e.g. call `source()` or `eval()` or another API that happened to call another Rcpp function.