### PR TITLE
sort case-insensitive to make RcppExports more deterministic 

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -422,7 +422,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
         dir.create(rDir)
 
     # get a list of all source files
-    cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp)?)|(h(pp)?))$")
+    cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp)?)|(h(pp)?))$", ignore.case = TRUE)
 
     # derive base names (will be used for modules)
     cppFileBasenames <- tools::file_path_sans_ext(cppFiles)


### PR DESCRIPTION
`compileAttributes` uses `list.files` which gives a locale-dependent ordering of the matched files. This differs between C and en-us.UTF-8, with C ordering putting upper-case file names first. This makes the code output to `RcppExports.*` different depending on the locale.

It was not obvious to me how to make this locale independent using base R, but at least ignoring case when calling `list.files` eliminates some of the discrepancies produced with these two widely used collations. People calling `compileAttributes()` from locales which are not ordered A-Z will see differences in the output order (and thus order of functions in the generated code).