### PR TITLE
Allow parenthesis and backslash characters inside default values

### DIFF
--- a/inst/unitTests/cpp/attributes.cpp
+++ b/inst/unitTests/cpp/attributes.cpp
@@ -20,3 +20,13 @@ std::string parse_declaration_test(std::string msg) {
 
 // [[Rcpp::export]]
 std::string parse_declaration_test(std::string msg = "Parse function declaration");
+
+// [[Rcpp::export]]
+std::string parse_default_values_with_str_parenthesis(const char* a = "(", const char* b= ")", std::string msg = "Parse function header with parenthis inside default string values.") {
+	return msg;
+}
+
+// [[Rcpp::export]]
+std::string parse_default_values_with_chr_parenthesis(char a = '(', char b= ')', std::string msg = "Parse function header with parenthis inside default char values.") {
+	return msg;
+}

--- a/inst/unitTests/cpp/attributes.cpp
+++ b/inst/unitTests/cpp/attributes.cpp
@@ -30,3 +30,8 @@ std::string parse_default_values_with_str_parenthesis(const char* a = "(", const
 std::string parse_default_values_with_chr_parenthesis(char a = '(', char b= ')', std::string msg = "Parse function header with parenthis inside default char values.") {
 	return msg;
 }
+
+// [[Rcpp::export]]
+std::string parse_default_values_with_chr_backslash(char a = '\\', std::string msg = "Parse function header with backslash inside default char values.") {
+	return msg;
+}

--- a/inst/unitTests/runit.attributes.R
+++ b/inst/unitTests/runit.attributes.R
@@ -32,6 +32,14 @@ if (.runThisTest) {
             parse_declaration_test(),
             "Parse function declaration"
         )
+        checkEquals(
+            parse_default_values_with_str_parenthesis(),
+            "Parse function header with parenthis inside default string values."
+        )
+        checkEquals(
+            parse_default_values_with_chr_parenthesis(),
+            "Parse function header with parenthis inside default char values."
+        )
     }
 
 }

--- a/inst/unitTests/runit.attributes.R
+++ b/inst/unitTests/runit.attributes.R
@@ -40,6 +40,10 @@ if (.runThisTest) {
             parse_default_values_with_chr_parenthesis(),
             "Parse function header with parenthis inside default char values."
         )
+        checkEquals(
+            parse_default_values_with_chr_backslash(),
+            "Parse function header with backslash inside default char values."
+        )
     }
 
 }

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1420,7 +1420,6 @@ namespace attributes {
 
         // Establish the text to parse for the signature
         std::string signature = parseSignature(lineNumber);
-		std::cerr << "-------------------------------- SourceFileAttributesParser::parseFunction 10" << std::endl << signature << std::endl;
         if (signature.empty()) {
             rcppExportNoFunctionFoundWarning(lineNumber);		// #nocov
             return Function();						// #nocov
@@ -1430,7 +1429,6 @@ namespace attributes {
         // (bail with an empty result if we can't find them)
         std::string::size_type endParenLoc = signature.find_last_of(')');
         std::string::size_type beginParenLoc = signature.find_first_of('(');
-		std::cerr << "-------------------------------- SourceFileAttributesParser::parseFunction 20" << std::endl << beginParenLoc << std::endl << endParenLoc << std::endl;
         if (endParenLoc == std::string::npos ||
             beginParenLoc == std::string::npos ||
             endParenLoc < beginParenLoc) {
@@ -1484,7 +1482,6 @@ namespace attributes {
                                                  endParenLoc-beginParenLoc-1);
         std::vector<std::string> args = parseArguments(argsText);
         for(auto arg: args)
-			std::cerr << "-------------------------------- SourceFileAttributesParser::parseFunction 30" << std::endl << arg << std::endl;
         for (std::vector<std::string>::const_iterator it =
                                         args.begin(); it != args.end(); ++it) {
 
@@ -1592,14 +1589,13 @@ namespace attributes {
     std::vector<std::string> SourceFileAttributesParser::parseArguments(
                                                 const std::string& argText) {
 
-			std::cerr << "-------------------------------- SourceFileAttributesParser::SourceFileAttributesParser::parseArguments 1" << std::endl << argText << std::endl;
         int templateCount = 0;
         int parenCount = 0;
         bool endOfArg = false;
         std::string currentArg;
         std::vector<std::string> args;
         char quote = 0;
-        char prevChar = 0;
+        bool escaped = false;
         typedef std::string::const_iterator it_t;
         for (it_t it = argText.begin(); it != argText.end(); ++it) {
 
@@ -1611,10 +1607,15 @@ namespace attributes {
             // Ignore quoted strings and character values in single quotes
             if ( ! quote && (ch == '"' || ch == '\''))
                 quote = ch;
-            else if (quote && ch == quote && prevChar != '\\')
+            else if (quote && ch == quote && ! escaped)
                 quote = 0;
 
-			std::cerr << "-------------------------------- SourceFileAttributesParser::SourceFileAttributesParser::parseArguments 10" << std::endl << "'" << prevChar << "' '" << ch << "' #" << quote << "#" << std::endl;
+            // Escaped character inside quotes
+            if (escaped)
+                escaped = false;
+            else if (quote && ch == '\\')
+                escaped = true;
+
             // Detect end of argument declaration
             if ( ! quote &&
                 (ch == ',') &&
@@ -1625,7 +1626,6 @@ namespace attributes {
                 endOfArg = true;
             }
 
-			std::cerr << "-------------------------------- SourceFileAttributesParser::SourceFileAttributesParser::parseArguments 20" << std::endl << endOfArg << std::endl;
             if ( ! endOfArg) {
 
                 // Append current character if not a space at start
@@ -1650,10 +1650,6 @@ namespace attributes {
                     }
                 }
             }
-			std::cerr << "-------------------------------- SourceFileAttributesParser::SourceFileAttributesParser::parseArguments 30" << std::endl << templateCount << " " << parenCount << std::endl;
-			std::cerr << "-------------------------------- SourceFileAttributesParser::SourceFileAttributesParser::parseArguments 40" << std::endl << currentArg << std::endl;
-
-            prevChar = ch;
         }
 
         if (!currentArg.empty())

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1590,15 +1590,12 @@ namespace attributes {
 
         int templateCount = 0;
         int parenCount = 0;
-        bool endOfArg = false;
         std::string currentArg;
         std::vector<std::string> args;
         char quote = 0;
         bool escaped = false;
         typedef std::string::const_iterator it_t;
         for (it_t it = argText.begin(); it != argText.end(); ++it) {
-
-            endOfArg = false;
 
             // Store current character
             char ch = *it;
@@ -1622,31 +1619,28 @@ namespace attributes {
                 (parenCount == 0)) {
                 args.push_back(currentArg);
                 currentArg.clear();
-                endOfArg = true;
+                continue;
             }
 
-            if ( ! endOfArg) {
+            // Append current character if not a space at start
+            if ( ! currentArg.empty() || ch != ' ')
+                currentArg.push_back(ch);
 
-                // Append current character if not a space at start
-                if ( ! currentArg.empty() || ch != ' ')
-                    currentArg.push_back(ch);
-
-                // Count use of potentially enclosed brackets
-                if ( ! quote) {
-                    switch(ch) {
-                        case '<':
-                            templateCount++;
-                            break;
-                        case '>':
-                            templateCount--;
-                            break;
-                        case '(':
-                            parenCount++;			// #nocov
-                            break;				// #nocov
-                        case ')':
-                            parenCount--;			// #nocov
-                            break;				// #nocov
-                    }
+            // Count use of potentially enclosed brackets
+            if ( ! quote) {
+                switch(ch) {
+                    case '<':
+                        templateCount++;
+                        break;
+                    case '>':
+                        templateCount--;
+                        break;
+                    case '(':
+                        parenCount++;			// #nocov
+                        break;				// #nocov
+                    case ')':
+                        parenCount--;			// #nocov
+                        break;				// #nocov
                 }
             }
         }

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1481,7 +1481,6 @@ namespace attributes {
         std::string argsText = signature.substr(beginParenLoc + 1,
                                                  endParenLoc-beginParenLoc-1);
         std::vector<std::string> args = parseArguments(argsText);
-        for(auto arg: args)
         for (std::vector<std::string>::const_iterator it =
                                         args.begin(); it != args.end(); ++it) {
 


### PR DESCRIPTION
Solves #975 
The argument parser method `SourceFileAttributesParser::parseArguments()` has been modified in order to allow the use of parenthesis and backslash characters inside quoted strings and character values.
