### PR TITLE
making Environment::new_child() const

### DIFF
--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -407,7 +407,7 @@ namespace Rcpp{
         /**
          * creates a new environment whose this is the parent
          */
-        Environment_Impl new_child(bool hashed) {
+        Environment_Impl new_child(bool hashed) const {
             SEXP newEnvSym = Rf_install("new.env");
             return Environment_Impl( Rcpp_eval(Rf_lang3( newEnvSym, Rf_ScalarLogical(hashed), Storage::get__() )) );
         }


### PR DESCRIPTION
so that we can call `new_child()` on a `const Environment&`. 

I did not add a test because for some reason 🤷‍♀️ the existing test about `new_child` is commented out: 

```r
    #test.environment.child <- function(){
    #    checkEquals( parent.env(runit_child()), globalenv(), msg = "child environment" )
    #}
```