### PR TITLE
Improvements for unwind-protect

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+
+2018-07-10  Lionel Henry  <lionel@rstudio.com>
+
+        * inst/include/Rcpp/exceptions.h: Move LongjumpException from the
+        Rcpp::internal namespace to the public Rcpp namespace. If you have a
+        catch-all statement like `catch (...)`, be sure to catch and rethrow
+        Rcpp::LongjumpException to prevent the R longjump from being ignored.
+        * inst/include/Rcpp/macros/macros.h (VOID_END_RCPP): idem
+        * src/attributes.cpp: idem
+
 2018-07-05  Lionel Henry  <lionel@rstudio.com>
 
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: Rename `RCPP_PROTECTED_EVAL`

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+
+2018-07-05  Lionel Henry  <lionel@rstudio.com>
+
+        * R/unit.tests.R (unitTestSetup): Pass extra arguments to sourceCpp()
+        for easier debugging.
+
 2018-06-22  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: Ensure R_BaseEnv is used

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,22 @@
+2018-07-05  Lionel Henry  <lionel@rstudio.com>
+
+        * inst/include/Rcpp/api/meat/Rcpp_eval.h: Rename `RCPP_PROTECTED_EVAL`
+        to `RCPP_USE_UNWIND_PROTECT` because the new API is now more general
+        than just evaluation of R code.
+        * inst/NEWS.Rd: idem
+        * inst/unitTests/runit.interface.R: idem
 
 2018-07-05  Lionel Henry  <lionel@rstudio.com>
 
         * R/unit.tests.R (unitTestSetup): Pass extra arguments to sourceCpp()
         for easier debugging.
 
+2018-07-05  Lionel Henry  <lionel@rstudio.com>
+
         * R/Attributes.R (.plugins[["unwindProtect"]]): You can now add
         `[[Rcpp::plugins(unwindProtect)]]` in one of your source file to enable
         the new unwind-protect mechanism easily. It appends
-        `-DRCPP_PROTECTED_EVAL` to `PKG_CPPFLAGS`.
+        `-DRCPP_USE_UNWIND_PROTECT` to `PKG_CPPFLAGS`.
 
         This is safer than using a `#define` because it ensures unwind-protect
         is enabled in all compilation units, including RcppExports.cpp.

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,16 @@
         * R/unit.tests.R (unitTestSetup): Pass extra arguments to sourceCpp()
         for easier debugging.
 
+        * R/Attributes.R (.plugins[["unwindProtect"]]): You can now add
+        `[[Rcpp::plugins(unwindProtect)]]` in one of your source file to enable
+        the new unwind-protect mechanism easily. It appends
+        `-DRCPP_PROTECTED_EVAL` to `PKG_CPPFLAGS`.
+
+        This is safer than using a `#define` because it ensures unwind-protect
+        is enabled in all compilation units, including RcppExports.cpp.
+
+        * inst/unitTests/cpp/stack.cpp: Use new plugin to enable unwind-protect.
+
 2018-06-22  Kevin Ushey  <kevinushey@gmail.com>
 
         * inst/include/Rcpp/api/meat/Rcpp_eval.h: Ensure R_BaseEnv is used

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -523,6 +523,10 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
                     PKG_LIBS="-fopenmp"))
 }
 
+.plugins[["unwindProtect"]] <- function() {
+    list(env = list(PKG_CPPFLAGS = "-DRCPP_PROTECTED_EVAL"))
+}
+
 # register a plugin
 registerPlugin <- function(name, plugin) {
     .plugins[[name]] <- plugin                                  # #nocov

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -524,7 +524,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
 }
 
 .plugins[["unwindProtect"]] <- function() {
-    list(env = list(PKG_CPPFLAGS = "-DRCPP_PROTECTED_EVAL"))
+    list(env = list(PKG_CPPFLAGS = "-DRCPP_USE_UNWIND_PROTECT"))
 }
 
 # register a plugin

--- a/R/unit.tests.R
+++ b/R/unit.tests.R
@@ -88,14 +88,15 @@ test <- function(output=if(file.exists("/tmp")) "/tmp" else getwd(),
 }
 
 unitTestSetup <- function(file, packages=NULL,
-                          pathToRcppTests=system.file("unitTests", package = "Rcpp")) {
+                          pathToRcppTests=system.file("unitTests", package = "Rcpp"),
+                          ...) {
     function() {
         if (! is.null(packages)) {
             for (p in packages) {
                 suppressMessages(require(p, character.only=TRUE))
             }
         }
-        sourceCpp(file.path(pathToRcppTests, "cpp", file))
+        sourceCpp(file.path(pathToRcppTests, "cpp", file), ...)
     }
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -28,7 +28,7 @@
       finely (Romain in \ghpr{868}).
       \item The new \code{Rcpp_fast_eval} is used instead of
       \code{Rcpp_eval} though this still requires setting
-      \code{RCPP_PROTECTED_EVAL} before including \code{Rcpp.h} (Qiang
+      \code{RCPP_USE_UNWIND_PROTECT} before including \code{Rcpp.h} (Qiang
       Kou in \ghpr{867} closing \ghit{866}).
       \item The \code{Rcpp::unwindProtect()} function extracts the
       unwinding from the \code{Rcpp_fast_eval()} function and makes it
@@ -110,7 +110,7 @@
       (Kevin in \ghpr{784}).
       \item Use public R APIs for \code{new_env} (Kevin in \ghpr{785}).
       \item Evaluation of R code is now safer when compiled against R
-      3.5 (you also need to explicitly define \code{RCPP_PROTECTED_EVAL}
+      3.5 (you also need to explicitly define \code{RCPP_USE_UNWIND_PROTECT}
       before including \code{Rcpp.h}). Longjumps of all kinds (condition
       catching, returns, restarts, debugger exit) are appropriately
       detected and handled, e.g. the C++ stack unwinds correctly

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -132,7 +132,7 @@ namespace Rcpp{
             obj.attr( "names") = names ;
             Shield<SEXP> call( Rf_lang3(as_df_symb, obj, wrap( strings_as_factors ) ) ) ;
             SET_TAG( CDDR(call),  strings_as_factors_symb ) ;
-            Shield<SEXP> res( Rcpp_fast_eval( call ) ) ;
+            Shield<SEXP> res(Rcpp_fast_eval(call, R_GlobalEnv));
             DataFrame_Impl out( res ) ;
             return out ;
 

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -33,7 +33,7 @@ namespace Rcpp{
             if( Rf_isEnvironment(x) ) return x ;
             SEXP asEnvironmentSym = Rf_install("as.environment");
             try {
-                Shield<SEXP> res( Rcpp_fast_eval( Rf_lang2( asEnvironmentSym, x ) ) );
+                Shield<SEXP> res(Rcpp_fast_eval(Rf_lang2(asEnvironmentSym, x), R_GlobalEnv));
                 return res ;
             } catch( const eval_error& ex) {
                 const char* fmt = "Cannot convert object to an environment: "
@@ -374,7 +374,7 @@ namespace Rcpp{
             try{
                 SEXP getNamespaceSym = Rf_install("getNamespace");
                 Shield<SEXP> package_str( Rf_mkString(package.c_str()) );
-                env = Rcpp_fast_eval( Rf_lang2(getNamespaceSym, package_str) ) ;
+                env = Rcpp_fast_eval(Rf_lang2(getNamespaceSym, package_str), R_GlobalEnv);
             } catch( ... ){
                 throw no_such_namespace( package  ) ;
             }
@@ -393,7 +393,7 @@ namespace Rcpp{
          */
         Environment_Impl new_child(bool hashed) const {
             SEXP newEnvSym = Rf_install("new.env");
-            return Environment_Impl( Rcpp_fast_eval(Rf_lang3( newEnvSym, Rf_ScalarLogical(hashed), Storage::get__() )) );
+            return Environment_Impl(Rcpp_fast_eval(Rf_lang3(newEnvSym, Rf_ScalarLogical(hashed), Storage::get__()), R_GlobalEnv));
         }
 
 

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -79,7 +79,7 @@ namespace Rcpp{
 
         SEXP operator()() const {
             Shield<SEXP> call(Rf_lang1(Storage::get__()));
-            return Rcpp_fast_eval(call);
+            return Rcpp_fast_eval(call, R_GlobalEnv);
         }
 
         #include <Rcpp/generated/Function__operator.h>

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -21,15 +21,10 @@
 #include <Rcpp/Interrupt.h>
 #include <Rversion.h>
 
-#if (defined(RCPP_USE_UNWIND_PROTECT) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
-#define RCPP_USING_PROTECT_UNWIND
-#include <Rcpp/api/meat/unwind.h>
-#endif
-
 
 namespace Rcpp { namespace internal {
 
-#ifdef RCPP_USING_PROTECT_UNWIND
+#ifdef RCPP_USING_UNWIND_PROTECT
 
 struct EvalData {
     SEXP expr;
@@ -61,7 +56,7 @@ inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
 
 namespace Rcpp {
 
-#ifdef RCPP_USING_PROTECT_UNWIND
+#ifdef RCPP_USING_UNWIND_PROTECT
 
 inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
     internal::EvalData data(expr, env);

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -21,15 +21,15 @@
 #include <Rcpp/Interrupt.h>
 #include <Rversion.h>
 
-#if (defined(RCPP_PROTECTED_EVAL) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
-#define RCPP_USE_PROTECT_UNWIND
+#if (defined(RCPP_USE_UNWIND_PROTECT) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
+#define RCPP_USING_PROTECT_UNWIND
 #include <Rcpp/api/meat/unwind.h>
 #endif
 
 
 namespace Rcpp { namespace internal {
 
-#ifdef RCPP_USE_PROTECT_UNWIND
+#ifdef RCPP_USING_PROTECT_UNWIND
 
 struct EvalData {
     SEXP expr;
@@ -61,7 +61,7 @@ inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
 
 namespace Rcpp {
 
-#ifdef RCPP_USE_PROTECT_UNWIND
+#ifdef RCPP_USING_PROTECT_UNWIND
 
 inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
     internal::EvalData data(expr, env);

--- a/inst/include/Rcpp/generated/Function__operator.h
+++ b/inst/include/Rcpp/generated/Function__operator.h
@@ -26,108 +26,108 @@
 
 	template <TYPENAMES>
 	SEXP operator()(ARGUMENTS){
-		return Rcpp_fast_eval( Rf_lang2( Storage::get__(), pairlist(PARAMETERS) ) ) ;
+		return Rcpp_fast_eval(Rf_lang2(Storage::get__(), pairlist(PARAMETERS)), R_GlobalEnv);
 	}
 
 */
 	template <typename T1>
 	SEXP operator()(const T1& t1) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1) ) ) ;
+		return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2>
 	SEXP operator()(const T1& t1, const T2& t2) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18, typename T19>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18, const T19& t19) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)), R_GlobalEnv);
 	}
 
 	template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14, typename T15, typename T16, typename T17, typename T18, typename T19, typename T20>
 	SEXP operator()(const T1& t1, const T2& t2, const T3& t3, const T4& t4, const T5& t5, const T6& t6, const T7& t7, const T8& t8, const T9& t9, const T10& t10, const T11& t11, const T12& t12, const T13& t13, const T14& t14, const T15& t15, const T16& t16, const T17& t17, const T18& t18, const T19& t19, const T20& t20) const {
-		return Rcpp_fast_eval( Rcpp_lcons( Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20) ) ) ;
+        return Rcpp_fast_eval(Rcpp_lcons(Storage::get__(), pairlist(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)), R_GlobalEnv);
 	}
 
 /* </code-bloat> */

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -41,7 +41,7 @@
     catch( Rcpp::internal::InterruptedException &__ex__) {                                       \
         rcpp_output_type = 1 ;                                                                   \
     }                                                                                            \
-    catch(Rcpp::internal::LongjumpException& __ex__) {                                           \
+    catch (Rcpp::LongjumpException& __ex__) {                                                    \
         rcpp_output_type = 3 ;                                                                   \
         rcpp_output_condition = __ex__.token;                                                    \
     }                                                                                            \
@@ -83,7 +83,7 @@
   catch (Rcpp::internal::InterruptedException &__ex__) {                       \
     return Rcpp::internal::interruptedError();                                 \
   }                                                                            \
-  catch (Rcpp::internal::LongjumpException& __ex__) {                          \
+  catch (Rcpp::LongjumpException& __ex__) {                                    \
     return Rcpp::internal::longjumpSentinel(__ex__.token);                     \
   }                                                                            \
   catch (std::exception &__ex__) {                                             \

--- a/inst/include/Rcpp/proxy/NamesProxy.h
+++ b/inst/include/Rcpp/proxy/NamesProxy.h
@@ -54,7 +54,7 @@ public:
             } else {
                 /* use the slower and more flexible version (callback to R) */
                 SEXP namesSym = Rf_install( "names<-" );
-                Shield<SEXP> new_vec( Rcpp_fast_eval(Rf_lang3( namesSym, parent, x ))) ;
+                Shield<SEXP> new_vec(Rcpp_fast_eval(Rf_lang3(namesSym, parent, x), R_GlobalEnv));
                 parent.set__(new_vec);
             }
 

--- a/inst/include/Rcpp/r/headers.h
+++ b/inst/include/Rcpp/r/headers.h
@@ -81,4 +81,8 @@
 # pragma pop_macro("makedev")
 #endif
 
+#if (defined(RCPP_USE_UNWIND_PROTECT) && defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0))
+# define RCPP_USING_UNWIND_PROTECT
+#endif
+
 #endif /* RCPP__R__HEADERS__H */

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -31,7 +31,7 @@ namespace Rcpp {
             Armor<SEXP> res;
             try{
                 SEXP funSym = Rf_install(fun);
-                res = Rcpp_fast_eval(Rf_lang2(funSym, x));
+                res = Rcpp_fast_eval(Rf_lang2(funSym, x), R_GlobalEnv);
             } catch( eval_error& e) {
                 const char* fmt = "Could not convert using R function: %s.";
                 throw not_compatible(fmt, fun);

--- a/inst/include/Rcpp/unwindProtect.h
+++ b/inst/include/Rcpp/unwindProtect.h
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef RCPP_API_MEAT_UNWIND_H
-#define RCPP_API_MEAT_UNWIND_H
+#ifndef RCPP_UNWINDPROTECT_H
+#define RCPP_UNWINDPROTECT_H
 
 #include <csetjmp>
 

--- a/inst/include/Rcpp/unwindProtect.h
+++ b/inst/include/Rcpp/unwindProtect.h
@@ -66,7 +66,7 @@ inline SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
         // Shield<SEXP> is on the stack.
         ::R_PreserveObject(token);
 
-        throw internal::LongjumpException(token);
+        throw LongjumpException(token);
     }
 
     return ::R_UnwindProtect(callback, data,

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -74,11 +74,11 @@ namespace Rcpp {
 
 namespace Rcpp {
 
-    SEXP Rcpp_fast_eval(SEXP expr_, SEXP env = R_GlobalEnv);
+    SEXP Rcpp_fast_eval(SEXP expr_, SEXP env);
     SEXP Rcpp_eval(SEXP expr_, SEXP env = R_GlobalEnv);
 
     namespace internal {
-        SEXP Rcpp_eval_impl(SEXP expr, SEXP env = R_GlobalEnv);
+        SEXP Rcpp_eval_impl(SEXP expr, SEXP env);
     }
 
     class Module;

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -128,13 +128,15 @@ namespace Rcpp {
 #include <Rcpp/exceptions.h>
 #include <Rcpp/proxy/proxy.h>
 
+#ifdef RCPP_USING_UNWIND_PROTECT
+  #include <Rcpp/unwindProtect.h>
+#endif
+
 #include <Rcpp/lang.h>
 #include <Rcpp/complex.h>
 #include <Rcpp/barrier.h>
 
 #define RcppExport extern "C" attribute_visible
-
-#include <Rcpp/exceptions.h>
 
 #include <Rcpp/Interrupt.h>
 

--- a/inst/unitTests/cpp/misc.cpp
+++ b/inst/unitTests/cpp/misc.cpp
@@ -60,12 +60,12 @@ int Dimension_const( SEXP ia ) {
 
 // [[Rcpp::export]]
 SEXP evaluator_error() {
-    return Rcpp_fast_eval( Rf_lang2( Rf_install("stop"), Rf_mkString( "boom" ) ) );
+    return Rcpp_fast_eval(Rf_lang2(Rf_install("stop"), Rf_mkString("boom")), R_GlobalEnv);
 }
 
 // [[Rcpp::export]]
 SEXP evaluator_ok(SEXP x) {
-    return Rcpp_fast_eval( Rf_lang2( Rf_install("sample"), x ) );
+    return Rcpp_fast_eval(Rf_lang2(Rf_install("sample"), x), R_GlobalEnv);
 }
 
 // [[Rcpp::export]]

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
-#define RCPP_PROTECTED_EVAL
+// [[Rcpp::plugins(unwindProtect,cpp11)]]
 
 #include <Rcpp.h>
 using namespace Rcpp;
@@ -71,8 +71,6 @@ SEXP testUnwindProtect(Environment indicator, bool fail) {
     return out;
 }
 
-
-// [[Rcpp::plugins("cpp11")]]
 
 // [[Rcpp::export]]
 SEXP testUnwindProtectLambda(Environment indicator, bool fail) {

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -65,7 +65,7 @@ SEXP testUnwindProtect(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect(&maybeThrow, &fail);
 #endif
     return out;
@@ -77,7 +77,7 @@ SEXP testUnwindProtectLambda(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect([&] () { return maybeThrow(&fail); });
 #endif
 
@@ -100,7 +100,7 @@ SEXP testUnwindProtectFunctionObject(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
+#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect(FunctionObj(10, fail));
 #endif
 

--- a/inst/unitTests/cpp/stack.cpp
+++ b/inst/unitTests/cpp/stack.cpp
@@ -26,22 +26,22 @@ using namespace Rcpp;
 
 // Class that indicates to R caller whether C++ stack was unwound
 struct unwindIndicator {
-    unwindIndicator(LogicalVector indicator_) {
-        // Reset the indicator to FALSE
+    unwindIndicator(Environment indicator_) {
+        // Reset the indicator to NULL
         indicator = indicator_;
-        *LOGICAL(indicator) = 0;
+        indicator["unwound"] = R_NilValue;
     }
 
     // Set indicator to TRUE when stack unwinds
     ~unwindIndicator() {
-        *LOGICAL(indicator) = 1;
+        indicator["unwound"] = LogicalVector::create(1);
     }
 
-    LogicalVector indicator;
+    Environment indicator;
 };
 
 // [[Rcpp::export]]
-SEXP testFastEval(RObject expr, Environment env, LogicalVector indicator) {
+SEXP testFastEval(RObject expr, Environment env, Environment indicator) {
     unwindIndicator my_data(indicator);
     return Rcpp::Rcpp_fast_eval(expr, env);
 }
@@ -61,7 +61,7 @@ SEXP maybeThrow(void* data) {
 }
 
 // [[Rcpp::export]]
-SEXP testUnwindProtect(LogicalVector indicator, bool fail) {
+SEXP testUnwindProtect(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 
@@ -75,7 +75,7 @@ SEXP testUnwindProtect(LogicalVector indicator, bool fail) {
 // [[Rcpp::plugins("cpp11")]]
 
 // [[Rcpp::export]]
-SEXP testUnwindProtectLambda(LogicalVector indicator, bool fail) {
+SEXP testUnwindProtectLambda(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 
@@ -98,7 +98,7 @@ struct FunctionObj {
 };
 
 // [[Rcpp::export]]
-SEXP testUnwindProtectFunctionObject(LogicalVector indicator, bool fail) {
+SEXP testUnwindProtectFunctionObject(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
 

--- a/inst/unitTests/runit.interface.R
+++ b/inst/unitTests/runit.interface.R
@@ -67,7 +67,7 @@ if (.runThisTest) {
         sys_sep <- if (.Platform$OS.type == "windows") ";" else ":"
         Sys.setenv(R_LIBS = paste(c(lib_path, old_lib_paths), collapse = sys_sep))
 
-        cfg <- "#define RCPP_PROTECTED_EVAL"
+        cfg <- "#define RCPP_USE_UNWIND_PROTECT"
         build_package(exporter_name, lib_path, config = cfg)
         build_package(user_name, lib_path, config = cfg)
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2192,7 +2192,7 @@ namespace attributes {
                        << std::endl;
                 ostr() << "        if (Rcpp::internal::isLongjumpSentinel(rcpp_result_gen))"
                        << std::endl
-                       << "            throw Rcpp::internal::LongjumpException(rcpp_result_gen);"
+                       << "            throw Rcpp::LongjumpException(rcpp_result_gen);"
                        << std::endl;
                 ostr() << "        if (rcpp_result_gen.inherits(\"try-error\"))"
                        << std::endl


### PR DESCRIPTION
- Add a plugin for enabling unwind-protect. Using `// [[Rcpp::plugins(unwindProtect)]]` is safer than `#define` because the plugin ensures unwind-protect is enabled in all compilation units including RcppExports.cpp. This avoids linking issues.

- Make `LongjumpException` public. Users should catch and rethrow it before `catch (...)` so longjumps are not ignored.

- Move `unwindProtect()` to Rcpp/unwindProtect.h. Include it early in RcppCommon to make it available in other header files. This will be useful for calling into R APIs for initialising static variables etc (more on that later).

- Rename `RCPP_PROTECTED_EVAL` to `RCPP_USE_UNWIND_PROTECT`. Then `RCPP_USING_UNWIND_PROTECT` is defined in headers.h if the R version is sufficient. The latter define can be used in the rest of header files.

- Refactor unit tests so that the unwound indicator is an environment rather than a logical vector. I got into trouble with the latter because the bytecode compiler replaces scalar logical with globally shared `TRUE` or `FALSE` values. Mutating these values corrupts the runtime.

- Pass `...` from `unitTestSetup()` to `sourceCpp()` for easy debugging.