### PR TITLE
execute embedded R script in specified env

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -196,7 +196,7 @@ sourceCpp <- function(file = "",
     if (embeddedR && (length(context$embeddedR) > 0)) {
         srcConn <- textConnection(context$embeddedR)
         setwd(rWorkingDir) # will be reset by previous on.exit handler
-        source(file=srcConn, echo=TRUE)
+        source(file = srcConn, local = env, echo = TRUE)
     }
 
     # cleanup the cache dir if requested


### PR DESCRIPTION
Fixes #851 

As mentioned in the issue, I have no idea about how to include a unit test to verify the new behavior; I am open to suggestions or somebody else adding it. Thanks!

I checked locally and it works:

`test.rcpp`

```cpp
#include <Rcpp.h>
using namespace Rcpp ;

// [[Rcpp::export]]
int answer(){
    return 42 ;
}

/*** R
    # call answer and check you get the right result
    x <- answer()
    x
*/
```

in R:

```R
> library(Rcpp)
> testEnv <- new.env()
> sourceCpp("test.cpp", env = testEnv)

>     # call answer and check you get the right result
>     x <- answer()

>     x
[1] 42
> ls(testEnv)
[1] "answer" "x"  
```