### PR TITLE
use rcpp/rcpp-testing as the container for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services: docker
 env:
   global:
     - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
-      DOCKER_CNTR="eddelbuettel/rcpp-testing"
+      DOCKER_CNTR="rcpp/rcpp-testing"
       R_BLD_CHK_OPTS="--no-build-vignettes --no-manual"
 
 before_install:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-09-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Switch to rcpp/rcpp-testing container
+
 2018-08-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .travis.yml: Use Dockerfile


### PR DESCRIPTION
This simple switches Travis to have Docker pull a container from the 'rcpp' account at Docker that I set up.  The container is the same. 

If you have an account at cloud.docker.com and want to be part of the 'rcpp' org let me know.