### PR TITLE
Remove editor headers

### DIFF
--- a/inst/examples/ConvolveBenchmarks/convolve10_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve10_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // this version expands convolve8_cpp by making Vec mimic the structure of
 // NumericVector. It peforms well, so this is is not the structure of
 // NumericVector that is the problem. So what is it then ?

--- a/inst/examples/ConvolveBenchmarks/convolve11_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve11_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This version uses nona to indicate that xb does not contain any missing
 // value. This is the assumption that all other versions do.
 

--- a/inst/examples/ConvolveBenchmarks/convolve12_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve12_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve13_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve13_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve14_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve14_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve3_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve3_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve4_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve4_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve5_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve5_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/convolve8_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve8_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // this version is between the Rcpp_New_ptr and the Rcpp_New_std version
 //                          test elapsed  relative user.self sys.self
 // 5    Rcpp_New_ptr(REPS, a, b)   0.214  1.000000     0.213    0.001

--- a/inst/examples/ConvolveBenchmarks/convolve9_cpp.cpp
+++ b/inst/examples/ConvolveBenchmarks/convolve9_cpp.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // this version expands convolve8_cpp by making Vec mimic the structure of
 // NumericVector. It peforms well, so this is is not the structure of
 // NumericVector that is the problem. So what is it then ?

--- a/inst/examples/ConvolveBenchmarks/overhead_1.cpp
+++ b/inst/examples/ConvolveBenchmarks/overhead_1.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 
 #include <Rcpp.h>

--- a/inst/examples/ConvolveBenchmarks/overhead_2.c
+++ b/inst/examples/ConvolveBenchmarks/overhead_2.c
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // This is a rewrite of the 'Writing R Extensions' section 5.10.1 example
 #include <R.h>
 #include <Rdefines.h>

--- a/inst/examples/OpenMP/piWithInterrupts.cpp
+++ b/inst/examples/OpenMP/piWithInterrupts.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 #include <Rcpp.h>
 
 #ifdef _OPENMP

--- a/inst/examples/SugarPerformance/Timer.h
+++ b/inst/examples/SugarPerformance/Timer.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Timer.h: Rcpp R/C++ interface class library -- simple timer class
 //
 // Copyright (C) 2010	Dirk Eddelbuettel and Romain Francois

--- a/inst/examples/SugarPerformance/Timertest.cpp
+++ b/inst/examples/SugarPerformance/Timertest.cpp
@@ -1,5 +1,3 @@
-// -*- mode: c++; compile-command: "g++ -Wall -O3 -o Timertest Timertest.cpp"; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-
 // from http://www.cs.uiowa.edu/~sriram/30/fall03/
 
 #include <iostream>

--- a/inst/include/Rcpp.h
+++ b/inst/include/Rcpp.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Rcpp.h: R/C++ interface class library
 //
 // Copyright (C) 2008 - 2009  Dirk Eddelbuettel

--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Timer.h: Rcpp R/C++ interface class library -- Rcpp benchmark utility
 //
 // Copyright (C) 2012 - 2014  JJ Allaire, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // DataFrame.h: Rcpp R/C++ interface class library -- data frames
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Dimension.h
+++ b/inst/include/Rcpp/Dimension.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Dimension.h: Rcpp R/C++ interface class library -- dimensions
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/DottedPair.h
+++ b/inst/include/Rcpp/DottedPair.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // DottedPair.h: Rcpp R/C++ interface class library -- dotted pair list template
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Environment.h: Rcpp R/C++ interface class library -- access R environments
 //
 // Copyright (C) 2009 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Extractor.h
+++ b/inst/include/Rcpp/Extractor.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Extractor.h: Rcpp R/C++ interface class library -- faster vectors (less interface)
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Fast.h
+++ b/inst/include/Rcpp/Fast.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Fast.h: Rcpp R/C++ interface class library -- faster vectors (less interface)
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Formula.h
+++ b/inst/include/Rcpp/Formula.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Formula.h: Rcpp R/C++ interface class library -- formula
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Function.h: Rcpp R/C++ interface class library -- functions (also primitives and builtins)
 //
 // Copyright (C) 2010 - 2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/InputParameter.h
+++ b/inst/include/Rcpp/InputParameter.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // InputParameter.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/InternalFunction.h
+++ b/inst/include/Rcpp/InternalFunction.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // InternalFunction.h: Rcpp R/C++ interface class library -- exposing C++ functions
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // InternalFunction_with_std_function.h: Rcpp R/C++ interface class library -- exposing C++ std::function's
 //
 // Copyright (C) 2014  Christian Authmann

--- a/inst/include/Rcpp/Interrupt.h
+++ b/inst/include/Rcpp/Interrupt.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Interrupt.h: Rcpp R/C++ interface class library -- check for interrupts
 //
 // Copyright (C) 2009 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Language.h: Rcpp R/C++ interface class library -- language objects (calls)
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Named.h
+++ b/inst/include/Rcpp/Named.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Named.h: Rcpp R/C++ interface class library -- named object
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Nullable.h: Rcpp R/C++ interface class library -- SEXP container which can be NULL
 //
 // Copyright (C) 2015         Dirk Eddelbuettel and Daniel C. Dillon

--- a/inst/include/Rcpp/Pairlist.h
+++ b/inst/include/Rcpp/Pairlist.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Pairlist.h: Rcpp R/C++ interface class library -- pair lists objects (LISTSXP)
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Promise.h: Rcpp R/C++ interface class library -- promises (PROMSXP)
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/RNGScope.h
+++ b/inst/include/Rcpp/RNGScope.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // RNGScope.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/RObject.h
+++ b/inst/include/Rcpp/RObject.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // RObject.h: Rcpp R/C++ interface class library -- general R object wrapper
 //
 // Copyright (C) 2009 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Reference.h
+++ b/inst/include/Rcpp/Reference.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Reference.h: Rcpp R/C++ interface class library -- Reference class objects
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Rmath.h
+++ b/inst/include/Rcpp/Rmath.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Rmath.h: Rcpp R/C++ interface class library -- Wrappers for R's Rmath API
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/S4.h
+++ b/inst/include/Rcpp/S4.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // S4.h: Rcpp R/C++ interface class library -- S4 objects
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // String.h: Rcpp R/C++ interface class library -- single string
 //
 // Copyright (C) 2012 - 2018  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/StringTransformer.h
+++ b/inst/include/Rcpp/StringTransformer.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // clone.h: Rcpp R/C++ interface class library -- clone RObject's
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Symbol.h
+++ b/inst/include/Rcpp/Symbol.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Symbol.h: Rcpp R/C++ interface class library -- access R environments
 //
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/Vector.h
+++ b/inst/include/Rcpp/Vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/WeakReference.h
+++ b/inst/include/Rcpp/WeakReference.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // WeakReference.h: Rcpp R/C++ interface class library -- weak references
 //
 // Copyright (C) 2009 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // XPtr.h: Rcpp R/C++ interface class library -- smart external pointers
 //
 // Copyright (C) 2009 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/algo.h
+++ b/inst/include/Rcpp/algo.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // algo.h: Rcpp R/C++ interface class library -- STL-style algorithms
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/algorithm.h
+++ b/inst/include/Rcpp/algorithm.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // algorithm.h: Rcpp R/C++ interface class library -- data frames
 //
 // Copyright (C) 2016 - 2017  Daniel C. Dillon

--- a/inst/include/Rcpp/api/bones/Date.h
+++ b/inst/include/Rcpp/api/bones/Date.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // Date_forward.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/bones/Datetime.h
+++ b/inst/include/Rcpp/api/bones/Datetime.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // Datetime_forward.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/bones/bones.h
+++ b/inst/include/Rcpp/api/bones/bones.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // bones.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/bones/wrap_extra_steps.h
+++ b/inst/include/Rcpp/api/bones/wrap_extra_steps.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // wrap_extra_steps.h: Rcpp R/C++ interface class library -- wrap forward decl
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/Date.h
+++ b/inst/include/Rcpp/api/meat/Date.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.

--- a/inst/include/Rcpp/api/meat/Datetime.h
+++ b/inst/include/Rcpp/api/meat/Datetime.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.

--- a/inst/include/Rcpp/api/meat/Environment.h
+++ b/inst/include/Rcpp/api/meat/Environment.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Environment.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/Vector.h
+++ b/inst/include/Rcpp/api/meat/Vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Vector.h: Rcpp R/C++ interface class library -- Vector meat
 //
 // Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/export.h
+++ b/inst/include/Rcpp/api/meat/export.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // export.h: Rcpp R/C++ interface class library -- export implementations
 //
 // Copyright (C) 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/is.h
+++ b/inst/include/Rcpp/api/meat/is.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // is.h: Rcpp R/C++ interface class library -- is implementations
 //
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/meat.h
+++ b/inst/include/Rcpp/api/meat/meat.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // meat.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/api/meat/proxy.h
+++ b/inst/include/Rcpp/api/meat/proxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // proxy.h: Rcpp R/C++ interface class library -- proxy meat
 //
 // Copyright (C) 2014    Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/include/Rcpp/api/meat/wrap.h
+++ b/inst/include/Rcpp/api/meat/wrap.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // wrap.h: Rcpp R/C++ interface class library -- wrap implementations
 //
 // Copyright (C) 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/as.h
+++ b/inst/include/Rcpp/as.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // as.h: Rcpp R/C++ interface class library -- convert SEXP to C++ objects
 //
 // Copyright (C) 2009 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/barrier.h
+++ b/inst/include/Rcpp/barrier.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // barrier.h: Rcpp R/C++ interface class library -- crossin the write barrier
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/clone.h
+++ b/inst/include/Rcpp/clone.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // clone.h: Rcpp R/C++ interface class library -- clone RObject's
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/complex.h
+++ b/inst/include/Rcpp/complex.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // complex.h: Rcpp R/C++ interface class library -- binary operators for Rcomplex
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // config.h: Rcpp R/C++ interface class library -- Rcpp configuration
 //
 // Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/date_datetime/Date.h
+++ b/inst/include/Rcpp/date_datetime/Date.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Date.h: Rcpp R/C++ interface class library -- dates
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/date_datetime/Datetime.h
+++ b/inst/include/Rcpp/date_datetime/Datetime.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Datetime.h: Rcpp R/C++ interface class library -- Datetime (POSIXct)
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/date_datetime/date_datetime.h
+++ b/inst/include/Rcpp/date_datetime/date_datetime.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // date_datetime.h: Rcpp R/C++ interface class library -- Date and Datetime support
 //
 // Copyright (C) 2016 - 2017  Dirk Eddelbuettel

--- a/inst/include/Rcpp/date_datetime/newDateVector.h
+++ b/inst/include/Rcpp/date_datetime/newDateVector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // newDateVector.h: Rcpp R/C++ interface class library -- Date vector support
 //
 // Copyright (C) 2016         Dirk Eddelbuettel

--- a/inst/include/Rcpp/date_datetime/newDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/newDatetimeVector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // newDatetimeVector.h: Rcpp R/C++ interface class library -- Datetime vector support
 //
 // Copyright (C) 2016         Dirk Eddelbuettel

--- a/inst/include/Rcpp/date_datetime/oldDateVector.h
+++ b/inst/include/Rcpp/date_datetime/oldDateVector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // DateVector.h: Rcpp R/C++ interface class library -- Date vector support
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/date_datetime/oldDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/oldDatetimeVector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // DatetimeVector.h: Rcpp R/C++ interface class library -- Datetime vector
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // exceptions.h: Rcpp R/C++ interface class library -- exceptions
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/exceptions/cpp11/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp11/exceptions.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // exceptions.h: Rcpp R/C++ interface class library -- exceptions
 //
 // Copyright (C) 2017 James J Balamuta

--- a/inst/include/Rcpp/exceptions/cpp98/exceptions.h
+++ b/inst/include/Rcpp/exceptions/cpp98/exceptions.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // exceptions.h: Rcpp R/C++ interface class library -- exceptions
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/DataFrame_generated.h
+++ b/inst/include/Rcpp/generated/DataFrame_generated.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // DataFrame_generated.h: Rcpp R/C++ interface class library -- data frames
 //
 // Copyright (C) 2010 - 2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/DottedPair__ctors.h
+++ b/inst/include/Rcpp/generated/DottedPair__ctors.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // DottedPair_Impl__ctors.h: Rcpp R/C++ interface class library -- generated helper code for DottedPair_Impl.h
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/Function__operator.h
+++ b/inst/include/Rcpp/generated/Function__operator.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Function__operator.h: Rcpp R/C++ interface class library -- generated helper code for Function.h
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/InternalFunctionWithStdFunction_call.h
+++ b/inst/include/Rcpp/generated/InternalFunctionWithStdFunction_call.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // InternalFunctionWithStdFunction_call.h -- generated helper code for
 //                                  InternalFunctionWithStdFunction.h
 //                                  see rcpp-scripts repo for generator script

--- a/inst/include/Rcpp/generated/InternalFunction__ctors.h
+++ b/inst/include/Rcpp/generated/InternalFunction__ctors.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // InternalFunction_Impl_ctors.h -- generated helper code for InternalFunction__ctors.h
 //                                  see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/generated/Language__ctors.h
+++ b/inst/include/Rcpp/generated/Language__ctors.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Language__ctors.h: Rcpp R/C++ interface class library -- generated helper code for Language.h
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/Pairlist__ctors.h
+++ b/inst/include/Rcpp/generated/Pairlist__ctors.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Pairlist__ctors.h: Rcpp R/C++ interface class library -- generated helper code for Pairlist.h
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/Vector__create.h
+++ b/inst/include/Rcpp/generated/Vector__create.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Vector__create.h: Rcpp R/C++ interface class library -- generated helper code for Vector.h
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/generated/grow__pairlist.h
+++ b/inst/include/Rcpp/generated/grow__pairlist.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // grow__pairlist.h: Rcpp R/C++ interface class library -- generated helper code for grow.h
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/grow.h
+++ b/inst/include/Rcpp/grow.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // grow.h: Rcpp R/C++ interface class library -- grow a pairlist
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/hash/IndexHash.h
+++ b/inst/include/Rcpp/hash/IndexHash.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // IndexHash.h: Rcpp R/C++ interface class library -- hashing utility, inspired
 // from Simon's fastmatch package
 //

--- a/inst/include/Rcpp/hash/SelfHash.h
+++ b/inst/include/Rcpp/hash/SelfHash.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // hash.h: Rcpp R/C++ interface class library -- hashing utility, inspired
 // from Simon's fastmatch package
 //

--- a/inst/include/Rcpp/hash/hash.h
+++ b/inst/include/Rcpp/hash/hash.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // hash.h: Rcpp R/C++ interface class library -- hashing
 //
 // Copyright (C) 2012  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/Exporter.h
+++ b/inst/include/Rcpp/internal/Exporter.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // exporter.h: Rcpp R/C++ interface class library -- identify if a class has a nested iterator typedef
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/ListInitialization.h
+++ b/inst/include/Rcpp/internal/ListInitialization.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // ListInitialization.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/NAComparator.h
+++ b/inst/include/Rcpp/internal/NAComparator.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // NAComparator.h: Rcpp R/C++ interface class library -- comparator
 //
 // Copyright (C) 2012-2014 Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/include/Rcpp/internal/Proxy_Iterator.h
+++ b/inst/include/Rcpp/internal/Proxy_Iterator.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // Proxy_Iterator.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/SEXP_Iterator.h
+++ b/inst/include/Rcpp/internal/SEXP_Iterator.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // SEXP_Iterator.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/caster.h
+++ b/inst/include/Rcpp/internal/caster.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // caster.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/converter.h
+++ b/inst/include/Rcpp/internal/converter.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // converter.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // export.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/na.h
+++ b/inst/include/Rcpp/internal/na.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // na.h: Rcpp R/C++ interface class library -- optimized na checking
 //
 // Copyright (C) 2012-2014 Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/include/Rcpp/internal/r_coerce.h
+++ b/inst/include/Rcpp/internal/r_coerce.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // r_coerce.h: Rcpp R/C++ interface class library -- coercion
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/include/Rcpp/internal/r_vector.h
+++ b/inst/include/Rcpp/internal/r_vector.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // r_vector.h: Rcpp R/C++ interface class library -- information about R vectors
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // wrap.h: Rcpp R/C++ interface class library -- wrap implementations
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/wrap_end.h
+++ b/inst/include/Rcpp/internal/wrap_end.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // wrap_end.h: R/C++ interface class library
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/iostream/Rstreambuf.h
+++ b/inst/include/Rcpp/iostream/Rstreambuf.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Rstreambuf.h: Rcpp R/C++ interface class library -- stream buffer
 //
 // Copyright (C) 2011 - 2017  Dirk Eddelbuettel, Romain Francois and Jelmer Ypma

--- a/inst/include/Rcpp/is.h
+++ b/inst/include/Rcpp/is.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // is.h: Rcpp R/C++ interface class library -- test if an R Object can be seen
 //                                             as one type
 //

--- a/inst/include/Rcpp/lang.h
+++ b/inst/include/Rcpp/lang.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // lang.h: Rcpp R/C++ interface class library -- extra lang_* functions
 //
 // Copyright (C) 2011 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/longlong.h
+++ b/inst/include/Rcpp/longlong.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // longlong.h: Rcpp R/C++ interface class library -- long long support
 //
 // Copyright (C) 2013 - 2017 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/debug.h
+++ b/inst/include/Rcpp/macros/debug.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // debug.h: Rcpp R/C++ interface class library -- debug macros
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/dispatch.h
+++ b/inst/include/Rcpp/macros/dispatch.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // dispatch.h: Rcpp R/C++ interface class library -- macros for dispatch
 //
 // Copyright (C) 2012 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // macros.h: Rcpp R/C++ interface class library -- Rcpp macros
 //
 // Copyright (C) 2012 - 2015 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/module.h
+++ b/inst/include/Rcpp/macros/module.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // macros.h: Rcpp R/C++ interface class library -- helper macros for Rcpp modules
 //
 // Copyright (C) 2012-2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/traits.h
+++ b/inst/include/Rcpp/macros/traits.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // traits.h: Rcpp R/C++ interface class library -- pre processor help
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/unroll.h
+++ b/inst/include/Rcpp/macros/unroll.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // unroll.h: Rcpp R/C++ interface class library -- loop unrolling macro
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/macros/xp.h
+++ b/inst/include/Rcpp/macros/xp.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // xp.h: Rcpp R/C++ interface class library -- pre processor help
 //
 // Copyright (C) 2012 - 2015 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/CppFunction.h
+++ b/inst/include/Rcpp/module/CppFunction.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // CppFunction.h: Rcpp R/C++ interface class library -- C++ exposed function
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module.h
+++ b/inst/include/Rcpp/module/Module.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_Add_Property.h
+++ b/inst/include/Rcpp/module/Module_Add_Property.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_Add_Property.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_Field.h
+++ b/inst/include/Rcpp/module/Module_Field.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_Add_Property.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_Property.h
+++ b/inst/include/Rcpp/module/Module_Property.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_Property.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_Constructor.h
+++ b/inst/include/Rcpp/module/Module_generated_Constructor.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_Constructor.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_CppFunction.h
+++ b/inst/include/Rcpp/module/Module_generated_CppFunction.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_CppFunction.h: -- generated helper code for Modules
 //                                    see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_CppMethod.h
+++ b/inst/include/Rcpp/module/Module_generated_CppMethod.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_CppMethod.h: -- generated helper code for Modules
 //                                  see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_Factory.h
+++ b/inst/include/Rcpp/module/Module_generated_Factory.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_Factory.h: Rcpp R/C++ interface class library -- Rcpp module class factories
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_Pointer_CppMethod.h
+++ b/inst/include/Rcpp/module/Module_generated_Pointer_CppMethod.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_PointerCppMethod.h: -- generated helper code for Modules
 //                                         see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_Pointer_method.h
+++ b/inst/include/Rcpp/module/Module_generated_Pointer_method.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_Pointer_method.h:  -- generated helper code for Modules
 //                                        see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_class_constructor.h
+++ b/inst/include/Rcpp/module/Module_generated_class_constructor.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_class_constructor.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_class_factory.h
+++ b/inst/include/Rcpp/module/Module_generated_class_factory.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_class_factory.h: Rcpp R/C++ interface class library -- alternative way to declare constructors
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_class_signature.h
+++ b/inst/include/Rcpp/module/Module_generated_class_signature.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Module_generated_Constructor.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_ctor_signature.h
+++ b/inst/include/Rcpp/module/Module_generated_ctor_signature.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // Module_generated_ctor_signature.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/Module_generated_function.h
+++ b/inst/include/Rcpp/module/Module_generated_function.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_function.h: -- generated helper code for Modules
 //                                 see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_get_signature.h
+++ b/inst/include/Rcpp/module/Module_generated_get_signature.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_get_signature.h: -- generated helper code for Modules
 //                                      see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/Module_generated_method.h
+++ b/inst/include/Rcpp/module/Module_generated_method.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Module_generated_method.h: -- generated helper code for Modules
 //                               see rcpp-scripts repo for generator script
 //

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // class.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/class_Base.h
+++ b/inst/include/Rcpp/module/class_Base.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // class_Base.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/module/get_return_type.h
+++ b/inst/include/Rcpp/module/get_return_type.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // Module_get_return_type.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // compiler.h: Rcpp R/C++ interface class library -- check compiler
 //
 // Copyright (C) 2012 - 2013  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/include/Rcpp/print.h
+++ b/inst/include/Rcpp/print.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Copyright (C) 2015 - 2016  Dirk Eddelbuettel
 //
 // This file is part of Rcpp.

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rcast.h: Rcpp R/C++ interface class library -- cast from one SEXP type to another
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/routines.h
+++ b/inst/include/Rcpp/routines.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Copyright (C) 2013  Romain Francois
 // Copyright (C) 2015  Dirk Eddelbuettel
 //

--- a/inst/include/Rcpp/sprintf.h
+++ b/inst/include/Rcpp/sprintf.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sprintf.h: Rcpp R/C++ interface class library -- string formatting
 //
 // Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/beta.h
+++ b/inst/include/Rcpp/stats/beta.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // beta.h: Rcpp R/C++ interface class library -- beta distribution
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/binom.h
+++ b/inst/include/Rcpp/stats/binom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // binom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/cauchy.h
+++ b/inst/include/Rcpp/stats/cauchy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // cauchy.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/chisq.h
+++ b/inst/include/Rcpp/stats/chisq.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // chisq.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/dpq/dpq.h
+++ b/inst/include/Rcpp/stats/dpq/dpq.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // dpq.h: Rcpp R/C++ interface class library -- normal distribution
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/exp.h
+++ b/inst/include/Rcpp/stats/exp.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // auto generated file (from script/stats.R)
 //
 // exp.h: Rcpp R/C++ interface class library --

--- a/inst/include/Rcpp/stats/f.h
+++ b/inst/include/Rcpp/stats/f.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // f.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/gamma.h
+++ b/inst/include/Rcpp/stats/gamma.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // auto generated file (from script/stats.R)
 //
 // gamma.h: Rcpp R/C++ interface class library --

--- a/inst/include/Rcpp/stats/geom.h
+++ b/inst/include/Rcpp/stats/geom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // geom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/hyper.h
+++ b/inst/include/Rcpp/stats/hyper.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // hyper.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/lnorm.h
+++ b/inst/include/Rcpp/stats/lnorm.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // auto generated file (from script/stats.R)
 //
 // lnorm.h: Rcpp R/C++ interface class library --

--- a/inst/include/Rcpp/stats/logis.h
+++ b/inst/include/Rcpp/stats/logis.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // logis.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nbeta.h
+++ b/inst/include/Rcpp/stats/nbeta.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nbeta.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nbinom.h
+++ b/inst/include/Rcpp/stats/nbinom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nbinom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nbinom_mu.h
+++ b/inst/include/Rcpp/stats/nbinom_mu.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nbinom_mu.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nchisq.h
+++ b/inst/include/Rcpp/stats/nchisq.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nchisq.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nf.h
+++ b/inst/include/Rcpp/stats/nf.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nf.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/norm.h
+++ b/inst/include/Rcpp/stats/norm.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // norm.h: Rcpp R/C++ interface class library -- normal distribution
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/nt.h
+++ b/inst/include/Rcpp/stats/nt.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // nt.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/pois.h
+++ b/inst/include/Rcpp/stats/pois.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // pois.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/random.h
+++ b/inst/include/Rcpp/stats/random/random.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // random.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rbeta.h
+++ b/inst/include/Rcpp/stats/random/rbeta.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rbeta.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rbinom.h
+++ b/inst/include/Rcpp/stats/random/rbinom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rbinom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rcauchy.h
+++ b/inst/include/Rcpp/stats/random/rcauchy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rcauchy.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rchisq.h
+++ b/inst/include/Rcpp/stats/random/rchisq.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rchisq.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rexp.h
+++ b/inst/include/Rcpp/stats/random/rexp.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rexp.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rf.h
+++ b/inst/include/Rcpp/stats/random/rf.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rf.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rgamma.h
+++ b/inst/include/Rcpp/stats/random/rgamma.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rgamma.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rgeom.h
+++ b/inst/include/Rcpp/stats/random/rgeom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rgeom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rhyper.h
+++ b/inst/include/Rcpp/stats/random/rhyper.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rhyper.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rlnorm.h
+++ b/inst/include/Rcpp/stats/random/rlnorm.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rlnorm.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rlogis.h
+++ b/inst/include/Rcpp/stats/random/rlogis.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rlogis.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rnbinom.h
+++ b/inst/include/Rcpp/stats/random/rnbinom.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rnbinom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rnbinom_mu.h
+++ b/inst/include/Rcpp/stats/random/rnbinom_mu.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rnbinom_mu.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rnchisq.h
+++ b/inst/include/Rcpp/stats/random/rnchisq.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rnchisq.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rnorm.h
+++ b/inst/include/Rcpp/stats/random/rnorm.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rnorm.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rpois.h
+++ b/inst/include/Rcpp/stats/random/rpois.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rpois.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rsignrank.h
+++ b/inst/include/Rcpp/stats/random/rsignrank.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rsignrank.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rt.h
+++ b/inst/include/Rcpp/stats/random/rt.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rt.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/runif.h
+++ b/inst/include/Rcpp/stats/random/runif.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // runif.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rweibull.h
+++ b/inst/include/Rcpp/stats/random/rweibull.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rweibull.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/random/rwilcox.h
+++ b/inst/include/Rcpp/stats/random/rwilcox.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rwilcox.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016  Douglas Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/stats.h
+++ b/inst/include/Rcpp/stats/stats.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // binom.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/t.h
+++ b/inst/include/Rcpp/stats/t.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // t.h: Rcpp R/C++ interface class library -- t distribution
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/stats/unif.h
+++ b/inst/include/Rcpp/stats/unif.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // auto generated file (from script/stats.R)
 //
 // unif.h: Rcpp R/C++ interface class library --

--- a/inst/include/Rcpp/stats/weibull.h
+++ b/inst/include/Rcpp/stats/weibull.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // auto generated file (from script/stats.R)
 //
 // weibull.h: Rcpp R/C++ interface class library --

--- a/inst/include/Rcpp/sugar/Range.h
+++ b/inst/include/Rcpp/sugar/Range.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Range.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/SugarBlock_1.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_1.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/SugarBlock_2.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_2.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/SugarBlock_3.h
+++ b/inst/include/Rcpp/sugar/block/SugarBlock_3.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/SugarMath.h
+++ b/inst/include/Rcpp/sugar/block/SugarMath.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/Vectorized_Math.h
+++ b/inst/include/Rcpp/sugar/block/Vectorized_Math.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/block/block.h
+++ b/inst/include/Rcpp/sugar/block/block.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // block.h: Rcpp R/C++ interface class library -- sugar blocks
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/Lazy.h
+++ b/inst/include/Rcpp/sugar/functions/Lazy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Lazy.h: Rcpp R/C++ interface class library -- Lazy
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/all.h
+++ b/inst/include/Rcpp/sugar/functions/all.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // all.h: Rcpp R/C++ interface class library -- all
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/any.h
+++ b/inst/include/Rcpp/sugar/functions/any.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // any.h: Rcpp R/C++ interface class library -- any
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/cbind.h
+++ b/inst/include/Rcpp/sugar/functions/cbind.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // cbind.h: Rcpp R/C++ interface class library -- cbind
 //
 // Copyright (C) 2016 Nathan Russell

--- a/inst/include/Rcpp/sugar/functions/clamp.h
+++ b/inst/include/Rcpp/sugar/functions/clamp.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // clamp.h: Rcpp R/C++ interface class library -- clamp
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/complex.h
+++ b/inst/include/Rcpp/sugar/functions/complex.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // complex.h: Rcpp R/C++ interface class library -- complex
 //
 // Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/cummax.h
+++ b/inst/include/Rcpp/sugar/functions/cummax.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // cumsum.h: Rcpp R/C++ interface class library -- cumsum
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/cummin.h
+++ b/inst/include/Rcpp/sugar/functions/cummin.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // cumsum.h: Rcpp R/C++ interface class library -- cumsum
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/cumprod.h
+++ b/inst/include/Rcpp/sugar/functions/cumprod.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // cumsum.h: Rcpp R/C++ interface class library -- cumsum
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/cumsum.h
+++ b/inst/include/Rcpp/sugar/functions/cumsum.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // cumsum.h: Rcpp R/C++ interface class library -- cumsum
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/diff.h
+++ b/inst/include/Rcpp/sugar/functions/diff.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // diff.h: Rcpp R/C++ interface class library -- diff
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/duplicated.h
+++ b/inst/include/Rcpp/sugar/functions/duplicated.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // duplicated.h: Rcpp R/C++ interface class library -- duplicated
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/functions.h
+++ b/inst/include/Rcpp/sugar/functions/functions.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // functions.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/head.h
+++ b/inst/include/Rcpp/sugar/functions/head.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // head.h: Rcpp R/C++ interface class library -- head
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/ifelse.h
+++ b/inst/include/Rcpp/sugar/functions/ifelse.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // ifelse.h: Rcpp R/C++ interface class library -- ifelse
 //
 // Copyright (C) 2010 - 2014 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/is_finite.h
+++ b/inst/include/Rcpp/sugar/functions/is_finite.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_finite.h: Rcpp R/C++ interface class library -- is_finite
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/is_infinite.h
+++ b/inst/include/Rcpp/sugar/functions/is_infinite.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_infinite.h: Rcpp R/C++ interface class library -- is_infinite
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/is_na.h
+++ b/inst/include/Rcpp/sugar/functions/is_na.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_na.h: Rcpp R/C++ interface class library -- is_na
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/is_nan.h
+++ b/inst/include/Rcpp/sugar/functions/is_nan.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_nan.h: Rcpp R/C++ interface class library -- is_nan
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/lapply.h
+++ b/inst/include/Rcpp/sugar/functions/lapply.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // lapply.h: Rcpp R/C++ interface class library -- lapply
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/mapply.h
+++ b/inst/include/Rcpp/sugar/functions/mapply.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // mapply.h: Rcpp R/C++ interface class library -- mapply
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // mapply_2.h: Rcpp R/C++ interface class library -- mapply_2
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // mapply_3.h: Rcpp R/C++ interface class library -- mapply_3
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/match.h
+++ b/inst/include/Rcpp/sugar/functions/match.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // match.h: Rcpp R/C++ interface class library -- match
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/math.h
+++ b/inst/include/Rcpp/sugar/functions/math.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // SugarBlock.h: Rcpp R/C++ interface class library -- sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/max.h
+++ b/inst/include/Rcpp/sugar/functions/max.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // max.h: Rcpp R/C++ interface class library -- max
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/mean.h
+++ b/inst/include/Rcpp/sugar/functions/mean.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // mean.h: Rcpp R/C++ interface class library -- mean
 //
 // Copyright (C) 2011 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/median.h
+++ b/inst/include/Rcpp/sugar/functions/median.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // median.h: Rcpp R/C++ interface class library -- median
 //
 // Copyright (C) 2016 Dirk Eddelbuettel, Romain Francois, and Nathan Russell

--- a/inst/include/Rcpp/sugar/functions/min.h
+++ b/inst/include/Rcpp/sugar/functions/min.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Min.h: Rcpp R/C++ interface class library -- min
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/na_omit.h
+++ b/inst/include/Rcpp/sugar/functions/na_omit.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // na_omit.h: Rcpp R/C++ interface class library -- na_omit
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/pmax.h
+++ b/inst/include/Rcpp/sugar/functions/pmax.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // pmax.h: Rcpp R/C++ interface class library -- pmax
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/pmin.h
+++ b/inst/include/Rcpp/sugar/functions/pmin.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // pmin.h: Rcpp R/C++ interface class library -- pmin
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/pow.h
+++ b/inst/include/Rcpp/sugar/functions/pow.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // pow.h: Rcpp R/C++ interface class library -- pow
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/range.h
+++ b/inst/include/Rcpp/sugar/functions/range.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // range.h: Rcpp R/C++ interface class library -- range
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/rep.h
+++ b/inst/include/Rcpp/sugar/functions/rep.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // rep.h: Rcpp R/C++ interface class library -- rep
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/rep_each.h
+++ b/inst/include/Rcpp/sugar/functions/rep_each.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // rep_each.h: Rcpp R/C++ interface class library -- rep_each
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/rep_len.h
+++ b/inst/include/Rcpp/sugar/functions/rep_len.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // rep_len.h: Rcpp R/C++ interface class library -- rep_len
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/rev.h
+++ b/inst/include/Rcpp/sugar/functions/rev.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // rev.h: Rcpp R/C++ interface class library -- rev
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/rowSums.h
+++ b/inst/include/Rcpp/sugar/functions/rowSums.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rowSums.h: Rcpp R/C++ interface class library -- rowSums, colSums, rowMeans, colMeans 
 //
 // Copyright (C) 2016 Nathan Russell

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // sample.h: Rcpp R/C++ interface class library -- sample
 //
 // Copyright (C) 2016 Nathan Russell

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sapply.h: Rcpp R/C++ interface class library -- sapply
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/sd.h
+++ b/inst/include/Rcpp/sugar/functions/sd.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // mean.h: Rcpp R/C++ interface class library -- mean
 //
 // Copyright (C) 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/self_match.h
+++ b/inst/include/Rcpp/sugar/functions/self_match.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // self_match.h: Rcpp R/C++ interface class library -- self match
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/seq_along.h
+++ b/inst/include/Rcpp/sugar/functions/seq_along.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // seq_along.h: Rcpp R/C++ interface class library -- any
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/setdiff.h
+++ b/inst/include/Rcpp/sugar/functions/setdiff.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // setdiff.h: Rcpp R/C++ interface class library -- setdiff
 //
 // Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/sign.h
+++ b/inst/include/Rcpp/sugar/functions/sign.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sign.h: Rcpp R/C++ interface class library -- sign
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/strings/collapse.h
+++ b/inst/include/Rcpp/sugar/functions/strings/collapse.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // collapse.h: Rcpp R/C++ interface class library -- string sugar functions
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/strings/strings.h
+++ b/inst/include/Rcpp/sugar/functions/strings/strings.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // strings.h: Rcpp R/C++ interface class library -- string sugar functions
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/strings/trimws.h
+++ b/inst/include/Rcpp/sugar/functions/strings/trimws.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // trimws.h: Rcpp R/C++ interface class library -- trimws
 //
 // Copyright (C) 2017 Nathan Russell

--- a/inst/include/Rcpp/sugar/functions/sum.h
+++ b/inst/include/Rcpp/sugar/functions/sum.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sum.h: Rcpp R/C++ interface class library -- sum
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/table.h
+++ b/inst/include/Rcpp/sugar/functions/table.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // table.h: Rcpp R/C++ interface class library -- table match
 //
 // Copyright (C) 2012 - 2013   Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/include/Rcpp/sugar/functions/tail.h
+++ b/inst/include/Rcpp/sugar/functions/tail.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // tail.h: Rcpp R/C++ interface class library -- tail
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/unique.h
+++ b/inst/include/Rcpp/sugar/functions/unique.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // unique.h: Rcpp R/C++ interface class library -- unique
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/var.h
+++ b/inst/include/Rcpp/sugar/functions/var.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // var.h: Rcpp R/C++ interface class library -- var
 //
 // Copyright (C) 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/which_max.h
+++ b/inst/include/Rcpp/sugar/functions/which_max.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // which_max.h: Rcpp R/C++ interface class library -- which.max
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/functions/which_min.h
+++ b/inst/include/Rcpp/sugar/functions/which_min.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // which_min.h: Rcpp R/C++ interface class library -- which.min
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/SingleLogicalResult.h
+++ b/inst/include/Rcpp/sugar/logical/SingleLogicalResult.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // SingleLogicalResult.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/and.h
+++ b/inst/include/Rcpp/sugar/logical/and.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // and.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/can_have_na.h
+++ b/inst/include/Rcpp/sugar/logical/can_have_na.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // can_have_na.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/is.h
+++ b/inst/include/Rcpp/sugar/logical/is.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/logical.h
+++ b/inst/include/Rcpp/sugar/logical/logical.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // logical.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/not.h
+++ b/inst/include/Rcpp/sugar/logical/not.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // not.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/logical/or.h
+++ b/inst/include/Rcpp/sugar/logical/or.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // or.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/as_vector.h
+++ b/inst/include/Rcpp/sugar/matrix/as_vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // as_vector.h: Rcpp R/C++ interface class library -- as_vector( sugar matrix expression )
 //
 // Copyright (C) 2010 - 2014 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // col.h: Rcpp R/C++ interface class library -- col
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/diag.h
+++ b/inst/include/Rcpp/sugar/matrix/diag.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // diag.h: Rcpp R/C++ interface class library -- diag
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // lower_tri.h: Rcpp R/C++ interface class library -- lower.tri
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/matrix_functions.h
+++ b/inst/include/Rcpp/sugar/matrix/matrix_functions.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // matrix_functions.h: Rcpp R/C++ interface class library -- matrix sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // outer.h: Rcpp R/C++ interface class library -- outer
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // row.h: Rcpp R/C++ interface class library -- row
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/tools.h
+++ b/inst/include/Rcpp/sugar/matrix/tools.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // matrix_functions.h: Rcpp R/C++ interface class library -- matrix sugar functions
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // upper_tri.h: Rcpp R/C++ interface class library -- upper.tri
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/nona/nona.h
+++ b/inst/include/Rcpp/sugar/nona/nona.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // nona.h: Rcpp R/C++ interface class library -- noNA handling
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/Comparator.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // LessThan.h: Rcpp R/C++ interface class library -- vector operators
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // LessThan.h: Rcpp R/C++ interface class library -- vector operators
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/divides.h
+++ b/inst/include/Rcpp/sugar/operators/divides.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // divides.h: Rcpp R/C++ interface class library -- operator-
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/logical_operators__Vector__Vector.h
+++ b/inst/include/Rcpp/sugar/operators/logical_operators__Vector__Vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // logical_operators__Vector__Vector.h: Rcpp R/C++ interface class library --
 //    logical operators for Vector to Vector comparisons
 //

--- a/inst/include/Rcpp/sugar/operators/logical_operators__Vector__primitive.h
+++ b/inst/include/Rcpp/sugar/operators/logical_operators__Vector__primitive.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // logical_operators__Vector__primitive.h: Rcpp R/C++ interface class library --
 //    logical operators for Vector to primitive comparisons
 //

--- a/inst/include/Rcpp/sugar/operators/minus.h
+++ b/inst/include/Rcpp/sugar/operators/minus.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // minus.h: Rcpp R/C++ interface class library -- operator-
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/not.h
+++ b/inst/include/Rcpp/sugar/operators/not.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // not.h: Rcpp R/C++ interface class library -- unary operator!
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/operators.h
+++ b/inst/include/Rcpp/sugar/operators/operators.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // any.h: Rcpp R/C++ interface class library -- any
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/plus.h
+++ b/inst/include/Rcpp/sugar/operators/plus.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // plus.h: Rcpp R/C++ interface class library -- operator+
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/r_binary_op.h
+++ b/inst/include/Rcpp/sugar/operators/r_binary_op.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // LessThan.h: Rcpp R/C++ interface class library -- vector operators
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/times.h
+++ b/inst/include/Rcpp/sugar/operators/times.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // times.h: Rcpp R/C++ interface class library -- operator*
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/operators/unary_minus.h
+++ b/inst/include/Rcpp/sugar/operators/unary_minus.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // unary_minus.h: Rcpp R/C++ interface class library -- unary operator-
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/sets.h
+++ b/inst/include/Rcpp/sugar/sets.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sets.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/sugar.h
+++ b/inst/include/Rcpp/sugar/sugar.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sugar.h: Rcpp R/C++ interface class library -- main file for Rcpp::sugar
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/sugar_forward.h
+++ b/inst/include/Rcpp/sugar/sugar_forward.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sugar_forward.h: Rcpp R/C++ interface class library -- forward declaration for Rcpp::sugar
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/tools/iterator.h
+++ b/inst/include/Rcpp/sugar/tools/iterator.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // iterator.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012 - 2013    Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/sugar/undoRmath.h
+++ b/inst/include/Rcpp/sugar/undoRmath.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // undoRmath.h: Rcpp R/C++ interface class library -- undo the macros set by Rmath.h
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/char_type.h
+++ b/inst/include/Rcpp/traits/char_type.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // char_type.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/expands_to_logical.h
+++ b/inst/include/Rcpp/traits/expands_to_logical.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // expands_to_logical.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/get_na.h
+++ b/inst/include/Rcpp/traits/get_na.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // get_na.h: Rcpp R/C++ interface class library -- NA handling
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/has_iterator.h
+++ b/inst/include/Rcpp/traits/has_iterator.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // has_iterator.h: Rcpp R/C++ interface class library -- identify if a class has a nested iterator typedef
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/has_na.h
+++ b/inst/include/Rcpp/traits/has_na.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // has_na.h: Rcpp R/C++ interface class library -- NA handling
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/if_.h
+++ b/inst/include/Rcpp/traits/if_.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // if.h: Rcpp R/C++ interface class library -- dispatch
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/init_type.h
+++ b/inst/include/Rcpp/traits/init_type.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // init_type.h: Rcpp R/C++ interface class library -- support traits for vector
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/integral_constant.h
+++ b/inst/include/Rcpp/traits/integral_constant.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // has_na.h: Rcpp R/C++ interface class library -- NA handling
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_arithmetic.h
+++ b/inst/include/Rcpp/traits/is_arithmetic.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_wide_string.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_const.h
+++ b/inst/include/Rcpp/traits/is_const.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_reference.h: Rcpp R/C++ interface class library -- identifies if a type is a reference
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_convertible.h
+++ b/inst/include/Rcpp/traits/is_convertible.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_convertible.h: Rcpp R/C++ interface class library -- type conversion detection
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_eigen_base.h
+++ b/inst/include/Rcpp/traits/is_eigen_base.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // is_eigen_base.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2011 Doug Bates, Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_finite.h
+++ b/inst/include/Rcpp/traits/is_finite.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // is_finite.h: Rcpp R/C++ interface class library -- is finite
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_infinite.h
+++ b/inst/include/Rcpp/traits/is_infinite.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_infinite.h: Rcpp R/C++ interface class library -- is infinite
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_module_object.h
+++ b/inst/include/Rcpp/traits/is_module_object.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_module_object.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_na.h
+++ b/inst/include/Rcpp/traits/is_na.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // is_na.h: Rcpp R/C++ interface class library -- vector operators
 //
 // Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_nan.h
+++ b/inst/include/Rcpp/traits/is_nan.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // is_nan.h: Rcpp R/C++ interface class library -- is NaN
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_pointer.h
+++ b/inst/include/Rcpp/traits/is_pointer.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_pointer.h: Rcpp R/C++ interface class library -- identifies if a type is a pointer
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_primitive.h
+++ b/inst/include/Rcpp/traits/is_primitive.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_primitive.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_reference.h
+++ b/inst/include/Rcpp/traits/is_reference.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_reference.h: Rcpp R/C++ interface class library -- identifies if a type is a reference
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_sugar_expression.h
+++ b/inst/include/Rcpp/traits/is_sugar_expression.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // is_sugar_expression.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_trivial.h
+++ b/inst/include/Rcpp/traits/is_trivial.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // traits.h: Rcpp R/C++ interface class library -- support traits for vector
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/is_wide_string.h
+++ b/inst/include/Rcpp/traits/is_wide_string.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_wide_string.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/longlong.h
+++ b/inst/include/Rcpp/traits/longlong.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // longlong.h: Rcpp R/C++ interface class library -- long long traits
 //
 // Copyright (C) 2013  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/matrix_interface.h
+++ b/inst/include/Rcpp/traits/matrix_interface.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // matrix_interface.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/module_wrap_traits.h
+++ b/inst/include/Rcpp/traits/module_wrap_traits.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // module_wrap_traits.h: Rcpp R/C++ interface class library -- traits to help module wrap
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/named_object.h
+++ b/inst/include/Rcpp/traits/named_object.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // named_object.h: Rcpp R/C++ interface class library -- named SEXP
 //
 // Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/num2type.h
+++ b/inst/include/Rcpp/traits/num2type.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // num2type.h: Rcpp R/C++ interface class library -- convert number to type
 //
 // Copyright (C) 2014 Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/include/Rcpp/traits/one_type.h
+++ b/inst/include/Rcpp/traits/one_type.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // one_type.h: Rcpp R/C++ interface class library -- traits functions for eye, ones, zeros
 //
 // Copyright (C) 2016 Nathan Russell

--- a/inst/include/Rcpp/traits/r_sexptype_traits.h
+++ b/inst/include/Rcpp/traits/r_sexptype_traits.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // r_sexptype_traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/r_type_traits.h
+++ b/inst/include/Rcpp/traits/r_type_traits.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // r_type_traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/remove_const.h
+++ b/inst/include/Rcpp/traits/remove_const.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_reference.h: Rcpp R/C++ interface class library -- identifies if a type is a reference
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/remove_const_and_reference.h
+++ b/inst/include/Rcpp/traits/remove_const_and_reference.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_reference.h: Rcpp R/C++ interface class library -- identifies if a type is a reference
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/remove_reference.h
+++ b/inst/include/Rcpp/traits/remove_reference.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // is_reference.h: Rcpp R/C++ interface class library -- identifies if a type is a reference
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/result_of.h
+++ b/inst/include/Rcpp/traits/result_of.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // result_of.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/same_type.h
+++ b/inst/include/Rcpp/traits/same_type.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // same_type.h: Rcpp R/C++ interface class library -- identifies if two types are the same
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/storage_type.h
+++ b/inst/include/Rcpp/traits/storage_type.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // r_sexptype_traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/traits.h
+++ b/inst/include/Rcpp/traits/traits.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/un_pointer.h
+++ b/inst/include/Rcpp/traits/un_pointer.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // un_pointer.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2012-2014 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/traits/wrap_type_traits.h
+++ b/inst/include/Rcpp/traits/wrap_type_traits.h
@@ -1,6 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
 // wrap_type_traits.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/utils/tinyformat.h
+++ b/inst/include/Rcpp/utils/tinyformat.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // tinyformat.h: Rcpp R/C++ interface class library -- tinyformat.h wrapper
 //
 // Copyright (C) 2008 - 2009  Dirk Eddelbuettel

--- a/inst/include/Rcpp/vector/00_forward_Vector.h
+++ b/inst/include/Rcpp/vector/00_forward_Vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // 00_forward_Vector.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/00_forward_proxy.h
+++ b/inst/include/Rcpp/vector/00_forward_proxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // 00_forward_proxy.h: Rcpp R/C++ interface class library -- proxies
 //
 // Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/DimNameProxy.h
+++ b/inst/include/Rcpp/vector/DimNameProxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // DimNameProxy.h: Rcpp R/C++ interface class library -- dimension name proxy
 //
 // Copyright (C) 2010 - 2014 Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/include/Rcpp/vector/LazyVector.h
+++ b/inst/include/Rcpp/vector/LazyVector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // LazyVector.h: Rcpp R/C++ interface class library -- lazy vectors
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Matrix.h: Rcpp R/C++ interface class library -- matrices
 //
 // Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/MatrixBase.h
+++ b/inst/include/Rcpp/vector/MatrixBase.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // MatrixBase.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2016 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // MatrixColumn.h: Rcpp R/C++ interface class library -- matrices column
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // MatrixRow.h: Rcpp R/C++ interface class library -- matrices row
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/RangeIndexer.h
+++ b/inst/include/Rcpp/vector/RangeIndexer.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // RangeIndexer.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/SubMatrix.h
+++ b/inst/include/Rcpp/vector/SubMatrix.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // SubMatrix.h: Rcpp R/C++ interface class library -- sub matrices
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Subsetter.h: Rcpp R/C++ interface class library -- vector subsetting
 //
 // Copyright (C) 2014  Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
 // Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/VectorBase.h
+++ b/inst/include/Rcpp/vector/VectorBase.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // VectorBase.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/const_string_proxy.h
+++ b/inst/include/Rcpp/vector/const_string_proxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // const_string_proxy.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2013 - 2018 Romain Francois

--- a/inst/include/Rcpp/vector/converter.h
+++ b/inst/include/Rcpp/vector/converter.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // converter.h: Rcpp R/C++ interface class library -- converters
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/instantiation.h
+++ b/inst/include/Rcpp/vector/instantiation.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // instantiation.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/no_init.h
+++ b/inst/include/Rcpp/vector/no_init.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/proxy.h
+++ b/inst/include/Rcpp/vector/proxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // proxy.h: Rcpp R/C++ interface class library -- proxies
 //
 // Copyright (C) 2010 - 2018  Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/string_proxy.h
+++ b/inst/include/Rcpp/vector/string_proxy.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // string_proxy.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/swap.h
+++ b/inst/include/Rcpp/vector/swap.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // swap.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // traits.h: Rcpp R/C++ interface class library -- support traits for vector
 //
 // Copyright (C) 2010 - 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/vector/vector_from_string.h
+++ b/inst/include/Rcpp/vector/vector_from_string.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // vector_from_string.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // RcppCommon.h: Rcpp R/C++ interface class library -- common include and defines statements
 //
 // Copyright (C) 2008 - 2009  Dirk Eddelbuettel

--- a/inst/include/doxygen/Examples.h
+++ b/inst/include/doxygen/Examples.h
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 4 -*-
-//
 // doxygen/Examples.h: R/C++ interface class library --- Examples definitions for Doxygen
 //
 // Copyright (C) 2009 - 2011 Dirk Eddelbuettel and Romain Francois

--- a/inst/skeleton/Num.cpp
+++ b/inst/skeleton/Num.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Num.cpp: Rcpp R/C++ interface class library -- Rcpp Module example
 //
 // Copyright (C) 2010 - 2012  Dirk Eddelbuettel and Romain Francois

--- a/inst/skeleton/rcpp_module.cpp
+++ b/inst/skeleton/rcpp_module.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rcpp_module.cpp: Rcpp R/C++ interface class library -- Rcpp Module examples
 //
 // Copyright (C) 2010 - 2012  Dirk Eddelbuettel and Romain Francois

--- a/inst/skeleton/stdVector.cpp
+++ b/inst/skeleton/stdVector.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // stdVector.cpp: Rcpp R/C++ interface class library -- Rcpp Module class example
 //
 // Copyright (C) 2010 - 2012  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/DataFrame.cpp
+++ b/inst/unitTests/cpp/DataFrame.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // DataFrame.cpp: Rcpp R/C++ interface class library -- DataFrame unit tests
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/Environment.cpp
+++ b/inst/unitTests/cpp/Environment.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Environment.cpp: Rcpp R/C++ interface class library -- Environment unit tests
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/Function.cpp
+++ b/inst/unitTests/cpp/Function.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Function.cpp: Rcpp R/C++ interface class library -- Rcpp::Function unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/InternalFunction.cpp
+++ b/inst/unitTests/cpp/InternalFunction.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // InternalFunction.cpp: Rcpp R/C++ interface class library -- InternalFunction unit tests
 //
 // Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/cpp/InternalFunctionCPP11.cpp
+++ b/inst/unitTests/cpp/InternalFunctionCPP11.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // InternalFunction.cpp: Rcpp R/C++ interface class library -- InternalFunction unit tests
 //
 // Copyright (C) 2014 Christian Authmann

--- a/inst/unitTests/cpp/Matrix.cpp
+++ b/inst/unitTests/cpp/Matrix.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Matrix.cpp: Rcpp R/C++ interface class library -- Matrix unit tests
 //
 // Copyright (C) 2013 - 2016  Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/unitTests/cpp/Module.cpp
+++ b/inst/unitTests/cpp/Module.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-// jedit: :folding=explicit:
 //
 // Module.cpp: Rcpp R/C++ interface class library -- module unit tests
 //

--- a/inst/unitTests/cpp/RObject.cpp
+++ b/inst/unitTests/cpp/RObject.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // RObject.cpp: Rcpp R/C++ interface class library -- RObject unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/Reference.cpp
+++ b/inst/unitTests/cpp/Reference.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Reference.cpp: Rcpp R/C++ interface class library -- Reference unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/S4.cpp
+++ b/inst/unitTests/cpp/S4.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // S4.cpp: Rcpp R/C++ interface class library -- S4 unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/Vector.cpp
+++ b/inst/unitTests/cpp/Vector.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Vector.cpp: Rcpp R/C++ interface class library -- Vector unit tests
 //
 // Copyright (C) 2012 - 2018    Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/VectorOld.cpp
+++ b/inst/unitTests/cpp/VectorOld.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Vector-old.cpp: Rcpp R/C++ interface class library -- Vector unit tests
 //
 // Copyright (C) 2014    Dirk Eddelbuettel, Romain Francois and Kevin Ushey

--- a/inst/unitTests/cpp/XPtr.cpp
+++ b/inst/unitTests/cpp/XPtr.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // XPtr.cpp: Rcpp R/C++ interface class library -- external pointer unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/as.cpp
+++ b/inst/unitTests/cpp/as.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // as.cpp: Rcpp R/C++ interface class library -- as<> unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/dates.cpp
+++ b/inst/unitTests/cpp/dates.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // dates.cpp: Rcpp R/C++ interface class library -- Date + Datetime tests
 //
 // Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/dispatch.cpp
+++ b/inst/unitTests/cpp/dispatch.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // dispatch.cpp: Rcpp R/C++ interface class library -- dispatch macro unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/embeddedR.cpp
+++ b/inst/unitTests/cpp/embeddedR.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Environment.cpp: Rcpp R/C++ interface class library -- Environment unit tests
 //
 // Copyright (C) 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/embeddedR2.cpp
+++ b/inst/unitTests/cpp/embeddedR2.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // Environment.cpp: Rcpp R/C++ interface class library -- Environment unit tests
 //
 // Copyright (C) 2018 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/exceptions.cpp
+++ b/inst/unitTests/cpp/exceptions.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // dates.cpp: Rcpp R/C++ interface class library -- Date + Datetime tests
 //
 // Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/language.cpp
+++ b/inst/unitTests/cpp/language.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // language.cpp: Rcpp R/C++ interface class library -- Language unit tests
 //
 // Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // misc.cpp: Rcpp R/C++ interface class library -- misc unit tests
 //
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/modref.cpp
+++ b/inst/unitTests/cpp/modref.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // modref.cpp: Rcpp R/C++ interface class library -- module unit tests
 //
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/na.cpp
+++ b/inst/unitTests/cpp/na.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // na.cpp: Rcpp R/C++ interface class library -- na unit tests
 //
 // Copyright (C) 2014 Kevin Ushey

--- a/inst/unitTests/cpp/rmath.cpp
+++ b/inst/unitTests/cpp/rmath.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // rmath.cpp: Rcpp R/C++ interface class library -- rmath unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // misc.cpp: Rcpp R/C++ interface class library -- misc unit tests
 //
 // Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/stats.cpp
+++ b/inst/unitTests/cpp/stats.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // stats.cpp: Rcpp R/C++ interface class library -- stats unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/sugar.cpp
+++ b/inst/unitTests/cpp/sugar.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sugar.cpp: Rcpp R/C++ interface class library -- sugar unit tests
 //
 // Copyright (C) 2012 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/support.cpp
+++ b/inst/unitTests/cpp/support.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // support.cpp: Rcpp R/C++ interface class library -- unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/cpp/table.cpp
+++ b/inst/unitTests/cpp/table.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // table.cpp: Rcpp R/C++ interface class library -- table<> unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel, Romain Francois, and Kevin Ushey

--- a/inst/unitTests/cpp/wrap.cpp
+++ b/inst/unitTests/cpp/wrap.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // wrap.cpp: Rcpp R/C++ interface class library -- wrap unit tests
 //
 // Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/testRcppClass/src/Num.cpp
+++ b/inst/unitTests/testRcppClass/src/Num.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-
 #include "rcpp_hello_world.h"
 
 class Num{

--- a/inst/unitTests/testRcppClass/src/rcpp_module.cpp
+++ b/inst/unitTests/testRcppClass/src/rcpp_module.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-
 #include <Rcpp.h>
 
 int bar(int x) {

--- a/inst/unitTests/testRcppClass/src/stdVector.cpp
+++ b/inst/unitTests/testRcppClass/src/stdVector.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-
 #include "rcpp_hello_world.h"
 
 // convenience typedef

--- a/inst/unitTests/testRcppModule/src/Num.cpp
+++ b/inst/unitTests/testRcppModule/src/Num.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Num.cpp: Rcpp R/C++ interface class library -- Rcpp Module example
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/testRcppModule/src/rcpp_module.cpp
+++ b/inst/unitTests/testRcppModule/src/rcpp_module.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // rcpp_module.cpp: Rcpp R/C++ interface class library -- Rcpp Module examples
 //
 // Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois

--- a/inst/unitTests/testRcppModule/src/stdVector.cpp
+++ b/inst/unitTests/testRcppModule/src/stdVector.cpp
@@ -1,5 +1,3 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // stdVector.cpp: Rcpp R/C++ interface class library -- Rcpp Module class example
 //
 // Copyright (C) 2010 - 2012  Dirk Eddelbuettel and Romain Francois


### PR DESCRIPTION
Follow up to #842 

The Emacs file-local settings are not consistent across files and take precedence over the the new `editorconfig` settings, causing confusion while editing.