### PR TITLE
Extract Rcpp::unwindProtect() from Rcpp::Rcpp_fast_eval()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+
+2018-06-21  Lionel Henry  <lionel@rstudio.com>
+
+        * inst/include/Rcpp/api/meat/unwind.h: Extract unwind protection from
+        Rcpp::Rcpp_fast_eval() into Rcpp::unwindProtect(). Use this function
+        whenever you need to call a C function that might longjump, for instance
+        a function from R's C API. Rcpp::unwindProtect() will protect your C++
+        stack and throw a Rcpp::internal::LongJump exception to ensure all
+        destructors are called. The R longjump is then resumed once it is safe
+        to do so. This function powers Rcpp_fast_eval().
+
+        You can use Rcpp::unwindProtect() in two ways. First with a C-like
+        callback interface that takes a `SEXP (*)(void* data)` function pointer
+        and a `void*` data argument that is passed to the function. Second, if
+        you have C++11 enabled, Rcpp::unwindProtect() implements an
+        `std::function<SEXP(void)>` overload. You can pass any function object
+        or lambda function with the right signature.
+        * inst/include/Rcpp/api/meat/Rcpp_eval.h: Idem
+
 2018-06-15  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -31,28 +31,28 @@ namespace Rcpp { namespace internal {
 
 #ifdef RCPP_USE_PROTECT_UNWIND
 
-    struct EvalData {
-        SEXP expr;
-        SEXP env;
-        EvalData(SEXP expr_, SEXP env_) : expr(expr_), env(env_) { }
-    };
+struct EvalData {
+    SEXP expr;
+    SEXP env;
+    EvalData(SEXP expr_, SEXP env_) : expr(expr_), env(env_) { }
+};
 
-    inline SEXP Rcpp_protected_eval(void* eval_data) {
-        EvalData* data = static_cast<EvalData*>(eval_data);
-        return ::Rf_eval(data->expr, data->env);
-    }
+inline SEXP Rcpp_protected_eval(void* eval_data) {
+    EvalData* data = static_cast<EvalData*>(eval_data);
+    return ::Rf_eval(data->expr, data->env);
+}
 
-    // This is used internally instead of Rf_eval() to make evaluation safer
-    inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
-        return Rcpp_fast_eval(expr, env);
-    }
+// This is used internally instead of Rf_eval() to make evaluation safer
+inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
+    return Rcpp_fast_eval(expr, env);
+}
 
 #else // R < 3.5.0
 
-    // Fall back to Rf_eval() when the protect-unwind API is unavailable
-    inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
-        return ::Rf_eval(expr, env);
-    }
+// Fall back to Rf_eval() when the protect-unwind API is unavailable
+inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
+    return ::Rf_eval(expr, env);
+}
 
 #endif
 
@@ -63,16 +63,16 @@ namespace Rcpp {
 
 #ifdef RCPP_USE_PROTECT_UNWIND
 
-    inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
-        internal::EvalData data(expr, env);
-        return unwindProtect(&internal::Rcpp_protected_eval, &data);
-    }
+inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
+    internal::EvalData data(expr, env);
+    return unwindProtect(&internal::Rcpp_protected_eval, &data);
+}
 
 #else
 
-    inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
-        return Rcpp_eval(expr, env);
-    }
+inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
+    return Rcpp_eval(expr, env);
+}
 
 #endif
 

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -23,12 +23,11 @@
 
 #if (defined(RCPP_PROTECTED_EVAL) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
 #define RCPP_USE_PROTECT_UNWIND
-#include <csetjmp>
+#include <Rcpp/api/meat/unwind.h>
 #endif
 
 
-namespace Rcpp {
-namespace internal {
+namespace Rcpp { namespace internal {
 
 #ifdef RCPP_USE_PROTECT_UNWIND
 
@@ -37,19 +36,6 @@ namespace internal {
         SEXP env;
         EvalData(SEXP expr_, SEXP env_) : expr(expr_), env(env_) { }
     };
-    struct EvalUnwindData {
-        std::jmp_buf jmpbuf;
-    };
-
-    // First jump back to the protected context with a C longjmp because
-    // `Rcpp_protected_eval()` is called from C and we can't safely throw
-    // exceptions across C frames.
-    inline void Rcpp_maybe_throw(void* unwind_data, Rboolean jump) {
-        if (jump) {
-            EvalUnwindData* data = static_cast<EvalUnwindData*>(unwind_data);
-            longjmp(data->jmpbuf, 1);
-        }
-    }
 
     inline SEXP Rcpp_protected_eval(void* eval_data) {
         EvalData* data = static_cast<EvalData*>(eval_data);
@@ -70,29 +56,16 @@ namespace internal {
 
 #endif
 
-} // namespace internal
+}} // namespace Rcpp::internal
 
+
+namespace Rcpp {
 
 #ifdef RCPP_USE_PROTECT_UNWIND
 
     inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
         internal::EvalData data(expr, env);
-        internal::EvalUnwindData unwind_data;
-        Shield<SEXP> token(::R_MakeUnwindCont());
-
-        if (setjmp(unwind_data.jmpbuf)) {
-            // Keep the token protected while unwinding because R code might run
-            // in C++ destructors. Can't use PROTECT() for this because
-            // UNPROTECT() might be called in a destructor, for instance if a
-            // Shield<SEXP> is on the stack.
-            ::R_PreserveObject(token);
-
-            throw internal::LongjumpException(token);
-        }
-
-        return ::R_UnwindProtect(internal::Rcpp_protected_eval, &data,
-                                 internal::Rcpp_maybe_throw, &unwind_data,
-                                 token);
+        return unwindProtect(&internal::Rcpp_protected_eval, &data);
     }
 
 #else

--- a/inst/include/Rcpp/api/meat/unwind.h
+++ b/inst/include/Rcpp/api/meat/unwind.h
@@ -1,0 +1,68 @@
+// unwind.h: Rcpp R/C++ interface class library -- Unwind Protect
+//
+// Copyright (C) 2018 RStudio
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef RCPP_API_MEAT_UNWIND_H
+#define RCPP_API_MEAT_UNWIND_H
+
+#include <csetjmp>
+
+
+namespace Rcpp { namespace internal {
+
+struct UnwindData {
+    std::jmp_buf jmpbuf;
+};
+
+// First jump back to the protected context with a C longjmp because
+// `Rcpp_protected_eval()` is called from C and we can't safely throw
+// exceptions across C frames.
+inline void maybeJump(void* unwind_data, Rboolean jump) {
+    if (jump) {
+        UnwindData* data = static_cast<UnwindData*>(unwind_data);
+        longjmp(data->jmpbuf, 1);
+    }
+}
+
+}} // namespace Rcpp::internal
+
+
+namespace Rcpp {
+
+SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
+    internal::UnwindData unwind_data;
+    Shield<SEXP> token(::R_MakeUnwindCont());
+
+    if (setjmp(unwind_data.jmpbuf)) {
+        // Keep the token protected while unwinding because R code might run
+        // in C++ destructors. Can't use PROTECT() for this because
+        // UNPROTECT() might be called in a destructor, for instance if a
+        // Shield<SEXP> is on the stack.
+        ::R_PreserveObject(token);
+
+        throw internal::LongjumpException(token);
+    }
+
+    return ::R_UnwindProtect(callback, data,
+                             internal::maybeJump, &unwind_data,
+                             token);
+}
+
+} // namespace Rcpp
+
+#endif

--- a/inst/include/Rcpp/api/meat/unwind.h
+++ b/inst/include/Rcpp/api/meat/unwind.h
@@ -44,7 +44,7 @@ inline void maybeJump(void* unwind_data, Rboolean jump) {
 }
 
 #ifdef RCPP_USING_CXX11
-SEXP unwindProtectUnwrap(void* data) {
+inline SEXP unwindProtectUnwrap(void* data) {
     std::function<SEXP(void)>* callback = (std::function<SEXP(void)>*) data;
     return (*callback)();
 }
@@ -55,7 +55,7 @@ SEXP unwindProtectUnwrap(void* data) {
 
 namespace Rcpp {
 
-SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
+inline SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
     internal::UnwindData unwind_data;
     Shield<SEXP> token(::R_MakeUnwindCont());
 
@@ -75,7 +75,7 @@ SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
 }
 
 #ifdef RCPP_USING_CXX11
-SEXP unwindProtect(std::function<SEXP(void)> callback) {
+inline SEXP unwindProtect(std::function<SEXP(void)> callback) {
     return unwindProtect(&internal::unwindProtectUnwrap, &callback);
 }
 #endif

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -65,3 +65,37 @@ SEXP testUnwindProtect(LogicalVector indicator) {
 #endif
     return R_NilValue; // Should never reach this
 }
+
+
+// [[Rcpp::plugins("cpp11")]]
+
+// [[Rcpp::export]]
+SEXP testUnwindProtectLambda(LogicalVector indicator) {
+    unwindIndicator my_data(indicator);
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+    Rcpp::unwindProtect([] () { return willThrow(NULL); });
+#endif
+    return R_NilValue; // Should never reach this
+}
+
+struct FunctionObj {
+    FunctionObj(int data_, bool fail_) : data(data_), fail(fail_) { }
+    SEXP operator() () {
+        if (fail)
+            willThrow(NULL);
+        NumericVector x = NumericVector::create(2);
+        x[0] = x[0] * data;
+        return x;
+    }
+    int data;
+    bool fail;
+};
+
+// [[Rcpp::export]]
+SEXP testUnwindProtectFunctionObject(LogicalVector indicator) {
+    unwindIndicator my_data(indicator);
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+    Rcpp::unwindProtect(FunctionObj(10, true));
+#endif
+    return R_NilValue; // Should never reach this
+}

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -51,3 +51,17 @@ SEXP testSendInterrupt() {
     Rf_onintr();
     return R_NilValue;
 }
+
+SEXP willThrow(void* data) {
+    Rf_error("throw!");
+    return R_NilValue;
+}
+
+// [[Rcpp::export]]
+SEXP testUnwindProtect(LogicalVector indicator) {
+    unwindIndicator my_data(indicator);
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+    Rcpp::unwindProtect(&willThrow, NULL);
+#endif
+    return R_NilValue; // Should never reach this
+}

--- a/inst/unitTests/runit.stack.R
+++ b/inst/unitTests/runit.stack.R
@@ -147,6 +147,14 @@ if (.runThisTest) {
             unwound <- FALSE
             checkException(testUnwindProtect(unwound))
             checkTrue(unwound)
+
+            unwound <- FALSE
+            checkException(testUnwindProtectLambda(unwound))
+            checkTrue(unwound)
+
+            unwound <- FALSE
+            checkException(testUnwindProtectFunctionObject(unwound))
+            checkTrue(unwound)
         }
     }
 }

--- a/inst/unitTests/runit.stack.R
+++ b/inst/unitTests/runit.stack.R
@@ -145,15 +145,27 @@ if (.runThisTest) {
     test.unwindProtect <- function() {
         if (hasUnwind) {
             unwound <- FALSE
-            checkException(testUnwindProtect(unwound))
+            checkException(testUnwindProtect(unwound, fail = TRUE))
             checkTrue(unwound)
 
             unwound <- FALSE
-            checkException(testUnwindProtectLambda(unwound))
+            checkException(testUnwindProtectLambda(unwound, fail = TRUE))
             checkTrue(unwound)
 
             unwound <- FALSE
-            checkException(testUnwindProtectFunctionObject(unwound))
+            checkException(testUnwindProtectFunctionObject(unwound, fail = TRUE))
+            checkTrue(unwound)
+
+            unwound <- FALSE
+            checkEquals(testUnwindProtect(unwound, fail = FALSE), 42)
+            checkTrue(unwound)
+
+            unwound <- FALSE
+            checkEquals(testUnwindProtectLambda(unwound, fail = FALSE), 42)
+            checkTrue(unwound)
+
+            unwound <- FALSE
+            checkEquals(testUnwindProtectFunctionObject(unwound, fail = FALSE), 420)
             checkTrue(unwound)
         }
     }

--- a/inst/unitTests/runit.stack.R
+++ b/inst/unitTests/runit.stack.R
@@ -142,4 +142,11 @@ if (.runThisTest) {
         checkTrue(unwound2) # Always unwound
     }
 
+    test.unwindProtect <- function() {
+        if (hasUnwind) {
+            unwound <- FALSE
+            checkException(testUnwindProtect(unwound))
+            checkTrue(unwound)
+        }
+    }
 }


### PR DESCRIPTION
This extracts the protecting logic from Rcpp_fast_eval into a new API function `Rcpp::unwindProtect()`. It is meant for calling any C function that might longjump, for example a function from R's C API.

When compiling against C++11, a `std::function` overload allows to use function objects or lambdas:

```c++
Rcpp::protectUnwind(() [] { return Rf_foo() })
```

For C++98 a C-style callback interface is provided:

```c++
SEXP do(void* data) {
    return Rf_foo();
};

Rcpp::protectUnwind(&do, &data)
```

I have been thinking we should remove the `Rcpp_` prefix from `Rcpp_fast_eval()`. In fact I think it should become `Rcpp::eval()`. This makes even more sense since we have switched the `.eval()` methods of classes (such as `Language::eval()`) to be synonymous with `.fast_eval()` methods. The latter should likely be deprecated in the long term. Any objection to rename to `Rcpp::eval()`?

Also given the API is becoming more general and no longer focused on R evaluation only (and a `Rcpp::tryCatch()` function is coming up), I think we should rename the define `RCPP_PROTECTED_EVAL` to `RCPP_USE_UNWIND_PROTECT`.