### PR TITLE
Replace back-quotes with straight-quotes in normal text

### DIFF
--- a/vignettes/Rcpp-attributes.Rmd
+++ b/vignettes/Rcpp-attributes.Rmd
@@ -557,7 +557,7 @@ moving code from a standalone \proglang{C++} source file to a package:
 ## Package Creation 
 
 To create a package that is based on \pkg{Rcpp} you should follow the
-guidelines in the `\textsl{Rcpp-package}' vignette. For a new package this
+guidelines in the '\textsl{Rcpp-package}' vignette. For a new package this
 is most conveniently done using  the `Rcpp.package.skeleton` function.
 
 To generate a new package with a simple hello, world function that uses
@@ -686,7 +686,7 @@ inst/include/fastcode.h
 This header file will also automatically be included in 
 `RcppExports.cpp`. Note that the convention of using `.h` for
 header files containing C++ code may seem unnatural, but this comes from the
-recommended practices described in `\textsl{Writing R Extensions}' 
+recommended practices described in '\textsl{Writing R Extensions}' 
 \citep{R:Extensions}.
 
 ## Roxygen Comments 
@@ -726,7 +726,7 @@ The interface exposed from \proglang{R} packages is most typically a set of
 a mechanism to allow the exporting of \proglang{C} and \proglang{C++}
 interfaces using package header files.  This is based on the
 `R_RegisterCCallable` and `R_GetCCallable` functions described in
-`\textsl{Writing R Extensions}' \citep{R:Extensions}.
+'\textsl{Writing R Extensions}' \citep{R:Extensions}.
 
 \proglang{C++} interfaces to a package are published within the
 top level `include` directory of the package (which within the package

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -96,7 +96,7 @@ by the \pkg{Rcpp} package and its underlying \proglang{C++} library
 \citep{CRAN:Rcpp,JSS:Rcpp}. \pkg{Rcpp} smoothes many of the rough edges in
 \proglang{R} and \proglang{C++} integration by replacing the traditional
 \proglang{R} Application Programming Interface (API) described in
-`\textsl{Writing R Extensions}' \citep{R:Extensions} with a consistent set of \proglang{C++}
+'\textsl{Writing R Extensions}' \citep{R:Extensions} with a consistent set of \proglang{C++}
 classes. The '\textsl{Rcpp-jss-2011}' vignette \citep{CRAN:Rcpp,JSS:Rcpp} describes the API and
 provides an introduction to using \pkg{Rcpp}.
 


### PR DESCRIPTION
* back-quotes used as single opening quotes by TeX are not necessary since csquotes.sty is used to handle smart quotes
* back-quotes can confuse the markdown parser (c.f. section '2.1 Package Creation')

BTW, the closing quote and the last letter of the phrase are awfully close. It might make sense from a typographic point of view to use \textsl{'...'}. If you are interested, I can add this to this PR.