### PR TITLE
Optionally suppress call info in Rcpp::stop and Rcpp::warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-03-05  Michael Weylandt  <michael.weylandt@gmail.com>
+
+        * inst/include/Rcpp/exceptions/cpp{98,11}/exceptions.h: Add
+        include_call argument to Rcpp::stop and Rcpp::warning to suppress
+        inclusion of call stack in resulting error / warning.
+
 2018-03-01  Dirk Eddelbuettel  <edd@debian.org>
 
         * inst/include/Rcpp/sugar/functions/complex.h (Rcpp): Remove RCPP_HYPOT

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,6 +13,10 @@
       \item The \code{R::pythag} wrapper has been commented out; the underlying
       function has been gone from R since 2.14.0, and \code{::hypot()} (part of
       C99) is now used unconditionally for complex numbers.
+      \item \code{Rcpp::stop} and \code{Rcpp::warning} gain a new \code{include_call}
+      argument which functions similarly to the \code{call.} argument to
+      \code{base::stop} and \code{base::warning} at the R level. By default,
+      this is \code{true} for back-compatability.
     }
     \itemize{
       \item The \code{long long} type can now be used on 64-bit Windows (Kevin

--- a/inst/include/Rcpp/exceptions/cpp11/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp11/exceptions.h
@@ -43,13 +43,22 @@ class __CLASS__ : public std::exception {                                       
 };
 
 template <typename... Args>
-inline void warning(const char* fmt, Args&&... args ) {
+inline void warning(const char* fmt, Args&&... args) {
     Rf_warning("%s", tfm::format(fmt, std::forward<Args>(args)... ).c_str());
 }
 
 template <typename... Args>
-inline void NORET stop(const char* fmt, Args&&... args) {
-    throw Rcpp::exception( tfm::format(fmt, std::forward<Args>(args)... ).c_str() );
+inline void warning(const char* fmt, Args&&... args, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, std::forward<Args>(args)... ).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, std::forward<Args>(args)... ).c_str());
+    }
+}
+
+template <typename... Args>
+inline void NORET stop(const char* fmt, Args&&... args, bool include_call = true) {
+    throw Rcpp::exception( tfm::format(fmt, std::forward<Args>(args)... ).c_str(), include_call);
 }
 
 } // namespace Rcpp

--- a/inst/include/Rcpp/exceptions/cpp98/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp98/exceptions.h
@@ -69,53 +69,93 @@ class __CLASS__ : public std::exception{                                        
 // -- Start Rcpp::warning declaration
 
 template <typename T1>
-inline void warning(const char* fmt, const T1& arg1) {
-    Rf_warning("%s", tfm::format(fmt, arg1).c_str());
+inline void warning(const char* fmt, const T1& arg1, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1).c_str());
+    }
 }
 
 template <typename T1, typename T2>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2).c_str());
+    }
 }
 
 template <typename T1, typename T2, typename T3>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3).c_str());
+    }
 }
 
 template <typename T1, typename T2, typename T3, typename T4>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4).c_str());
+    }
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str());
+    }
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str());
+    }
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str());
+    };
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str());
+    };
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str());
+    };
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
-inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
-    Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str());
+inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str());
+    };
 }
 
 // -- End Rcpp::warning declaration
@@ -123,53 +163,53 @@ inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& a
 // -- Start Rcpp::stop declaration
 
 template <typename T1>
-inline void NORET stop(const char* fmt, const T1& arg1) {
-    throw Rcpp::exception(tfm::format(fmt, arg1).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1).c_str(), include_call);
 }
 
 template <typename T1, typename T2>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9).c_str(), include_call);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
-inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10) {
-    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str());
+inline void NORET stop(const char* fmt, const T1& arg1, const T2& arg2, const T3& arg3, const T4& arg4, const T5& arg5, const T6& arg6, const T7& arg7, const T8& arg8, const T9& arg9, const T10& arg10, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10).c_str(), include_call);
 }
 
 // -- End Rcpp::stop declaration

--- a/inst/include/Rcpp/exceptions/cpp98/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp98/exceptions.h
@@ -68,6 +68,14 @@ class __CLASS__ : public std::exception{                                        
 
 // -- Start Rcpp::warning declaration
 
+inline void warning(const char* fmt, bool include_call = true) {
+    if(include_call){
+        Rf_warning("%s", tfm::format(fmt).c_str());
+    } else {
+        Rf_warningcall(R_NilValue, "%s", tfm::format(fmt).c_str());
+    }
+}
+
 template <typename T1>
 inline void warning(const char* fmt, const T1& arg1, bool include_call = true) {
     if(include_call){
@@ -161,6 +169,10 @@ inline void warning(const char* fmt, const T1& arg1, const T2& arg2, const T3& a
 // -- End Rcpp::warning declaration
 
 // -- Start Rcpp::stop declaration
+
+inline void NORET stop(const char* fmt, bool include_call = true) {
+    throw Rcpp::exception(tfm::format(fmt).c_str(), include_call);
+}
 
 template <typename T1>
 inline void NORET stop(const char* fmt, const T1& arg1, bool include_call = true) {

--- a/inst/unitTests/cpp/exceptions.cpp
+++ b/inst/unitTests/cpp/exceptions.cpp
@@ -67,3 +67,13 @@ double takeLogNested(double val) {
 void noCall() {
     throw Rcpp::exception("Testing", false);
 }
+
+// [[Rcpp::export]]
+void noCall_stop() {
+    Rcpp::stop("Testing", false);
+}
+
+// [[Rcpp::export]]
+void noCall_warning() {
+    Rcpp::warning("Testing", false);
+}

--- a/inst/unitTests/runit.exceptions.R
+++ b/inst/unitTests/runit.exceptions.R
@@ -120,4 +120,26 @@ test.rcppExceptionNoCall <- function() {
   checkIdentical(e$cppstack, NULL)
   checkIdentical(class(e), c("Rcpp::exception", "C++Error", "error", "condition"))
 }
+
+test.rcppExceptionNoCall_stop <- function() {
+
+    # Can throw exceptions that don't include a call stack
+    e <- tryCatch(noCall_stop(), error = identity)
+
+    checkIdentical(e$message, "Testing")
+    checkIdentical(e$call, NULL)
+    checkIdentical(e$cppstack, NULL)
+    checkIdentical(class(e), c("Rcpp::exception", "C++Error", "error", "condition"))
+}
+
+test.rcppExceptionNoCall_warning <- function() {
+
+    # Can throw exceptions that don't include a call stack
+    w <- tryCatch(noCall_warning(), warning = identity)
+
+    checkIdentical(w$message, "Testing")
+    checkIdentical(w$call, NULL)
+    checkIdentical(w$cppstack, NULL)
+    checkIdentical(class(w), c("Rcpp::exception", "C++Error", "error", "condition"))
+}
 }


### PR DESCRIPTION
Add `bool include_call` arguments to `Rcpp::stop` and `Rcpp::warning` to
control inclusion of the call stack in Rcpp produced errors and warnings. 

See discussion at http://lists.r-forge.r-project.org/pipermail/rcpp-devel/2018-March/009906.html (and thread)

Currently, the following produces a sub-par error message (`Error in (function (x)  : My error message.`): 

```{r}
library(Rcpp)

sourceCpp(code='

#include "Rcpp.h"

// [[Rcpp::export]]
Rcpp::NumericVector internal_function_name(Rcpp::NumericVector x){
    Rcpp::stop("My error message.");
    return x + 2;
}')

add2 <- function(x){
    if(!is.numeric(x)){
        x <- as.numeric(x)
    }

    do.call(internal_function_name, list(x))
}

add2(1:5)
```

With the attached PR, this will give a cleaner error message (`Error: My error message.`): : 

```{r}
library(Rcpp)

sourceCpp(code='

#include "Rcpp.h"

// [[Rcpp::export]]
Rcpp::NumericVector internal_function_name(Rcpp::NumericVector x){
    Rcpp::stop("My error message.", false); // include_call = false
    return x + 2;
}')

add2 <- function(x){
    if(!is.numeric(x)){
        x <- as.numeric(x)
    }

    do.call(internal_function_name, list(x))
}

add2(1:5)
```
