### PR TITLE
add definition for glob

### DIFF
--- a/vignettes/Rcpp-quickref.Rmd
+++ b/vignettes/Rcpp-quickref.Rmd
@@ -442,8 +442,10 @@ Environment env( 2 ); // by position
 Environment::Rcpp_namespace();
 Environment::base_env();
 Environment::base_namespace();
-Environment::global_env();
 Environment::empty_env();
+
+Environment glob = Environment::global_env();
+
 
 // Extract function from specific environment
 Function rnorm = stats["rnorm"];


### PR DESCRIPTION
maybe the order can be adjusted as

```cpp
// Obtain an R environment
Environment stats("package:stats");
Environment env( 2 ); // by position
Environment glob = Environment::global_env();

// Special environments
Environment::Rcpp_namespace();
Environment::base_env();
Environment::base_namespace();
Environment::empty_env();
```