### PR TITLE
Resolve segfault when running embeddedR test

### DIFF
--- a/inst/unitTests/runit.embeddedR.R
+++ b/inst/unitTests/runit.embeddedR.R
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
-.runThisTest <- FALSE #Sys.getenv("RunAllRcppTests") == "yes"
+.runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
 
 if (.runThisTest) {
 
@@ -27,13 +27,13 @@ if (.runThisTest) {
         expectedVars <- c("foo", "x")
 
         # embeddedR.cpp exposes the function foo, R snippet calls foo
-        newEnv <- new.env()
+        newEnv <- new.env(parent = baseenv())
         Rcpp::sourceCpp(file.path(path, "embeddedR.cpp"),
                         env = newEnv)
         checkEquals(ls(newEnv), expectedVars, msg = " sourcing code in custom env")
 
         # R snippet in embeddedR2.cpp also contains a call to foo from previous cpp
-        newEnv2 <- new.env()
+        newEnv2 <- new.env(parent = baseenv())
         checkException(Rcpp::sourceCpp(file.path(path, "embeddedR2.cpp"), env = newEnv2),
                                        " not available in other env")
     }


### PR DESCRIPTION
As @lionel- suggested, having the new environments be a child of the base environment fixed the nasty side effects described by @eddelbuettel and @coatless in https://github.com/RcppCore/Rcpp/issues/851#issuecomment-395932776