### PR TITLE
when debugging, abort with error on cast when incompatible with STRSXP

### DIFF
--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -123,7 +123,12 @@ namespace Rcpp {
                 return Rf_ScalarString( PRINTNAME( x ) );
             default:
                 const char* fmt = "Not compatible with STRSXP: [type=%s].";
+#ifndef NDEBUG
+                REprintf(fmt, Rf_type2char(TYPEOF(x)));
+                abort();
+#else
                 throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
+#endif
             }
             return R_NilValue; /* -Wall */
         }


### PR DESCRIPTION
As with #860, if `NDEBUG` is unset, then abort on a failed cast to `STRSXP`. #860 missed this code path. (Although I think this is a benign, the current master 2d4eb219bdff6bb4675e46b doesn't pass its own tests, so I can't complete an R CMD check after this patch.)