### PR TITLE
fix issue with 'stale' symbols being registered

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-02-11  Kevin Ushey  <kevinushey@gmail.com>
+
+	* R/Attributes.R: better handle pre-existing RcppExports.cpp,
+	RcppExports.R when calling compileAttributes()
+
 2018-12-26  Zhuoer Dong  <dongzhuoer@mail.nankai.edu.cn>
 
 	* vignettes/Rcpp-quickref.Rmd: Fix three bugs: use `Named()`, define

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -421,8 +421,14 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
     if (!file.exists(rDir))
         dir.create(rDir)
 
+    # remove the old RcppExports.R file
+    unlink(file.path(rDir, "RcppExports.R"))
+
     # get a list of all source files
     cppFiles <- list.files(srcDir, pattern = "\\.((c(c|pp)?)|(h(pp)?))$", ignore.case = TRUE)
+
+    # don't include RcppExports.cpp
+    cppFiles <- setdiff(cppFiles, "RcppExports.cpp")
 
     # locale independent sort for stable output
     locale <- Sys.getlocale(category = "LC_COLLATE")

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,6 +15,9 @@
     \item Changes in Rcpp Attributes:
     \itemize{
       \item A new plugin was added for C++20 (Dirk in \ghpr{927})
+      \item Fixed an issue where 'stale' symbols could become registered in
+      RcppExports.cpp, leading to linker errors and other related issues.
+      (\ghit{733}; \ghit{934})
     }
     \item Changes in Rcpp Documentation:
     \itemize{


### PR DESCRIPTION
Closes #733, #934.

The underlying issue here IIUC is that the machinery that attempts to discover used symbols was also crawling the various RcppExports files, and since those were 'stale' at the time when `compileAttributes()` is run, they would incorrectly contribute 'old' symbols which would then remain incorrectly registered.

The fix here removes the R-level `RcppExports.R` file (since we want to ensure that `tools::package_native_routine_registration_skeleton()` doesn't touch it), and also removes `RcppExports.cpp` from the set of files we crawl for exportable functions.