### PR TITLE
Sort the files scanned for attributes in the C locale

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-09-18  JJ Allaire  <jj@rstudio.com>
+
+	* R/Attributes.R: Sort the files scanned for attributes in the C locale
+	for stable output across systems.
+
 2018-10-07  Ralf Stubner  <ralf.stubner@daqana.com>
 
         * vignettes/Rcpp-extending.Rmd: Correct EXPORT to EXPOSED in displays

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -424,6 +424,12 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
     # get a list of all source files
     cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp)?)|(h(pp)?))$", ignore.case = TRUE)
 
+    # locale independent sort for stable output
+    locale <- Sys.getlocale(category = "LC_COLLATE")
+    Sys.setlocale(category = "LC_COLLATE", locale = "C")
+    cppFiles <- sort(cppFiles)
+    Sys.setlocale(category = "LC_COLLATE", locale = locale)
+
     # derive base names (will be used for modules)
     cppFileBasenames <- tools::file_path_sans_ext(cppFiles)
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -19,6 +19,11 @@
       test flag (for release versions) inside the container (Dirk).
       \item Correct the \code{R CMD check} call to skip vignettes (Dirk).
     }
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      \item Sort the files scanned for attributes in the C locale for
+      stable output across systems.
+    }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The 'Rcpp Extending' vignette was corrected and refers to


### PR DESCRIPTION
Should provide more stable output of generated code in RcppExports.cpp across systems.

Change originally suggested in this discussion: https://github.com/RcppCore/Rcpp/pull/878

See additional discussion here: https://github.com/apache/arrow/pull/2711#discussion_r223207795

@romainfrancois We might want to test this on your system to confirm that you get stable output in both package build incantations.

@wesm Hopefully this will provide final resolution to this issue (although there might be one final churn while migrating into the stable form).
