### PR TITLE
Control whether exceptions include the call and C++ stack with a macros

### DIFF
--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -24,6 +24,9 @@
 
 #include <Rversion.h>
 
+#ifndef RCPP_DEFAULT_INCLUDE_CALL
+#define RCPP_DEFAULT_INCLUDE_CALL true
+#endif
 
 #define GET_STACKTRACE() stack_trace( __FILE__, __LINE__ )
 
@@ -31,12 +34,12 @@ namespace Rcpp {
 
     class exception : public std::exception {
     public:
-        explicit exception(const char* message_, bool include_call = true) :	// #nocov start
+        explicit exception(const char* message_, bool include_call = RCPP_DEFAULT_INCLUDE_CALL) :	// #nocov start
             message(message_),
             include_call_(include_call){
             rcpp_set_stack_trace(Shield<SEXP>(stack_trace()));
         }
-        exception(const char* message_, const char*, int, bool include_call = true) :
+        exception(const char* message_, const char*, int, bool include_call = RCPP_DEFAULT_INCLUDE_CALL) :
             message(message_),
             include_call_(include_call){
             rcpp_set_stack_trace(Shield<SEXP>(stack_trace()));

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -309,34 +309,32 @@ inline SEXP make_condition(const std::string& ex_msg, SEXP call, SEXP cppstack, 
     return res ;
 }
 
-inline SEXP rcpp_exception_to_r_condition(const Rcpp::exception& ex) {
-    std::string ex_class = demangle( typeid(ex).name() ) ;
-    std::string ex_msg   = ex.what() ;
+template <typename Exception>
+inline SEXP exception_to_condition_template( const Exception& ex, bool include_call) {
+  std::string ex_class = demangle( typeid(ex).name() ) ;
+  std::string ex_msg   = ex.what() ;
 
-    SEXP call, cppstack;
-    if (ex.include_call()) {
-        call = Rcpp::Shield<SEXP>(get_last_call());
-        cppstack = Rcpp::Shield<SEXP>( rcpp_get_stack_trace());
-    } else {
-        call = R_NilValue;
-        cppstack = R_NilValue;
-    }
-    Rcpp::Shield<SEXP> classes( get_exception_classes(ex_class) );
-    Rcpp::Shield<SEXP> condition( make_condition( ex_msg, call, cppstack, classes) );
-    rcpp_set_stack_trace( R_NilValue ) ;
-    return condition ;
+  Rcpp::Shelter<SEXP> shelter;
+  SEXP call, cppstack;
+  if (include_call) {
+      call = shelter(get_last_call());
+      cppstack = shelter(rcpp_get_stack_trace());
+  } else {
+      call = R_NilValue;
+      cppstack = R_NilValue;
+  }
+  SEXP classes = shelter( get_exception_classes(ex_class) );
+  SEXP condition = shelter( make_condition( ex_msg, call, cppstack, classes) );
+  rcpp_set_stack_trace( R_NilValue ) ;
+  return condition ;
+}
+
+inline SEXP rcpp_exception_to_r_condition(const Rcpp::exception& ex) {
+  return exception_to_condition_template(ex, ex.include_call());
 }
 
 inline SEXP exception_to_r_condition( const std::exception& ex){
-    std::string ex_class = demangle( typeid(ex).name() ) ;
-    std::string ex_msg   = ex.what() ;
-
-    Rcpp::Shield<SEXP> cppstack( rcpp_get_stack_trace() );
-    Rcpp::Shield<SEXP> call( get_last_call() );
-    Rcpp::Shield<SEXP> classes( get_exception_classes(ex_class) );
-    Rcpp::Shield<SEXP> condition( make_condition( ex_msg, call, cppstack, classes) );
-    rcpp_set_stack_trace( R_NilValue ) ;
-    return condition ;
+  return exception_to_condition_template(ex, RCPP_DEFAULT_INCLUDE_CALL);
 }
 
 inline SEXP string_to_try_error( const std::string& str){

--- a/inst/unitTests/cpp/Exceptions_nocall.cpp
+++ b/inst/unitTests/cpp/Exceptions_nocall.cpp
@@ -8,6 +8,6 @@ void Rcpp_exception(){
 }
 
 // [[Rcpp::export]]
-void eval_error(){
+void eval_error_no_call(){
     Rcpp_eval(Rf_lang1(Rf_install("ouch")), R_EmptyEnv);
 }

--- a/inst/unitTests/cpp/Exceptions_nocall.cpp
+++ b/inst/unitTests/cpp/Exceptions_nocall.cpp
@@ -1,5 +1,6 @@
 #define RCPP_DEFAULT_INCLUDE_CALL false
 #include <Rcpp.h>
+using namespace Rcpp;
 
 // [[Rcpp::export]]
 void Rcpp_exception(){

--- a/inst/unitTests/cpp/Exceptions_nocall.cpp
+++ b/inst/unitTests/cpp/Exceptions_nocall.cpp
@@ -1,0 +1,12 @@
+#define RCPP_DEFAULT_INCLUDE_CALL false
+#include <Rcpp.h>
+
+// [[Rcpp::export]]
+void Rcpp_exception(){
+    throw Rcpp::exception("ouch");
+}
+
+// [[Rcpp::export]]
+void eval_error(){
+    Rcpp_eval(Rf_lang1(Rf_install("ouch")), R_EmptyEnv);
+}

--- a/inst/unitTests/runit.Exceptions_nocall.R
+++ b/inst/unitTests/runit.Exceptions_nocall.R
@@ -31,7 +31,7 @@ if (.runThisTest) {
     }
 
     test.eval_error <- function() {
-        tryCatch(eval_error(), error = function(e){
+        tryCatch(eval_error_no_call(), error = function(e){
             checkTrue(is.null(e$call))
             checkTrue(is.null(e$cppstack))
         })

--- a/inst/unitTests/runit.Exceptions_nocall.R
+++ b/inst/unitTests/runit.Exceptions_nocall.R
@@ -1,0 +1,40 @@
+#!/usr/bin/r -t
+#
+# Copyright (C) 2018  Dirk Eddelbuettel and Romain Francois
+#
+# This file is part of Rcpp.
+#
+# Rcpp is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Rcpp is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+.runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
+
+if (.runThisTest) {
+
+    .setUp <- Rcpp:::unitTestSetup("Exceptions_nocall.cpp")
+
+    test.Rcpp_exception <- function() {
+        tryCatch(Rcpp_exception(), error = function(e){
+            checkTrue(is.null(e$call))
+            checkTrue(is.null(e$cppstack))
+        })
+    }
+
+    test.eval_error <- function() {
+        tryCatch(eval_error(), error = function(e){
+            checkTrue(is.null(e$call))
+            checkTrue(is.null(e$cppstack))
+        })
+    }
+
+}


### PR DESCRIPTION
Follow up to #663. 

The idea is to have a general default for whether exceptions generated by Rcpp include the call stack or not. 

```cpp
#define RCPP_DEFAULT_INCLUDE_CALL false
#include <Rcpp.h>

// [[Rcpp::export]]
void Rcpp_exception(){
    throw Rcpp::exception("ouch");
}

// [[Rcpp::export]]
void eval_error(){
    Rcpp_eval(Rf_lang1(Rf_install("ouch")), R_EmptyEnv);
}
```

Adding the `RCPP_DEFAULT_INCLUDE_CALL` which by default is defined to `true` in Rcpp. When it is defined to false such as above, the default for `include_call` in Rcpp::exception is set to false, and the other exceptions, e.g. `eval_error` don't include the call and c++ stack. 

```r
> Rcpp::sourceCpp('inst/unitTests/cpp/Exceptions_nocall.cpp')
> Rcpp_exception()
Error: ouch
> eval_error_no_call()
Error: Evaluation error: could not find function "ouch".
> stop_no_call()
Error: ouch
```

Having this in place means that a 📦 can globally decide not to include the call stack for all exceptions that are generated by Rcpp internal code, and also still be able to use `stop(...)` instead of `throw Rcpp::exception(tfm::format(...).c_str(), include_call = false)` which is I believe the only way available after #663. 

The alternative to this PR would be to rework all other exception classes so that they also have the `bool include_call` setting. 

This is not necessary as these other exceptions are mostly thrown by Rcpp itself and so there is no opportunity to set the `include_call` argument in their constructors. 