### PR TITLE
provide class for suspension of RNG synchronization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2018-06-06  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/RNGScope.h: Allow suspension of RNG synchronization
+	* inst/include/Rcpp/routines.h: Idem
+	* src/Rcpp_init.cpp: Idem
+	* src/api.cpp: Idem
+
 2018-05-09  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION: Release 0.12.17

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,10 @@
     \itemize{
       \item The random number \code{Generator} class no longer inhreits from
       \code{RNGScope} (Kevin in \ghpr{837} fixing \ghit{836}).
+	  \item A new class, \code{SuspendRNGSynchronizationScope}, can be created
+	  and used to ensure that calls to Rcpp functions do not attempt to call
+	  \code{::GetRNGstate()} or \code{::PutRNGstate()} for the duration of
+	  some code block.
       \item A spurious parenthesis was removed to please gcc8 (Dirk
       fixing \ghit{841})
       \item The optional \code{Timer} class header now undefines

--- a/inst/include/Rcpp/RNGScope.h
+++ b/inst/include/Rcpp/RNGScope.h
@@ -30,6 +30,12 @@ public:
     ~RNGScope(){ internal::exitRNGScope(); }
 };
 
+class SuspendRNGSynchronizationScope {
+public:
+    SuspendRNGSynchronizationScope() { internal::beginSuspendRNGSynchronization(); }
+    ~SuspendRNGSynchronizationScope() { internal::endSuspendRNGSynchronization(); }
+};
+
 } // namespace Rcpp
 
 #endif

--- a/inst/include/Rcpp/routines.h
+++ b/inst/include/Rcpp/routines.h
@@ -31,6 +31,8 @@ namespace Rcpp{
     namespace internal{
         unsigned long enterRNGScope();
         unsigned long exitRNGScope();
+        unsigned long beginSuspendRNGSynchronization();
+        unsigned long endSuspendRNGSynchronization();
         char* get_string_buffer();
         SEXP get_Rcpp_namespace();
     }
@@ -83,6 +85,18 @@ namespace Rcpp {
         inline attribute_hidden unsigned long exitRNGScope(){
             typedef unsigned long (*Fun)(void);
             static Fun fun = GET_CALLABLE("exitRNGScope");
+            return fun();
+        }
+
+        inline attribute_hidden unsigned long beginSuspendRNGSynchronization(){
+            typedef unsigned long (*Fun)(void);
+            static Fun fun = GET_CALLABLE("beginSuspendRNGSynchronization");
+            return fun();
+        }
+
+        inline attribute_hidden unsigned long endSuspendRNGSynchronization(){
+            typedef unsigned long (*Fun)(void);
+            static Fun fun = GET_CALLABLE("endSuspendRNGSynchronization");
             return fun();
         }
 

--- a/src/Rcpp_init.cpp
+++ b/src/Rcpp_init.cpp
@@ -94,6 +94,8 @@ void registerFunctions(){
     RCPP_REGISTER(demangle)
     RCPP_REGISTER(enterRNGScope)
     RCPP_REGISTER(exitRNGScope)
+    RCPP_REGISTER(beginSuspendRNGSynchronization);
+    RCPP_REGISTER(endSuspendRNGSynchronization);
     RCPP_REGISTER(get_Rcpp_namespace)
     RCPP_REGISTER(get_cache)
     RCPP_REGISTER(stack_trace)

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -65,16 +65,32 @@ namespace Rcpp {
 
     namespace internal {
 
+        int rngSynchronizationSuspended = 0;
+
         // [[Rcpp::register]]
         unsigned long enterRNGScope() {
-            GetRNGstate();
+            if (rngSynchronizationSuspended == 0)
+                GetRNGstate();
             return 0;
         }
 
         // [[Rcpp::register]]
         unsigned long exitRNGScope() {
-            PutRNGstate();
+            if (rngSynchronizationSuspended == 0)
+                PutRNGstate();
             return 0;
+        }
+
+        // [[Rcpp::register]]
+        unsigned long beginSuspendRNGSynchronization() {
+            ++rngSynchronizationSuspended;
+            return rngSynchronizationSuspended;
+        }
+
+        // [[Rcpp::register]]
+        unsigned long endSuspendRNGSynchronization() {
+            --rngSynchronizationSuspended;
+            return rngSynchronizationSuspended;
         }
 
         // [[Rcpp::register]]


### PR DESCRIPTION
This PR provides a class, `SuspendRNGSynchronizationScope`, which can be used to signal that throughout the lifetime of that object Rcpp should not attempt to synchronize the R and C RNG states.

This tool effectively allows users to opt-in to the 'old' Rcpp RNG behavior by creating an instance of this class where desired. This could be used to fix, for example, https://github.com/eddelbuettel/rcppde/issues/14#issuecomment-395135496.

The intention would be for `RcppDE` to construct an instance of `SuspendRNGSynchronizationScope` pretty early in the `DEOptim_impl` implementation.

FWIW, I tested this fix with a locally built copy of `RcppDE` and it does fix the issue -- I can send a PR if we find that this change looks good.