### PR TITLE
Named[] should be Named() in quick ref vignette

### DIFF
--- a/vignettes/Rcpp-quickref.Rmd
+++ b/vignettes/Rcpp-quickref.Rmd
@@ -111,7 +111,7 @@ NumericVector xx(y.begin(), y.end());
 NumericVector xx =
     NumericVector::create(1.0, 2.0, 3.0, 4.0);
 NumericVector yy =
-    NumericVector::create(Named["foo"] = 1.0,
+    NumericVector::create(Named("foo") = 1.0,
                          _["bar"]      = 2.0);
                          // _ short for Named
 ```


### PR DESCRIPTION
```
> Rcpp::evalCpp('NumericVector::create(Named["foo"] = 1.0,_["bar"] = 2.0 )')
file419870ee27e6.cpp: In function ‘SEXPREC* get_value()’:
file419870ee27e6.cpp:6:65: error: invalid types ‘<unresolved overloaded function type>[const char [4]]’ for array subscript
 SEXP get_value(){ return wrap( NumericVector::create(Named["foo"] = 1.0,_["bar"] = 2.0 ) ) ; }
                                                                 ^
make: *** [file419870ee27e6.o] Error 1
g++  -I"/usr/share/R/include" -DNDEBUG   -I"/home/zhuoer/.local/lib/R/Rcpp/include" -I"/tmp/Rtmp7XEiDX/sourceCpp-x86_64-pc-linux-gnu-1.0.0"    -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-oUvOgu/r-base-3.5.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c file419870ee27e6.cpp -o file419870ee27e6.o
/usr/lib/R/etc/Makeconf:168: recipe for target 'file419870ee27e6.o' failed
Error in sourceCpp(code = code, env = env, rebuild = rebuild, cacheDir = cacheDir,  : 
  Error 1 occurred building shared library.
```
