### PR TITLE
Feature/travis docker

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,4 @@ inst/include/Rcpp.h.old
 LICENSE
 .*.tar.gz
 \.editorconfig
+docker

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ Rcpp.pro.user
 *.tar.gz
 
 vignettes/*_cache
+
+## GNU global
+GPATH
+GRTAGS
+GTAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,37 @@
-# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
+# Run Travis CI for R via Docker
+#
+# Made by Dirk Eddelbuettel in August 2018 and released under GPL (>=2)
 
-language: c
-
-sudo: required
-
+os: linux
 dist: trusty
+sudo: required
+services: docker
+
+env:
+  global:
+    - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
+      DOCKER_CNTR="eddelbuettel/rcpp-testing"
+      R_BLD_CHK_OPTS="--no-build-vignettes --no-manual"
 
 env:
   global:
     - RunAllRcppTests="yes"
 
 before_install:
-  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # add our launchpad repo which has (inter alia) the r-cran-rbenchmark package
-  - sudo add-apt-repository -y ppa:edd/misc
-  - ./run.sh bootstrap
+  - docker pull ${DOCKER_CNTR}
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} r -p -e 'sessionInfo()'
 
 install:
-  - ./run.sh install_aptget r-cran-runit r-cran-inline r-cran-rbenchmark r-cran-rmarkdown r-cran-knitr r-cran-pinp r-cran-pkgkitten
+  # Rcpp test runner can be forced to run more tests via this a variable
+  - echo 'RunAllRcppTests="yes"' > ~/.Renviron
+  #
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD build ${R_BLD_CHK_OPTS} .
 
-script: 
-  - ./run.sh run_tests
+script:
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_BLD_CHK_OPTS} Rcpp_*.tar.gz
 
 after_success:
-  - ./run.sh coverage
-
-after_failure:
-  - ./run.sh dump_logs
+  - r -l covr -e 'codecov()'
 
 notifications:
   email:
@@ -34,5 +39,3 @@ notifications:
     on_failure: change
   slack:
     secure: kUzgzzpgBMc6a+qSjGovfU14U7x9GUXfghDgyF5qBaND/MjFpkmTBfW438Out2buiY+hFNnZc4zThifJM300cOXbcwVentmzuVQ5lLjBhTDvwQgdqytgWr/Ds9dErBeMXr178UD3MJXSOCLhO0wUke2xp2ZsDhsjquT+vFYnuk8=
-      
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_BLD_CHK_OPTS} Rcpp_*.tar.gz
 
 after_success:
-  - r -l covr -e 'codecov()'
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} r -l covr -e 'codecov()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ env:
       DOCKER_CNTR="eddelbuettel/rcpp-testing"
       R_BLD_CHK_OPTS="--no-build-vignettes --no-manual"
 
-env:
-  global:
-    - RunAllRcppTests="yes"
-
 before_install:
   - docker pull ${DOCKER_CNTR}
   - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} r -p -e 'sessionInfo()'

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2018-08-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Use Dockerfile
+
+2018-08-28  Dirk Eddelbuettel  <edd@debian.org>
+
+	* docker/Dockerfile: Add Dockerfile for use by Travis CI
+
 2018-08-27  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+## Emacs, make this -*- mode: sh; -*-
+
+FROM r-base:latest
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
+      maintainer="Dirk Eddelbuettel <edd@debian.org>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends \
+                r-cran-runit \
+                r-cran-inline \
+                r-cran-rmarkdown \
+                r-cran-knitr \
+                r-cran-pkgkitten \
+                r-cran-curl \
+                r-cran-openssl \
+                r-cran-httr \
+                r-cran-lazyeval \
+                r-cran-withr \
+        && install.r rbenchmark pinp covr \
+        && mkdir ~/.R \
+        && echo _R_CHECK_FORCE_SUGGESTS_=FALSE > ~/.R/check.Renviron
+
+CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
                 r-cran-httr \
                 r-cran-lazyeval \
                 r-cran-withr \
+                git \
         && install.r rbenchmark pinp covr \
         && mkdir ~/.R \
         && echo _R_CHECK_FORCE_SUGGESTS_=FALSE > ~/.R/check.Renviron


### PR DESCRIPTION
This is still somewhat experimental, but it is now the third GitHub repo where I tried this with success.

In essence, we convert Travis to 'bring your own container' which is quite powerful as the CI runs now become portable. By relying on a Docker Hub container, the _same_ test could run at GitLab, or on your computer, or anywhere else.

Plus, by relying on containers we open up for easy / easier test matrices with r-devel, r-olrel, r-rchk, r-ubsan, r-with-different-compilers, ...  Truly endless possibilities.  

[ The old system worked well for us too, but I need to update it as well to at least get us to using R 3.5.x (and it is a bug in my r-travis repo that we're not yet ... but I have some setups still relying on PPAs built against R 3.4.x -- but different bug in different repo. ]

Thoughts or comments on this?   