### PR TITLE
Switching from Rcpp_eval to Rcpp_fast_eval. close #866

### DIFF
--- a/inst/examples/SugarPerformance/sugarBenchmarks.R
+++ b/inst/examples/SugarPerformance/sugarBenchmarks.R
@@ -53,7 +53,7 @@ src <- sprintf( '
 
     timer.Reset(); timer.Start();
     for (unsigned int i=0; i<runs; i++) {
-        NumericVector res2 = Rcpp_eval( call, e ) ;
+        NumericVector res2 = Rcpp_fast_eval( call, e ) ;
     }
     timer.Stop();
     double t3 = timer.ElapsedTime();

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -132,7 +132,7 @@ namespace Rcpp{
             obj.attr( "names") = names ;
             Shield<SEXP> call( Rf_lang3(as_df_symb, obj, wrap( strings_as_factors ) ) ) ;
             SET_TAG( CDDR(call),  strings_as_factors_symb ) ;
-            Shield<SEXP> res( Rcpp_eval( call ) ) ;
+            Shield<SEXP> res( Rcpp_fast_eval( call ) ) ;
             DataFrame_Impl out( res ) ;
             return out ;
 

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -33,7 +33,7 @@ namespace Rcpp{
             if( Rf_isEnvironment(x) ) return x ;
             SEXP asEnvironmentSym = Rf_install("as.environment");
             try {
-                Shield<SEXP> res( Rcpp_eval( Rf_lang2( asEnvironmentSym, x ) ) );
+                Shield<SEXP> res( Rcpp_fast_eval( Rf_lang2( asEnvironmentSym, x ) ) );
                 return res ;
             } catch( const eval_error& ex) {
                 const char* fmt = "Cannot convert object to an environment: "
@@ -249,7 +249,7 @@ namespace Rcpp{
                     Shield<SEXP> call( Rf_lang2(internalSym,
                             Rf_lang4(removeSym, Rf_mkString(name.c_str()), Storage::get__(), Rf_ScalarLogical( FALSE ))
                         ) );
-                    Rcpp_eval( call, R_GlobalEnv ) ;
+                    Rcpp_fast_eval( call, R_GlobalEnv ) ;
                 }
             } else{
                 throw no_such_binding(name) ;
@@ -374,7 +374,7 @@ namespace Rcpp{
             try{
                 SEXP getNamespaceSym = Rf_install("getNamespace");
                 Shield<SEXP> package_str( Rf_mkString(package.c_str()) );
-                env = Rcpp_eval( Rf_lang2(getNamespaceSym, package_str) ) ;
+                env = Rcpp_fast_eval( Rf_lang2(getNamespaceSym, package_str) ) ;
             } catch( ... ){
                 throw no_such_namespace( package  ) ;
             }
@@ -393,7 +393,7 @@ namespace Rcpp{
          */
         Environment_Impl new_child(bool hashed) const {
             SEXP newEnvSym = Rf_install("new.env");
-            return Environment_Impl( Rcpp_eval(Rf_lang3( newEnvSym, Rf_ScalarLogical(hashed), Storage::get__() )) );
+            return Environment_Impl( Rcpp_fast_eval(Rf_lang3( newEnvSym, Rf_ScalarLogical(hashed), Storage::get__() )) );
         }
 
 

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -79,7 +79,7 @@ namespace Rcpp{
 
         SEXP operator()() const {
             Shield<SEXP> call(Rf_lang1(Storage::get__()));
-            return Rcpp_eval(call);
+            return Rcpp_fast_eval(call);
         }
 
         #include <Rcpp/generated/Function__operator.h>

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -134,14 +134,14 @@ namespace Rcpp{
          * eval this call in the global environment
          */
         SEXP eval() const {
-            return Rcpp_eval( Storage::get__(), R_GlobalEnv ) ;
+            return Rcpp_fast_eval( Storage::get__(), R_GlobalEnv ) ;
         }
 
         /**
          * eval this call in the requested environment
          */
         SEXP eval(SEXP env) const {
-            return Rcpp_eval( Storage::get__(), env ) ;
+            return Rcpp_fast_eval( Storage::get__(), env ) ;
         }
 
         SEXP fast_eval() const {

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -454,7 +454,7 @@ static VARIABLE_IS_NOT_USED SEXP moduleSym = NULL;
 // this macro is called by code wanting to load a module -- see RInside's rinside_module_sample0.cpp
 #define LOAD_RCPP_MODULE(NAME) \
     Shield<SEXP> __load_module_call__( Rf_lang2( GET_MODULE_SYM, _rcpp_module_boot_##NAME() ) ); \
-    Rcpp_eval( __load_module_call__, R_GlobalEnv );
+    Rcpp_fast_eval( __load_module_call__, R_GlobalEnv );
 
 #endif
 

--- a/inst/include/Rcpp/Reference.h
+++ b/inst/include/Rcpp/Reference.h
@@ -59,7 +59,7 @@ namespace Rcpp{
         Reference_Impl( const std::string& klass ) {
             SEXP newSym = Rf_install("new");
             Shield<SEXP> call( Rf_lang2( newSym, Rf_mkString( klass.c_str() ) ) );
-            Storage::set__( Rcpp_eval( call , Rcpp::internal::get_Rcpp_namespace()) );
+            Storage::set__( Rcpp_fast_eval( call , Rcpp::internal::get_Rcpp_namespace()) );
         }
 
         void update( SEXP x){

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -255,7 +255,7 @@ inline SEXP get_last_call(){
     SEXP sys_calls_symbol = Rf_install("sys.calls");
 
     Rcpp::Shield<SEXP> sys_calls_expr(Rf_lang1(sys_calls_symbol));
-    Rcpp::Shield<SEXP> calls(Rcpp_eval(sys_calls_expr, R_GlobalEnv));
+    Rcpp::Shield<SEXP> calls(Rcpp_fast_eval(sys_calls_expr, R_GlobalEnv));
 
     SEXP cur, prev;
     prev = cur = calls;

--- a/inst/include/Rcpp/generated/Function__operator.h
+++ b/inst/include/Rcpp/generated/Function__operator.h
@@ -26,108 +26,108 @@
 
 	template <TYPENAMES>
 	SEXP operator()(ARGUMENTS){
-		return Rcpp_eval( Rf_lang2( Storage::get__(), pairlist(PARAMETERS) ) ) ;
+		return Rcpp_fast_eval( Rf_lang2( Storage::get__(), pairlist(PARAMETERS) ) ) ;
 	}
 
 */
 	template <typename T1>
 	SEXP operator()(const T1& t1) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1) ) ) ;
 	}
 
 	template <typename T1, typename T2>
 	SEXP operator()(const T1& t1, const T2& t2) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18, typename T19>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18, const T19& t19) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19) ) ) ;
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18, typename T19, typename T20>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18, const T19& t19, const T20& t20) const {
-		return Rcpp_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20) ) ) ;
+		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20) ) ) ;
 	}
 
 /* </code-bloat> */

--- a/inst/include/Rcpp/proxy/FieldProxy.h
+++ b/inst/include/Rcpp/proxy/FieldProxy.h
@@ -42,12 +42,12 @@ public:
 
         SEXP get() const {
             Shield<SEXP> call( Rf_lang3( R_DollarSymbol, parent, Rf_mkString(field_name.c_str()) ) ) ;
-            return Rcpp_eval( call, R_GlobalEnv ) ;
+            return Rcpp_fast_eval( call, R_GlobalEnv ) ;
         }
         void set(SEXP x ) {
             SEXP dollarGetsSym = Rf_install( "$<-");
             Shield<SEXP> call( Rf_lang4( dollarGetsSym, parent, Rf_mkString(field_name.c_str()) , x ) ) ;
-            parent.set__( Rcpp_eval( call, R_GlobalEnv ) );
+            parent.set__( Rcpp_fast_eval( call, R_GlobalEnv ) );
         }
     } ;
 
@@ -67,7 +67,7 @@ public:
 
         SEXP get() const {
             Shield<SEXP> call( Rf_lang3( R_DollarSymbol, parent, Rf_mkString(field_name.c_str()) ) ) ;
-            return Rcpp_eval( call, R_GlobalEnv ) ;
+            return Rcpp_fast_eval( call, R_GlobalEnv ) ;
         }
     } ;
 

--- a/inst/include/Rcpp/proxy/NamesProxy.h
+++ b/inst/include/Rcpp/proxy/NamesProxy.h
@@ -54,7 +54,7 @@ public:
             } else {
                 /* use the slower and more flexible version (callback to R) */
                 SEXP namesSym = Rf_install( "names<-" );
-                Shield<SEXP> new_vec( Rcpp_eval(Rf_lang3( namesSym, parent, x ))) ;
+                Shield<SEXP> new_vec( Rcpp_fast_eval(Rf_lang3( namesSym, parent, x ))) ;
                 parent.set__(new_vec);
             }
 

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -31,7 +31,7 @@ namespace Rcpp {
             Armor<SEXP> res;
             try{
                 SEXP funSym = Rf_install(fun);
-                res = Rcpp_eval(Rf_lang2(funSym, x));
+                res = Rcpp_fast_eval(Rf_lang2(funSym, x));
             } catch( eval_error& e) {
                 const char* fmt = "Could not convert using R function: %s.";
                 throw not_compatible(fmt, fun);
@@ -114,7 +114,7 @@ namespace Rcpp {
                     // return Rf_coerceVector( x, STRSXP );
                     // coerceVector does not work for some reason
                     Shield<SEXP> call( Rf_lang2( Rf_install( "as.character" ), x ) );
-                    Shield<SEXP> res( Rcpp_eval( call, R_GlobalEnv ) );
+                    Shield<SEXP> res( Rcpp_fast_eval( call, R_GlobalEnv ) );
                     return res;
                 }
             case CHARSXP:

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -1126,11 +1126,11 @@ public:
 public:
 
     inline SEXP eval() const {
-        return Rcpp_eval( Storage::get__(), R_GlobalEnv ) ;
+        return Rcpp_fast_eval( Storage::get__(), R_GlobalEnv ) ;
     }
 
     inline SEXP eval(SEXP env) const {
-        return Rcpp_eval( Storage::get__(), env );
+        return Rcpp_fast_eval( Storage::get__(), env );
     }
 
 

--- a/inst/unitTests/cpp/language.cpp
+++ b/inst/unitTests/cpp/language.cpp
@@ -68,7 +68,7 @@ Language runit_lang_square_lv(){
 SEXP runit_lang_fun( Function fun, IntegerVector x ){
     Language call( fun );
     call.push_back(x) ;
-    return Rcpp_eval( call, R_GlobalEnv ) ;
+    return Rcpp_fast_eval( call, R_GlobalEnv ) ;
 }
 
 // [[Rcpp::export]]

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -60,12 +60,12 @@ int Dimension_const( SEXP ia ) {
 
 // [[Rcpp::export]]
 SEXP evaluator_error() {
-    return Rcpp_eval( Rf_lang2( Rf_install("stop"), Rf_mkString( "boom" ) ) );
+    return Rcpp_fast_eval( Rf_lang2( Rf_install("stop"), Rf_mkString( "boom" ) ) );
 }
 
 // [[Rcpp::export]]
 SEXP evaluator_ok(SEXP x) {
-    return Rcpp_eval( Rf_lang2( Rf_install("sample"), x ) );
+    return Rcpp_fast_eval( Rf_lang2( Rf_install("sample"), x ) );
 }
 
 // [[Rcpp::export]]

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -28,8 +28,6 @@
 #include <algorithm>
 #include <Rcpp/protection/Shield.h>
 
-namespace Rcpp { SEXP Rcpp_eval(SEXP, SEXP); }
-
 // [[Rcpp::register]]
 SEXP get_string_elt(SEXP x, R_xlen_t i) {
     return STRING_ELT(x, i);
@@ -97,7 +95,7 @@ SEXP get_rcpp_cache() {
         SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
         Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
         Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-        Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
+        Rcpp::Shield<SEXP> RCPP(Rf_eval(call, R_GlobalEnv));
 
         Rcpp_cache = Rf_findVarInFrame(RCPP, Rf_install(".rcpp_cache"));
         Rcpp_cache_know = true;
@@ -139,7 +137,7 @@ SEXP init_Rcpp_cache() {
     SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
     Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
     Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-    Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
+    Rcpp::Shield<SEXP> RCPP(Rf_eval(call, R_GlobalEnv));
     Rcpp::Shield<SEXP> cache(Rf_allocVector(VECSXP, RCPP_CACHE_SIZE));
 
     // the Rcpp namespace

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <Rcpp/protection/Shield.h>
 
-namespace Rcpp { SEXP Rcpp_fast_eval(SEXP, SEXP); }
+namespace Rcpp { SEXP Rcpp_eval(SEXP, SEXP); }
 
 // [[Rcpp::register]]
 SEXP get_string_elt(SEXP x, R_xlen_t i) {
@@ -97,7 +97,7 @@ SEXP get_rcpp_cache() {
         SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
         Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
         Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-        Rcpp::Shield<SEXP> RCPP(Rcpp_fast_eval(call, R_GlobalEnv));
+        Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
 
         Rcpp_cache = Rf_findVarInFrame(RCPP, Rf_install(".rcpp_cache"));
         Rcpp_cache_know = true;
@@ -139,7 +139,7 @@ SEXP init_Rcpp_cache() {
     SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
     Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
     Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-    Rcpp::Shield<SEXP> RCPP(Rcpp_fast_eval(call, R_GlobalEnv));
+    Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
     Rcpp::Shield<SEXP> cache(Rf_allocVector(VECSXP, RCPP_CACHE_SIZE));
 
     // the Rcpp namespace

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <Rcpp/protection/Shield.h>
 
-namespace Rcpp { SEXP Rcpp_eval(SEXP, SEXP); }
+namespace Rcpp { SEXP Rcpp_fast_eval(SEXP, SEXP); }
 
 // [[Rcpp::register]]
 SEXP get_string_elt(SEXP x, R_xlen_t i) {
@@ -97,7 +97,7 @@ SEXP get_rcpp_cache() {
         SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
         Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
         Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-        Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
+        Rcpp::Shield<SEXP> RCPP(Rcpp_fast_eval(call, R_GlobalEnv));
 
         Rcpp_cache = Rf_findVarInFrame(RCPP, Rf_install(".rcpp_cache"));
         Rcpp_cache_know = true;
@@ -139,7 +139,7 @@ SEXP init_Rcpp_cache() {
     SEXP getNamespaceSym = Rf_install("getNamespace"); // cannot be gc()'ed  once in symbol table
     Rcpp::Shield<SEXP> RcppString(Rf_mkString("Rcpp"));
     Rcpp::Shield<SEXP> call(Rf_lang2(getNamespaceSym, RcppString));
-    Rcpp::Shield<SEXP> RCPP(Rcpp_eval(call, R_GlobalEnv));
+    Rcpp::Shield<SEXP> RCPP(Rcpp_fast_eval(call, R_GlobalEnv));
     Rcpp::Shield<SEXP> cache(Rf_allocVector(VECSXP, RCPP_CACHE_SIZE));
 
     // the Rcpp namespace


### PR DESCRIPTION
@Enchufa2 

This PR ports most of the `Rcpp_eval` to `Rcpp_fast_eval`.

I might need a little more time to double check.