### PR TITLE
making string_proxy::operator==( string_proxy ) const to disambiguate

### DIFF
--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -194,10 +194,13 @@ namespace internal{
 			return strcmp( begin(), other ) != 0 ;
 		}
 
-		bool operator==( const string_proxy& other) const {
+		template<template <class> class SP>
+		bool operator==( const string_proxy<STRSXP, SP>& other) const {
 			return strcmp( begin(), other.begin() ) == 0 ;
 		}
-		bool operator!=( const string_proxy& other) const {
+
+		template<template <class> class SP>
+		bool operator!=( const string_proxy<STRSXP,SP>& other) const {
 			return strcmp( begin(), other.begin() ) != 0 ;
 		}
 

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -187,31 +187,30 @@ namespace internal{
 			std::for_each( begin(), end(), op );
 		}
 
-		bool operator==( const char* other){
+		bool operator==( const char* other) const {
 			return strcmp( begin(), other ) == 0 ;
 		}
-		bool operator!=( const char* other){
+		bool operator!=( const char* other) const {
 			return strcmp( begin(), other ) != 0 ;
 		}
 
-		bool operator==( const string_proxy& other){
+		bool operator==( const string_proxy& other) const {
 			return strcmp( begin(), other.begin() ) == 0 ;
 		}
-		bool operator!=( const string_proxy& other){
+		bool operator!=( const string_proxy& other) const {
 			return strcmp( begin(), other.begin() ) != 0 ;
 		}
 
-                bool operator==( SEXP other ) const {
-                    return get() == other;
-                }
+        bool operator==( SEXP other ) const {
+            return get() == other;
+        }
 
-                bool operator!=( SEXP other ) const {
-                    return get() != other;
-                }
+        bool operator!=( SEXP other ) const {
+            return get() != other;
+        }
 
-
-		private:
-			static std::string buffer ;
+	private:
+		static std::string buffer ;
 
 	} ;
 

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -877,3 +877,12 @@ bool CharacterVector_test_equality(CharacterVector x, CharacterVector y) {
 
     return std::equal(x.begin(), x.end(), y.begin());
 }
+
+// [[Rcpp::export]]
+bool CharacterVector_test_equality_crosspolicy(CharacterVector x, Vector<STRSXP,NoProtectStorage> y) {
+    if (x.length() != y.length()) {
+        return false;
+    }
+
+    return std::equal(x.begin(), x.end(), y.begin());
+}

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -868,3 +868,12 @@ List ListNoProtect_crosspolicy(Vector<VECSXP, NoProtectStorage> data){
     data2[0] = data[0];
     return data2;
 }
+
+// [[Rcpp::export]]
+bool CharacterVector_test_equality(CharacterVector x, CharacterVector y) {
+    if (x.length() != y.length()) {
+        return false;
+    }
+
+    return std::equal(x.begin(), x.end(), y.begin());
+}

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -772,4 +772,8 @@ if (.runThisTest) {
         data2 <- ListNoProtect_crosspolicy(data)
         checkEquals(data, data2)
     }
+
+    test.CharacterVector_test_equality <- function(){
+       checkTrue( !CharacterVector_test_equality("foo", "bar") )
+    }
 }

--- a/inst/unitTests/runit.Vector.R
+++ b/inst/unitTests/runit.Vector.R
@@ -774,6 +774,7 @@ if (.runThisTest) {
     }
 
     test.CharacterVector_test_equality <- function(){
-       checkTrue( !CharacterVector_test_equality("foo", "bar") )
+        checkTrue( !CharacterVector_test_equality("foo", "bar") )
+        checkTrue( !CharacterVector_test_equality_crosspolicy("foo", "bar") )
     }
 }


### PR DESCRIPTION
Fixes #854 

```cpp
#include <algorithm>
#include <Rcpp.h>
using namespace Rcpp ;

// [[Rcpp::export]]
bool test(CharacterVector x, CharacterVector y) {
    if (x.length() != y.length()) {
        return false;
    }

    return std::equal(x.begin(), x.end(), y.begin());
}


/*** R
test("foo", "bar")
*/
```

 gives : 

```
romain@purrplex ~/git/RcppCore $ Rscript -e 'Rcpp::sourceCpp("~/Desktop/test.cpp")'

> test("foo", "bar")
[1] FALSE
```