### PR TITLE
don't let generators inherit from RNGScope

### DIFF
--- a/inst/include/Rcpp/stats/random/random.h
+++ b/inst/include/Rcpp/stats/random/random.h
@@ -25,7 +25,7 @@
 namespace Rcpp{
 
 template <typename T>
-class Generator : public RNGScope {
+class Generator {
 public:
     typedef T r_generator ;
 };


### PR DESCRIPTION
Fixes #836. See associated issue for discussion.