### PR TITLE
Add new class StreambufSwitcher

### DIFF
--- a/inst/include/Rcpp/iostream/Rstreambuf.h
+++ b/inst/include/Rcpp/iostream/Rstreambuf.h
@@ -24,6 +24,7 @@
 
 #include <cstdio>
 #include <streambuf>
+#include <iostream>
 
 namespace Rcpp {
 
@@ -83,6 +84,20 @@ namespace Rcpp {
     static Rostream<true>  Rcout;
     static Rostream<false> Rcerr;
 
+    // Redirect std::cout/cerr to Rstreambuf during its lifetime
+    class StreambufSwitcher {
+    public:
+        StreambufSwitcher():
+            stdoutbuf_(std::cout.rdbuf(Rcpp::Rcout.rdbuf())),
+            stderrbuf_(std::cerr.rdbuf(Rcpp::Rcerr.rdbuf())) {}
+        ~StreambufSwitcher() {
+            std::cout.rdbuf(stdoutbuf_);
+            std::cerr.rdbuf(stderrbuf_);
+        }
+    private:
+        std::streambuf* stdoutbuf_;
+        std::streambuf* stderrbuf_;
+    };
 
 }
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2753,6 +2753,7 @@ namespace attributes {
                      << "(" << argument.name() << "SEXP);" << std::endl;
             }
 
+            ostr << "    Rcpp::StreambufSwitcher streambuf_switcher;\n";
             ostr << "    ";
             if (!function.type().isVoid())
                 ostr << "rcpp_result_gen = Rcpp::wrap(";


### PR DESCRIPTION
It redirects std::cout/cerr to Rstreambuf during its lifetime. As a trial, I inserted a code to construct an object in `RcppExports.cpp` for package developers. It works as expected, but `std:cout` is detected and complained by `R CMD check`. The definition of `StreambufSwitcher` may need to be move to somewhere outside the scope of the check. I also don't know how to apply this feature to non-package usage like `sourceCpp()`. Therefore, please take this PR as a starting point of discussion.