### PR TITLE
bugfixes for Rcpp::exposeClass

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-07-24  Martin Lysy  <mlysy@uwaterloo.ca>
+
+        * R/loadRcppClass.R: Search in R module for 'Class' instead of 'CppClass'.
+        * R/exposeClass.R: Fixed 'rename' argument to work as expected.
+        * inst/unitTests/runit.exposeClass.R: Added unit tests for the above.
+
 2018-07-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/bib/Rcpp.bib: More updates
@@ -26,6 +32,10 @@
 2018-07-19  Jack Wasey  <jack@jackwasey.com>
 
         * inst/include/Rcpp/r_cast.h: Error and abort if debugging for STRSXP
+2018-07-24  Martin Lysy  <mlysy@uwaterloo.ca>
+	* R/loadRcppClass.R: Search in R module for 'Class' instead of 'CppClass'.
+	* R/exposeClass.R: Fixed 'rename' argument to work as expected.
+	* inst/unitTests/runit.exposeClass.R: Added unit tests for the above.
 
 2018-07-12  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/R/RcppClass.R
+++ b/R/RcppClass.R
@@ -53,13 +53,13 @@ loadRcppClass <- function(Class, CppClass = Class,
     }
     mod <- loadModule(module, NULL, env = where, loadNow = TRUE)
     storage <- get("storage", envir = as.environment(mod))
-    if(exists(CppClass, envir = storage, inherits = FALSE)) {
-        cppclassinfo <- get(CppClass, envir = storage)
+    if(exists(Class, envir = storage, inherits = FALSE)) {
+        cppclassinfo <- get(Class, envir = storage)
         if(!is(cppclassinfo, "C++Class"))
-            stop(gettextf("Object \"%s\" in module \"%s\" is not a C++ class description", CppClass, module))
+            stop(gettextf("Object \"%s\" in module \"%s\" is not a C++ class description", Class, module))
     }
     else
-        stop(gettextf("No object \"%s\" in module \"%s\"", CppClass, module))
+        stop(gettextf("No object \"%s\" in module \"%s\"", Class, module))
     allmethods <- .makeCppMethods(methods, cppclassinfo, where)
     allfields <- .makeCppFields(fields, cppclassinfo, where)
     value <- setRefClass(Class, fields = allfields,

--- a/R/exposeClass.R
+++ b/R/exposeClass.R
@@ -92,7 +92,7 @@ exposeClass <- function(class, constructors, fields, methods,
     }
     if(is.character(file)) {
         ## are we in a package directory?  Writable, searchable src subdirectory:
-        if(file.access("src",3)==0)
+        if(file.access("src",3)==0 && (basename(file) == file))
             cfile <- file.path("src", file)
         else
             cfile <- file
@@ -107,7 +107,7 @@ exposeClass <- function(class, constructors, fields, methods,
         if(identical(Rfile, TRUE))
             Rfile <- sprintf("%sClass.R",class)
         if(is.character(Rfile)) {
-            if(file.access("R",3)==0) # in a package directory
+            if(file.access("R",3)==0 && (basename(file) == file)) # in a package directory
                 Rfile <- file.path("R", Rfile)
             Rcon <- file(Rfile, "w")
             msg <- sprintf("Wrote R file \"%s\"",Rfile)
@@ -200,11 +200,11 @@ exposeClass <- function(class, constructors, fields, methods,
         if(missing(CppClass))
             CppString <- ""
         else
-            CppString <- paste(",",dQuote(CppClass))
+            CppString <- paste0(", \"",CppClass, "\"")
         if(missing(module))
             ModString <- ""
         else
-            ModString <- paste(", module =", dQuote(module))
+            ModString <- paste0(", module = \"", module, "\"")
         writeLines(sprintf("%s <- setRcppClass(\"%s\"%s%s)",
                                class, class, CppString,ModString), Rcon)
     }

--- a/R/exposeClass.R
+++ b/R/exposeClass.R
@@ -136,16 +136,17 @@ exposeClass <- function(class, constructors, fields, methods,
     }
     writeLines("", mcon)
     flds <- .specifyItems(fields)
-    nm <- names(flds)
+    nm <- fnm <- names(flds)
     rdOnly <- nm %in% readOnly
     macros <- ifelse(rdOnly, ".field_readonly", ".field")
     test <- nm %in% rename
     if(any(test))
-        nm[test] <- newnames[match(nm[test], newnames)]
+        nm[test] <- newnames[match(nm[test], rename)]
     ns <- NULL
     for(i in seq_along(nm)) {
         typei <- flds[[i]]
-        nmi <- fldi <- nm[[i]]
+        fldi <- fnm[i]
+        nmi <- nm[[i]]
         macroi <- macros[[i]]
         if(!length(typei) || identical(typei, "")) ## direct field
             writeLines(sprintf("    %s(\"%s\", &%s::%s)",
@@ -171,7 +172,7 @@ exposeClass <- function(class, constructors, fields, methods,
     nm <- mds <- names(sigs)
     test <- nm %in% rename
     if(any(test))
-        nm[test] <- newnames[match(nm[test], newnames)]
+        nm[test] <- newnames[match(nm[test], rename)]
     for(i in seq_along(nm)) {
         sigi <- sigs[[i]]
         nmi <-  nm[[i]]

--- a/inst/unitTests/runit.exposeClass.R
+++ b/inst/unitTests/runit.exposeClass.R
@@ -34,9 +34,8 @@ if (.runThisTest) {
 #define foo_h 1
 // class to set/get double
 class foo {
- private:
-  double x;
  public:
+  double x;
   double get_x() {return x;}
   void set_x(double _x) {x = _x; return;}
   foo(double _x) {set_x(_x);}
@@ -54,10 +53,11 @@ class foo {
         ## check that result of exposeClass compiles and runs properly
         exposeClass(class = "fooR",
                     constructors = list("double"),
-                    fields = character(),
+                    fields = "x",
                     methods = c("get_x", "set_x"),
                     header = '#include "foo.h"',
                     CppClass = "foo",
+                    rename = c(y = "x", get_y = "get_x", set_y = "set_x"),
                     file = file.path(src_path, "fooModule.cpp"),
                     Rfile = file.path(R_path, "fooClass.R"))
         compileAttributes(pkg_path)
@@ -86,11 +86,17 @@ class foo {
         checkTrue( exists("bar", envir = env, inherits = FALSE),
                   "module object successfully instantiated" )
         gs <- replicate(n = 10, {
-          x <- rnorm(1)
-          bar$set_x(x)
-          bar$get_x() - x
+          y <- rnorm(1)
+          bar$set_y(y)
+          bar$get_y() - y
         })
-        checkTrue( all(gs == 0), "object methods function as expected" )
+        checkTrue( all(gs == 0), "renamed methods function as expected" )
+        gs <- replicate(n = 10, {
+          y <- rnorm(1)
+          bar$set_y(y)
+          bar$y - y
+        })
+        checkTrue( all(gs == 0), "renamed direct field functions as expected" )
 
     }
 

--- a/inst/unitTests/runit.exposeClass.R
+++ b/inst/unitTests/runit.exposeClass.R
@@ -1,0 +1,97 @@
+# Copyright (C) 2013 - 2014  Dirk Eddelbuettel and Romain Francois
+#
+# This file is part of Rcpp.
+#
+# Rcpp is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Rcpp is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+.runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
+
+if (.runThisTest) {
+
+    test.exposeClass <- function(){
+
+        tempdir <- tempdir()
+        ## foo has already been loaded in test.Rcpp.package.skeleton.R,
+        ## so named differently here to avoid namespace conflicts
+        pkg_name <- "fooModule"
+        path <- tempdir
+        pkg_path <- file.path(path, pkg_name)
+        R_path <- file.path(pkg_path, "R")
+        src_path <- file.path(pkg_path, "src")
+        foo_header <- "
+#ifndef foo_h
+#define foo_h 1
+// class to set/get double
+class foo {
+ private:
+  double x;
+ public:
+  double get_x() {return x;}
+  void set_x(double _x) {x = _x; return;}
+  foo(double _x) {set_x(_x);}
+};
+#endif
+"
+
+        ## create package
+        Rcpp.package.skeleton(pkg_name, path=path, environment = environment(),
+                              example_code = FALSE, module = TRUE)
+        on.exit(unlink(pkg_path, recursive=TRUE))
+        file.remove(list.files(c(src_path, R_path), full.names = TRUE))
+        cat(foo_header, file = file.path(src_path, "foo.h"))
+
+        ## check that result of exposeClass compiles and runs properly
+        exposeClass(class = "fooR",
+                    constructors = list("double"),
+                    fields = character(),
+                    methods = c("get_x", "set_x"),
+                    header = '#include "foo.h"',
+                    CppClass = "foo",
+                    file = file.path(src_path, "fooModule.cpp"),
+                    Rfile = file.path(R_path, "fooClass.R"))
+        compileAttributes(pkg_path)
+        invisible(sapply( list.files( file.path(pkg_path, "man"), full.names=TRUE), unlink ))
+
+        ## check build
+        owd <- getwd()
+        setwd(path)
+        on.exit( setwd(owd), add=TRUE )
+        R <- shQuote( file.path( R.home( component = "bin" ), "R" ))
+        system( paste(R, "CMD build", pkg_path) )
+        gz_name <- paste0(pkg_name, "_1.0.tar.gz")
+        checkTrue( file.exists(gz_name), "can successfully R CMD build the pkg")
+
+        ## check install + require
+        dir.create("templib")
+        install.packages(gz_name, file.path(path, "templib"), repos=NULL, type="source")
+        on.exit( unlink( file.path(path, gz_name) ), add=TRUE)
+        status <- require(pkg_name, file.path(path, "templib"), character.only=TRUE)
+        on.exit( unlink( file.path(path, "templib"), recursive=TRUE), add=TRUE )
+        checkTrue(status, "can successfully require the pkg")
+
+        ## check object creation
+        bar <- fooR(0)
+        env <- environment()
+        checkTrue( exists("bar", envir = env, inherits = FALSE),
+                  "module object successfully instantiated" )
+        gs <- replicate(n = 10, {
+          x <- rnorm(1)
+          bar$set_x(x)
+          bar$get_x() - x
+        })
+        checkTrue( all(gs == 0), "object methods function as expected" )
+
+    }
+
+}

--- a/inst/unitTests/testRcppClass/src/stdVector.cpp
+++ b/inst/unitTests/testRcppClass/src/stdVector.cpp
@@ -36,7 +36,7 @@ RCPP_MODULE(stdVector){
     using namespace Rcpp ;
 
     // we expose the class std::vector<double> as "vec" on the R side
-    class_<vec>( "vec")
+    class_<vec>( "stdNumeric")
 
     // exposing the default constructor
     .constructor()


### PR DESCRIPTION
Attempts to fix issue #879 and a couple of other minor issues with `Rcpp::exposeClass`, namely:

* `loadRcppClass` (called by `exposeClass`) handles the `Class` and `CppClass` arguments correctly now, such that the R and C++ class names for a given module needn't be the same.
* The `rename` argument to `exposeClass` now functions properly.
* When `exposeClass` is called in the root directory of a package, the generated wrapper code is put in `src` and `R` subdirectories.  This behavior is now ignored if `file` or `Rfile` contain absolute paths, in which case the files are written there.

A basic unit test for these changes (`inst/unitTests/runit.exposeClass.R`) is provided.