### PR TITLE
new C++2a plugin for g++ 8 or later

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-12-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R: Added new 'c++2a' plugin for '-std=c++2a'
+	compilation standard supported by g++ 8 or later
+
 2018-11-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/vector/Subsetter.h (check_indices): More

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2012 - 2017  JJ Allaire, Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2012 - 2018  JJ Allaire, Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -469,7 +469,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
 # setup plugins environment
 .plugins <- new.env()
 
-# built-in C++98 plugin 
+# built-in C++98 plugin
 .plugins[["cpp98"]] <- function() {
     if (getRversion() >= "3.4")         # with recent R versions, R can decide
         list(env = list(USE_CXX98 = "yes"))
@@ -521,6 +521,12 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
 ## see https://gcc.gnu.org/projects/cxx-status.html
 .plugins[["cpp1z"]] <- function() {
     list(env = list(PKG_CXXFLAGS ="-std=c++1z"))
+}
+
+## built-in C++2a plugin for g++ 8 and later
+## cf https://gcc.gnu.org/projects/cxx-status.html as of Dec 2018
+.plugins[["cpp2a"]] <- function() {
+    list(env = list(PKG_CXXFLAGS ="-std=c++2a"))
 }
 
 ## built-in OpenMP plugin

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,6 +8,12 @@
     \itemize{
       \item Subsetting is no longer limited by an integer range (William
       Nolan in \ghpr{920} fixing \ghit{919}).
+      \item Error messages from subsetting are now more informative
+      (Qiang and Dirk).
+    }
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      \item A new plugin was added for C++20 (Dirk in \ghpr{927})
     }
   }
 }


### PR DESCRIPTION
Adds a C++2a plugin given the support in `g++` version 8 and later which is becoming more widespread (eg Ubuntu 18.10, presumably also current Fedora Core).