### PR TITLE
Explicit Rcpp:: in the initalize method for C++ classes wrapped inside modules

### DIFF
--- a/R/Module.R
+++ b/R/Module.R
@@ -230,11 +230,11 @@ Module <- function( module, PACKAGE = methods::getPackageName(where), where = to
         .self <- .refClassDef <- NULL
         generator$methods(initialize =
               if(cpp_hasDefaultConstructor(CLASS))
-                 function(...) cpp_object_initializer(.self,.refClassDef, ...)
+                 function(...) Rcpp::cpp_object_initializer(.self,.refClassDef, ...)
               else
                  function(...) {
-                     if(nargs()) cpp_object_initializer(.self,.refClassDef, ...)
-                     else cpp_object_dummy(.self, .refClassDef)
+                     if(nargs()) Rcpp::cpp_object_initializer(.self,.refClassDef, ...)
+                     else Rcpp::cpp_object_dummy(.self, .refClassDef)
                  }
                           )
         rm( .self, .refClassDef )


### PR DESCRIPTION
Otherwise the Rcpp functions are unknown when objects are initialized, unless Rcpp is attached.

``` r
inc <- '
class World {
public:
    World() {};
    std::string greet() { return "hello"; };

};
RCPP_MODULE(yada){
    using namespace Rcpp ;
    class_<World>("World")
    .constructor()
    .method("greet", &World::greet)
    ;
}
'
fx <- inline::cxxfunction(signature(), plugin = "Rcpp", include = inc)
yada <- Rcpp::Module("yada", inline::getDynLib(fx))
new(yada$World)$greet()
#> Error in cpp_object_initializer(.self, .refClassDef, ...): could not find function "cpp_object_initializer"
library(Rcpp)
new(yada$World)$greet()
#> [1] "hello"
```

<sup>Created on 2019-07-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.1 (2019-07-05)
#>  os       Ubuntu 18.04.2 LTS          
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       Europe/Zurich               
#>  date     2019-07-21                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package     * version date       lib source                        
#>  assertthat    0.2.1   2019-03-21 [1] CRAN (R 3.6.0)                
#>  backports     1.1.4   2019-04-10 [1] CRAN (R 3.6.0)                
#>  callr         3.3.1   2019-07-18 [1] CRAN (R 3.6.1)                
#>  cli           1.1.0   2019-03-19 [1] CRAN (R 3.6.0)                
#>  codetools     0.2-16  2018-12-24 [4] CRAN (R 3.5.2)                
#>  crayon        1.3.4   2017-09-16 [1] CRAN (R 3.6.0)                
#>  desc          1.2.0   2018-05-01 [1] CRAN (R 3.6.0)                
#>  devtools      2.1.0   2019-07-06 [1] CRAN (R 3.6.1)                
#>  digest        0.6.20  2019-07-04 [1] CRAN (R 3.6.1)                
#>  evaluate      0.14    2019-05-28 [1] CRAN (R 3.6.0)                
#>  fs            1.3.1   2019-05-06 [1] CRAN (R 3.6.0)                
#>  glue          1.3.1   2019-03-12 [1] CRAN (R 3.6.0)                
#>  highr         0.8     2019-03-20 [1] CRAN (R 3.6.0)                
#>  htmltools     0.3.6   2017-04-28 [1] CRAN (R 3.6.0)                
#>  inline        0.3.15  2018-05-18 [1] CRAN (R 3.6.1)                
#>  knitr         1.23    2019-05-18 [1] CRAN (R 3.6.1)                
#>  magrittr      1.5     2014-11-22 [1] CRAN (R 3.6.0)                
#>  memoise       1.1.0   2017-04-21 [1] CRAN (R 3.6.0)                
#>  pkgbuild      1.0.3   2019-03-20 [1] CRAN (R 3.6.0)                
#>  pkgload       1.0.2   2018-10-29 [1] CRAN (R 3.6.0)                
#>  prettyunits   1.0.2   2015-07-13 [1] CRAN (R 3.6.0)                
#>  processx      3.4.1   2019-07-18 [1] CRAN (R 3.6.1)                
#>  ps            1.3.0   2018-12-21 [1] CRAN (R 3.6.0)                
#>  R6            2.4.0   2019-02-14 [1] CRAN (R 3.6.0)                
#>  Rcpp        * 1.0.2   2019-07-21 [1] Github (RcppCore/Rcpp@84c787f)
#>  remotes       2.1.0   2019-06-24 [1] CRAN (R 3.6.0)                
#>  rlang         0.4.0   2019-06-25 [1] CRAN (R 3.6.0)                
#>  rmarkdown     1.14    2019-07-12 [1] CRAN (R 3.6.1)                
#>  rprojroot     1.3-2   2018-01-03 [1] CRAN (R 3.6.0)                
#>  sessioninfo   1.1.1   2018-11-05 [1] CRAN (R 3.6.0)                
#>  stringi       1.4.3   2019-03-12 [1] CRAN (R 3.6.0)                
#>  stringr       1.4.0   2019-02-10 [1] CRAN (R 3.6.0)                
#>  testthat      2.1.1   2019-04-23 [1] CRAN (R 3.6.0)                
#>  usethis       1.5.1   2019-07-04 [1] CRAN (R 3.6.0)                
#>  withr         2.1.2   2018-03-15 [1] CRAN (R 3.6.0)                
#>  xfun          0.8     2019-06-25 [1] CRAN (R 3.6.0)                
#>  yaml          2.2.0   2018-07-25 [1] CRAN (R 3.6.0)                
#> 
#> [1] /home/mirai/R/x86_64-pc-linux-gnu-library/3.6
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```
</details>

This occurs when modules are created explicitly via `Module()`, both inline (see above) and in packages. The latter case can be seen e.g. using  `Rcpp.package.skeleton() ` and replacing `loadModule("yada", TRUE)` with `yada <- Module("yada")` and running `new(yada$World)$greet()` after installing and loading the package.
This not an issue for the common case of using `loadModule()` in packages, where typically `import(Rcpp)` is in the `NAMESPACE`, otherwise we would observe the same behavior.

The effectiveness of using `Rcpp::` can be tested by re-running the example above after intalling Rcpp from the branch
```r
remotes::install_github("riccardoporreca/Rcpp", "fix-module-initialize")
```
The object can now be created even prior to Rcpp being attached.