### PR TITLE
More thorough use of storage policy in Vector internals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 0.12.16.2
-Date: 2018-04-25
+Version: 0.12.16.3
+Date: 2018-05-04
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -2,7 +2,7 @@
 //
 // String.h: Rcpp R/C++ interface class library -- single string
 //
-// Copyright (C) 2012 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2018  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -483,8 +483,8 @@ namespace Rcpp {
     }
 
     namespace internal {
-        template <int RTYPE>
-        string_proxy<RTYPE>& string_proxy<RTYPE>::operator=(const String& s) {
+        template <int RTYPE, template <class> class StoragePolicy>
+        string_proxy<RTYPE, StoragePolicy>& string_proxy<RTYPE, StoragePolicy>::operator=(const String& s) {
             set(s.get_sexp());
             return *this;
         }
@@ -500,9 +500,9 @@ namespace Rcpp {
             return s.get_sexp();
         }
 
-        template <int RTYPE>
+        template <int RTYPE, template <class> class StoragePolicy>
         template <typename T>
-        string_proxy<RTYPE>& string_proxy<RTYPE>::operator+=(const T& rhs) {
+        string_proxy<RTYPE, StoragePolicy>& string_proxy<RTYPE, StoragePolicy>::operator+=(const T& rhs) {
             String tmp = get();
             tmp += rhs;
             set(tmp);

--- a/inst/include/Rcpp/internal/Proxy_Iterator.h
+++ b/inst/include/Rcpp/internal/Proxy_Iterator.h
@@ -81,7 +81,7 @@ public:
 		}
 
 		inline reference operator*() {
-			return proxy ;
+		    return proxy ;
 		}
 		inline pointer operator->(){
 			return &proxy ;

--- a/inst/include/Rcpp/vector/00_forward_proxy.h
+++ b/inst/include/Rcpp/vector/00_forward_proxy.h
@@ -2,7 +2,7 @@
 //
 // 00_forward_proxy.h: Rcpp R/C++ interface class library -- proxies
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,25 +25,25 @@
 namespace Rcpp{
 
 namespace internal{
-	template <int RTYPE> class string_proxy ;
-	template <int RTYPE> class const_string_proxy ;
-	template <int RTYPE> class generic_proxy ;
-	template <int RTYPE> class const_generic_proxy ;
-	template <int RTYPE> class simple_name_proxy ;
-	template <int RTYPE> class string_name_proxy ;
-	template <int RTYPE> class generic_name_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class string_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class const_string_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class generic_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class const_generic_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class simple_name_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class string_name_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> class generic_name_proxy ;
 }
 
 namespace traits {
     template <int RTYPE, template <class> class StoragePolicy> struct r_vector_cache_type ;
 	template <int RTYPE, template <class> class StoragePolicy> class r_vector_cache ;
 
-	template <int RTYPE> struct r_vector_name_proxy ;
-	template <int RTYPE> struct r_vector_proxy ;
-	template <int RTYPE> struct r_vector_const_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> struct r_vector_name_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> struct r_vector_proxy ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> struct r_vector_const_proxy ;
 
-	template <int RTYPE> struct r_vector_iterator ;
-	template <int RTYPE> struct r_vector_const_iterator ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> struct r_vector_iterator ;
+	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage> struct r_vector_const_iterator ;
 
 }
 }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -936,6 +936,7 @@ private:
         }
 
         R_xlen_t n = size() ;
+
         Vector target( n - 1 ) ;
         iterator target_it(target.begin()) ;
         iterator it(begin()) ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -2,7 +2,7 @@
 //
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
-// Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -40,12 +40,12 @@ public:
     typedef StoragePolicy<Vector> Storage ;
 
     typename traits::r_vector_cache_type<RTYPE, StoragePolicy>::type cache ;
-    typedef typename traits::r_vector_proxy<RTYPE>::type Proxy ;
-    typedef typename traits::r_vector_const_proxy<RTYPE>::type const_Proxy ;
-    typedef typename traits::r_vector_name_proxy<RTYPE>::type NameProxy ;
-    typedef typename traits::r_vector_proxy<RTYPE>::type value_type ;
-    typedef typename traits::r_vector_iterator<RTYPE>::type iterator ;
-    typedef typename traits::r_vector_const_iterator<RTYPE>::type const_iterator ;
+    typedef typename traits::r_vector_proxy<RTYPE, StoragePolicy>::type Proxy ;
+    typedef typename traits::r_vector_const_proxy<RTYPE, StoragePolicy>::type const_Proxy ;
+    typedef typename traits::r_vector_name_proxy<RTYPE, StoragePolicy>::type NameProxy ;
+    typedef typename traits::r_vector_proxy<RTYPE, StoragePolicy>::type value_type ;
+    typedef typename traits::r_vector_iterator<RTYPE, StoragePolicy>::type iterator ;
+    typedef typename traits::r_vector_const_iterator<RTYPE, StoragePolicy>::type const_iterator ;
     typedef typename traits::init_type<RTYPE>::type init_type ;
     typedef typename traits::r_vector_element_converter<RTYPE>::type converter_type ;
     typedef typename traits::storage_type<RTYPE>::type stored_type ;

--- a/inst/include/Rcpp/vector/const_generic_proxy.h
+++ b/inst/include/Rcpp/vector/const_generic_proxy.h
@@ -1,6 +1,6 @@
 // const_generic_proxy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2013 Romain Francois
+// Copyright (C) 2013 - 2018 Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,10 +23,10 @@
 namespace Rcpp{
 namespace internal{
 
-    template <int RTYPE>
-	class const_generic_proxy : public GenericProxy< const_generic_proxy<RTYPE> > {
+    template <int RTYPE, template <class> class StoragePolicy>
+	class const_generic_proxy : public GenericProxy< const_generic_proxy<RTYPE, StoragePolicy> > {
 		public:
-			typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+			typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 
 			const_generic_proxy(): parent(0), index(-1){}
 
@@ -48,7 +48,7 @@ namespace internal{
 			operator int() const { return ::Rcpp::as<int>(get()) ; }
 
 			inline void move(R_xlen_t n) { index += n ; }
-			
+
 			const VECTOR* parent;
 			R_xlen_t index ;
 

--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -2,7 +2,7 @@
 //
 // const_string_proxy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2013 Romain Francois
+// Copyright (C) 2013 - 2018 Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,10 +25,11 @@
 namespace Rcpp{
 namespace internal{
 
-	template<int RTYPE> class const_string_proxy {
+	template<int RTYPE, template <class> class StoragePolicy>
+	class const_string_proxy {
 	public:
 
-		typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef const char* iterator ;
 		typedef const char& reference ;
 
@@ -43,7 +44,7 @@ namespace internal{
 		const_string_proxy( const VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
 
         const_string_proxy(SEXP x): parent(0), index(0) {
-            Vector<RTYPE> tmp(x);
+            VECTOR tmp(x);
             parent = &tmp;
         }
 
@@ -76,11 +77,11 @@ namespace internal{
 		 * Prints the element this proxy refers to to an
 		 * output stream
 		 */
-		template <int RT>
-		friend std::ostream& operator<<(std::ostream& os, const const_string_proxy<RT>& proxy);
+		template <int RT, template <class> class StoragePolicy_>
+		friend std::ostream& operator<<(std::ostream& os, const const_string_proxy<RT, StoragePolicy_>& proxy);
 
-		template <int RT>
-		friend std::string operator+( const std::string& x, const const_string_proxy<RT>& proxy);
+		template <int RT, template <class> class StoragePolicy_>
+		friend std::string operator+( const std::string& x, const const_string_proxy<RT, StoragePolicy_>& proxy);
 
 		const VECTOR* parent;
 		R_xlen_t index ;
@@ -110,13 +111,13 @@ namespace internal{
 			return strcmp( begin(), other.begin() ) != 0 ;
 		}
 
-                bool operator==( SEXP other ) const {
-                    return get() == other;
-                }
+        bool operator==( SEXP other ) const {
+            return get() == other;
+        }
 
-                bool operator!=( SEXP other ) const {
-                    return get() != other;
-                }
+        bool operator!=( SEXP other ) const {
+            return get() != other;
+        }
 
 		private:
 			static std::string buffer ;
@@ -155,20 +156,22 @@ namespace internal{
 			) <= 0 ;
 	}
 
-	template<int RTYPE> std::string const_string_proxy<RTYPE>::buffer ;
+	template<int RTYPE, template <class> class StoragePolicy> std::string const_string_proxy<RTYPE, StoragePolicy>::buffer ;
 
-	inline std::ostream& operator<<(std::ostream& os, const const_string_proxy<STRSXP>& proxy) {
+	template <template <class> class StoragePolicy>
+	inline std::ostream& operator<<(std::ostream& os, const const_string_proxy<STRSXP, StoragePolicy>& proxy) {
 	    os << static_cast<const char*>(proxy) ;
 	    return os;
 	}
 
-	inline std::string operator+( const std::string& x, const const_string_proxy<STRSXP>& y ){
+	template <template <class> class StoragePolicy>
+	inline std::string operator+( const std::string& x, const const_string_proxy<STRSXP, StoragePolicy>& y ){
 		return x + static_cast<const char*>(y) ;
 	}
 
-
-	template <int RTYPE>
-	string_proxy<RTYPE>& string_proxy<RTYPE>::operator=(const const_string_proxy<RTYPE>& other){
+	template <int RTYPE, template <class> class StoragePolicy1>
+	template <template <class> class StoragePolicy2>
+	string_proxy<RTYPE, StoragePolicy1>& string_proxy<RTYPE, StoragePolicy1>::operator=(const const_string_proxy<RTYPE, StoragePolicy2>& other){
        set( other.get() ) ;
        return *this ;
     }

--- a/inst/include/Rcpp/vector/generic_proxy.h
+++ b/inst/include/Rcpp/vector/generic_proxy.h
@@ -31,17 +31,26 @@ namespace internal{
 			generic_proxy(): parent(0), index(-1){}
 
 			generic_proxy( const generic_proxy& other ) :
-				parent(other.parent), index(other.index){} ;
+				parent(other.parent), index(other.index)
+			{}
 
-			generic_proxy( VECTOR& v, R_xlen_t i ) : parent(&v), index(i){} ;
+			generic_proxy( VECTOR& v, R_xlen_t i ) :
+			    parent(&v), index(i)
+			{}
 
 			generic_proxy& operator=(SEXP rhs) {
 				set(rhs) ;
 				return *this ;
 			}
 
-			generic_proxy& operator=(const generic_proxy& rhs) {
-				set(rhs.get());
+			generic_proxy& operator=(const generic_proxy& rhs){
+			    set(rhs.get());
+    		    return *this ;
+			}
+
+			template <template <class> class StoragePolicy2>
+			generic_proxy& operator=(const generic_proxy<RTYPE,StoragePolicy2>& rhs) {
+			    set(rhs.get());
 				return *this ;
 			}
 
@@ -78,13 +87,15 @@ namespace internal{
 				index  = other.index ;
 			}
 
+			inline SEXP get() const {
+			    return VECTOR_ELT(*parent, index );
+			}
+
 		private:
 			inline void set(SEXP x) {
 			    SET_VECTOR_ELT( *parent, index, x ) ;
 			}
-			inline SEXP get() const {
-			    return VECTOR_ELT(*parent, index );
-			}
+
 
 	}  ;
 

--- a/inst/include/Rcpp/vector/generic_proxy.h
+++ b/inst/include/Rcpp/vector/generic_proxy.h
@@ -1,6 +1,6 @@
 // generic_proxy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -23,10 +23,10 @@
 namespace Rcpp{
 namespace internal{
 
-	template <int RTYPE>
-	class generic_proxy : public GenericProxy< generic_proxy<RTYPE> > {
+	template <int RTYPE, template <class> class StoragePolicy>
+	class generic_proxy : public GenericProxy< generic_proxy<RTYPE, StoragePolicy> > {
 		public:
-			typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+			typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 
 			generic_proxy(): parent(0), index(-1){}
 

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -2,7 +2,7 @@
 //
 // proxy.h: Rcpp R/C++ interface class library -- proxies
 //
-// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,10 +25,12 @@
 namespace Rcpp{
 namespace internal{
 
-	template <int RTYPE> class simple_name_proxy {
+	template <int RTYPE, template <class> class StoragePolicy>
+    class simple_name_proxy {
 	public:
-		typedef ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef typename ::Rcpp::traits::storage_type<RTYPE>::type CTYPE ;
+
 		simple_name_proxy( VECTOR& v, const std::string& name_) :
 			parent(v), name(name_){} ;
 		simple_name_proxy( const simple_name_proxy& other ) :
@@ -78,10 +80,10 @@ namespace internal{
 		}
 	} ;
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	class string_name_proxy{
 	public:
-		typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef const char* iterator ;
 		typedef const char& reference ;
 
@@ -131,9 +133,10 @@ namespace internal{
 
 	} ;
 
-	template <int RTYPE> class generic_name_proxy {
+	template <int RTYPE, template <class> class StoragePolicy>
+	class generic_name_proxy {
 	public:
-		typedef ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		generic_name_proxy( VECTOR& v, const std::string& name_) :
 			parent(v), name(name_){}
 		generic_name_proxy( const generic_name_proxy& other ) :
@@ -192,70 +195,81 @@ namespace internal{
 
 namespace traits {
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	struct r_vector_name_proxy{
-		typedef typename ::Rcpp::internal::simple_name_proxy<RTYPE> type ;
+		typedef typename ::Rcpp::internal::simple_name_proxy<RTYPE, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_name_proxy<STRSXP>{
-		typedef ::Rcpp::internal::string_name_proxy<STRSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_name_proxy<STRSXP, StoragePolicy>{
+		typedef ::Rcpp::internal::string_name_proxy<STRSXP, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_name_proxy<VECSXP>{
-		typedef ::Rcpp::internal::generic_name_proxy<VECSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_name_proxy<VECSXP, StoragePolicy>{
+		typedef ::Rcpp::internal::generic_name_proxy<VECSXP, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_name_proxy<EXPRSXP>{
-		typedef ::Rcpp::internal::generic_name_proxy<EXPRSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_name_proxy<EXPRSXP, StoragePolicy>{
+		typedef ::Rcpp::internal::generic_name_proxy<EXPRSXP, StoragePolicy> type ;
 	} ;
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	struct r_vector_proxy{
 		typedef typename storage_type<RTYPE>::type& type ;
 	} ;
-	template<> struct r_vector_proxy<STRSXP> {
-		typedef ::Rcpp::internal::string_proxy<STRSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_proxy<STRSXP, StoragePolicy> {
+		typedef ::Rcpp::internal::string_proxy<STRSXP, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_proxy<EXPRSXP> {
+	template<template <class> class StoragePolicy>
+	struct r_vector_proxy<EXPRSXP, StoragePolicy> {
 		typedef ::Rcpp::internal::generic_proxy<EXPRSXP> type ;
 	} ;
-	template<> struct r_vector_proxy<VECSXP> {
+	template<template <class> class StoragePolicy>
+	struct r_vector_proxy<VECSXP, StoragePolicy> {
 		typedef ::Rcpp::internal::generic_proxy<VECSXP> type ;
 	} ;
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	struct r_vector_const_proxy{
 		typedef const typename storage_type<RTYPE>::type& type ;
 	} ;
-	template<> struct r_vector_const_proxy<STRSXP> {
-		typedef ::Rcpp::internal::const_string_proxy<STRSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_const_proxy<STRSXP, StoragePolicy> {
+		typedef ::Rcpp::internal::const_string_proxy<STRSXP, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_const_proxy<VECSXP> {
-		typedef ::Rcpp::internal::const_generic_proxy<VECSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_const_proxy<VECSXP, StoragePolicy> {
+		typedef ::Rcpp::internal::const_generic_proxy<VECSXP, StoragePolicy> type ;
 	} ;
-	template<> struct r_vector_const_proxy<EXPRSXP> {
-		typedef ::Rcpp::internal::const_generic_proxy<EXPRSXP> type ;
+	template<template <class> class StoragePolicy>
+	struct r_vector_const_proxy<EXPRSXP, StoragePolicy> {
+		typedef ::Rcpp::internal::const_generic_proxy<EXPRSXP, StoragePolicy> type ;
 	} ;
 
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	struct r_vector_iterator {
 		typedef typename storage_type<RTYPE>::type* type ;
 	};
-	template <int RTYPE>
+	template <int RTYPE, template <class> class StoragePolicy>
 	struct r_vector_const_iterator {
 		typedef const typename storage_type<RTYPE>::type* type ;
 	};
 
-	template <int RTYPE> struct proxy_based_iterator{
-		typedef ::Rcpp::internal::Proxy_Iterator< typename r_vector_proxy<RTYPE>::type > type ;
+	template <int RTYPE, template <class> class StoragePolicy>
+	struct proxy_based_iterator{
+		typedef ::Rcpp::internal::Proxy_Iterator< typename r_vector_proxy<RTYPE, StoragePolicy>::type > type ;
 	} ;
-	template<> struct r_vector_iterator<VECSXP> : proxy_based_iterator<VECSXP>{} ;
-	template<> struct r_vector_iterator<EXPRSXP> : proxy_based_iterator<EXPRSXP>{} ;
-	template<> struct r_vector_iterator<STRSXP> : proxy_based_iterator<STRSXP>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_iterator<VECSXP, StoragePolicy> : proxy_based_iterator<VECSXP, StoragePolicy>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_iterator<EXPRSXP, StoragePolicy> : proxy_based_iterator<EXPRSXP, StoragePolicy>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_iterator<STRSXP, StoragePolicy> : proxy_based_iterator<STRSXP, StoragePolicy>{} ;
 
-	template <int RTYPE> struct proxy_based_const_iterator{
-		typedef ::Rcpp::internal::Proxy_Iterator< typename r_vector_const_proxy<RTYPE>::type > type ;
+	template <int RTYPE, template <class> class StoragePolicy>
+	struct proxy_based_const_iterator{
+		typedef ::Rcpp::internal::Proxy_Iterator< typename r_vector_const_proxy<RTYPE, StoragePolicy>::type > type ;
 	} ;
-	template<> struct r_vector_const_iterator<VECSXP> : proxy_based_const_iterator<VECSXP>{} ;
-	template<> struct r_vector_const_iterator<EXPRSXP> : proxy_based_const_iterator<EXPRSXP>{} ;
-	template<> struct r_vector_const_iterator<STRSXP> : proxy_based_const_iterator<STRSXP>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_const_iterator<VECSXP, StoragePolicy> : proxy_based_const_iterator<VECSXP, StoragePolicy>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_const_iterator<EXPRSXP, StoragePolicy> : proxy_based_const_iterator<EXPRSXP, StoragePolicy>{} ;
+	template<template <class> class StoragePolicy> struct r_vector_const_iterator<STRSXP, StoragePolicy> : proxy_based_const_iterator<STRSXP, StoragePolicy>{} ;
 
 }  // traits
 }

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -222,11 +222,11 @@ namespace traits {
 	} ;
 	template<template <class> class StoragePolicy>
 	struct r_vector_proxy<EXPRSXP, StoragePolicy> {
-		typedef ::Rcpp::internal::generic_proxy<EXPRSXP> type ;
+		typedef ::Rcpp::internal::generic_proxy<EXPRSXP, StoragePolicy> type ;
 	} ;
 	template<template <class> class StoragePolicy>
 	struct r_vector_proxy<VECSXP, StoragePolicy> {
-		typedef ::Rcpp::internal::generic_proxy<VECSXP> type ;
+		typedef ::Rcpp::internal::generic_proxy<VECSXP, StoragePolicy> type ;
 	} ;
 
 	template <int RTYPE, template <class> class StoragePolicy>

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -53,9 +53,10 @@ namespace internal{
 		 *
 		 * @param rhs another proxy, possibly from another vector
 		 */
-		string_proxy& operator=(const string_proxy& other){
-			set( other.get() ) ;
-			return *this ;
+		template <template <class> class StoragePolicy2>
+		string_proxy& operator=( const string_proxy<RTYPE, StoragePolicy2>& other) {
+		    set( other.get() ) ;
+		    return *this ;
 		}
 
 		template <template <class> class StoragePolicy2>

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -2,7 +2,7 @@
 //
 // string_proxy.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -25,10 +25,11 @@
 namespace Rcpp{
 namespace internal{
 
-	template<int RTYPE> class string_proxy {
+	template<int RTYPE, template <class> class StoragePolicy>
+	class string_proxy {
 	public:
 
-		typedef typename ::Rcpp::Vector<RTYPE> VECTOR ;
+		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef const char* iterator ;
 		typedef const char& reference ;
 
@@ -57,7 +58,8 @@ namespace internal{
 			return *this ;
 		}
 
-		string_proxy& operator=( const const_string_proxy<RTYPE>& other) ;
+		template <template <class> class StoragePolicy2>
+		string_proxy& operator=( const const_string_proxy<RTYPE, StoragePolicy2>& other) ;
 
 		string_proxy& operator=( const String& s) ;
 
@@ -238,7 +240,7 @@ namespace internal{
 			) <= 0 ;
 	}
 
-	template<int RTYPE> std::string string_proxy<RTYPE>::buffer ;
+	template<int RTYPE, template <class> class StoragePolicy> std::string string_proxy<RTYPE, StoragePolicy>::buffer ;
 
 	inline std::ostream& operator<<(std::ostream& os, const string_proxy<STRSXP>& proxy) {
 	    os << static_cast<const char*>(proxy) ;

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -44,7 +44,8 @@ namespace internal{
 		string_proxy( VECTOR& v, R_xlen_t index_ ) : parent(&v), index(index_){}
 
 		string_proxy( const string_proxy& other ) :
-			parent(other.parent), index(other.index){} ;
+			parent(other.parent), index(other.index)
+		{} ;
 
 		/**
 		 * lhs use. Assign the value of the referred element to
@@ -53,6 +54,11 @@ namespace internal{
 		 *
 		 * @param rhs another proxy, possibly from another vector
 		 */
+		string_proxy& operator=( const string_proxy<RTYPE, StoragePolicy>& other) {
+		    set( other.get() ) ;
+		    return *this ;
+		}
+
 		template <template <class> class StoragePolicy2>
 		string_proxy& operator=( const string_proxy<RTYPE, StoragePolicy2>& other) {
 		    set( other.get() ) ;

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -2,7 +2,7 @@
 //
 // traits.h: Rcpp R/C++ interface class library -- support traits for vector
 //
-// Copyright (C) 2010 - 2015 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -57,8 +57,8 @@ namespace traits{
 		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
 		typedef typename r_vector_iterator<RTYPE>::type iterator ;
 		typedef typename r_vector_const_iterator<RTYPE>::type const_iterator ;
-		typedef typename r_vector_proxy<RTYPE>::type proxy ;
-		typedef typename r_vector_const_proxy<RTYPE>::type const_proxy ;
+		typedef typename r_vector_proxy<RTYPE, StoragePolicy>::type proxy ;
+		typedef typename r_vector_const_proxy<RTYPE, StoragePolicy>::type const_proxy ;
 
 		proxy_cache(): p(0){}
 		~proxy_cache(){}

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -55,8 +55,8 @@ namespace traits{
 	class proxy_cache{
 	public:
 		typedef typename ::Rcpp::Vector<RTYPE, StoragePolicy> VECTOR ;
-		typedef typename r_vector_iterator<RTYPE>::type iterator ;
-		typedef typename r_vector_const_iterator<RTYPE>::type const_iterator ;
+		typedef typename r_vector_iterator<RTYPE, StoragePolicy>::type iterator ;
+		typedef typename r_vector_const_iterator<RTYPE, StoragePolicy>::type const_iterator ;
 		typedef typename r_vector_proxy<RTYPE, StoragePolicy>::type proxy ;
 		typedef typename r_vector_const_proxy<RTYPE, StoragePolicy>::type const_proxy ;
 
@@ -75,8 +75,8 @@ namespace traits{
 		inline const_proxy ref() const { return const_proxy(*p,0) ; }
 		inline const_proxy ref(R_xlen_t i) const { return const_proxy(*p,i);}
 
-		private:
-			VECTOR* p ;
+	private:
+		VECTOR* p ;
 	} ;
 
 	// regular types for INTSXP, REALSXP, ...

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -855,3 +855,16 @@ int CharacterVectorNoProtect(Vector<STRSXP, NoProtectStorage> s){
     return s.size();
 }
 
+// [[Rcpp::export]]
+CharacterVector CharacterVectorNoProtect_crosspolicy(Vector<STRSXP, NoProtectStorage> s){
+    CharacterVector s2(1) ;
+    s2[0] = s[0];
+    return s;
+}
+
+// [[Rcpp::export]]
+List ListNoProtect_crosspolicy(Vector<VECSXP, NoProtectStorage> data){
+    List data2(1) ;
+    data2[0] = data[0];
+    return data2;
+}

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -2,7 +2,7 @@
 //
 // Vector.cpp: Rcpp R/C++ interface class library -- Vector unit tests
 //
-// Copyright (C) 2012 - 2015    Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2018    Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -848,3 +848,10 @@ String vec_print_integer(IntegerVector v) {
 IntegerVector vec_subset(IntegerVector x, IntegerVector y) {
     return x[y - 1];
 }
+
+// [[Rcpp::export]]
+int CharacterVectorNoProtect(Vector<STRSXP, NoProtectStorage> s){
+    s[0] = "";
+    return s.size();
+}
+

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env r
 #       hey emacs, please make this use  -*- tab-width: 4 -*-
 #
-# Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -499,7 +499,7 @@ if (.runThisTest) {
                     paste(letters, collapse=""),
                     msg = "CharacterVector::iterator using std::accumulate" )
     }
-    
+
     test.CharacterVector.iterator <- function(){
         fun <- character_const_iterator1
         checkEquals(fun(letters),
@@ -655,12 +655,12 @@ if (.runThisTest) {
         res <- character_vector_const_proxy( "fooo" )
         checkEquals( res, "fooo", msg = "CharacterVector const proxy. #32" )
     }
-    
+
     test.CharacterVector.test.const.proxy <- function(){
         res <- CharacterVector_test_const_proxy( letters )
         checkEquals( res, letters )
     }
-  
+
     test.sort <- function() {
         num <- setNames( c(1, -1, 4, NA, 5, NaN), letters[1:5] )
         checkIdentical( sort_numeric(num), sort(num, na.last=TRUE) )
@@ -671,33 +671,33 @@ if (.runThisTest) {
         lgcl <- as.logical(int)
         checkIdentical( sort_logical(lgcl), sort(lgcl, na.last=TRUE) )
     }
-    
+
     test.sort_desc <- function() {
         num <- setNames(c(1, -1, 4, NA, 5, NaN), letters[1:5])
         checkIdentical(
-            sort_numeric_desc(num), 
+            sort_numeric_desc(num),
             sort(num, decreasing = TRUE, na.last = FALSE)
         )
-        
+
         int <- as.integer(num)
         checkIdentical(
-            sort_integer_desc(int), 
-            sort(int, decreasing = TRUE, na.last = FALSE) 
+            sort_integer_desc(int),
+            sort(int, decreasing = TRUE, na.last = FALSE)
         )
-        
+
         char <- setNames(sample(letters, 5), LETTERS[1:5])
         checkIdentical(
-            sort_character_desc(char), 
-            sort(char, decreasing = TRUE, na.last = FALSE) 
+            sort_character_desc(char),
+            sort(char, decreasing = TRUE, na.last = FALSE)
         )
-        
+
         lgcl <- as.logical(int)
         checkIdentical(
-            sort_logical_desc(lgcl), 
-            sort(lgcl, decreasing = TRUE, na.last = FALSE) 
+            sort_logical_desc(lgcl),
+            sort(lgcl, decreasing = TRUE, na.last = FALSE)
         )
     }
-    
+
     test.List.assign.SEXP <- function() {
         l <- list(1, 2, 3)
         other <- list_sexp_assign(l)
@@ -711,12 +711,12 @@ if (.runThisTest) {
     test.logical.vector.from.bool.assign <- function() {
         checkIdentical(logical_vector_from_bool_assign(), TRUE)
     }
-    
+
     test.noprotect_vector <- function(){
         x <- rnorm(10)
         checkIdentical( noprotect_vector(x), 10L )
     }
-    
+
     test.noprotect_matrix <- function(){
         x <- matrix(rnorm(10), nrow=2)
         checkIdentical( noprotect_matrix(x), 2L )
@@ -754,6 +754,12 @@ if (.runThisTest) {
         z <- vec_subset(x, y)
         gctorture(FALSE)
         checkEquals(x[y], z)
+    }
+
+    test.CharacterVectorNoProtect <- function(){
+        s <- "foo"
+        checkEquals(CharacterVectorNoProtect(s), 1L)
+        checkEquals(s, "")
     }
 }
 

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -761,5 +761,15 @@ if (.runThisTest) {
         checkEquals(CharacterVectorNoProtect(s), 1L)
         checkEquals(s, "")
     }
-}
 
+    test.CharacterVectorNoProtect_crosspolicy <- function(){
+        s <- "foo"
+        checkEquals(CharacterVectorNoProtect_crosspolicy(s), s)
+    }
+
+    test.ListNoProtect_crosspolicy <- function(){
+        data <- list(1:10)
+        data2 <- ListNoProtect_crosspolicy(data)
+        checkEquals(data, data2)
+    }
+}


### PR DESCRIPTION
This was a but more than I anticipated. Probably not exhaustive. but it makes the tests pass. 

```cpp
// [[Rcpp::export]]
int CharacterVectorNoProtect(Vector<STRSXP, NoProtectStorage> s){
    s[0] = "";
    return s.size();
}

// [[Rcpp::export]]
CharacterVector CharacterVectorNoProtect_crosspolicy(Vector<STRSXP, NoProtectStorage> s){
    CharacterVector s2(1) ;
    s2[0] = s[0];
    return s;
}

// [[Rcpp::export]]
List ListNoProtect_crosspolicy(Vector<VECSXP, NoProtectStorage> data){
    List data2(1) ;
    data2[0] = data[0];
    return data2;
}
```