### PR TITLE
Modules vignette review

### DIFF
--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -73,12 +73,6 @@ skip_final_break: true
 # Produce a pinp document
 output: pinp::pinp
 
-# CHECK-PR: Keep the option to run the examples? (look for params$eval)
-# Parameters defining the evaluation behavior (chunk options) 
-params:
-    eval: FALSE
-    results: "hide"
-
 header-includes: >
   \newcommand{\proglang}[1]{\textsf{#1}}
   \newcommand{\pkg}[1]{\textbf{#1}}
@@ -94,20 +88,6 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
-
-```{r setup, include=FALSE}
-# disable evaluation globally
-knitr::opts_chunk$set(eval = FALSE)
-if (params$eval) {
-    library(Rcpp)
-    library(inline)
-    # convenience wrapper to extract code from chunks and call cxxfunction()
-    chunk_cxxfunction <- function(chunks) {
-        inc <- unlist(knitr::knit_code$get(chunks))
-        cxxfunction(signature(), plugin = "Rcpp", include = inc)
-    }
-}
-```
 
 # Motivation
 
@@ -269,7 +249,7 @@ DE 21 Sep 2013: there must a bug somewhere in the vignette processing
              hence shortened example to not show code again
 -->
 
-```{r}
+```{r, eval=FALSE}
 f1 <- cxxfunction( , "", includes = unifModCode,
                   plugin = "Rcpp" )
 getDynLib(f1)  ## will display info about 'f1' 
@@ -278,7 +258,7 @@ getDynLib(f1)  ## will display info about 'f1'
 The following listing shows some \textsl{manual} wrapping to access the code,
 we will see later how this can be automated:
 
-```{r}
+```{r, eval=FALSE}
 setClass("Uniform",
          representation( pointer = "externalptr"))
 
@@ -358,7 +338,7 @@ the need for a wrapper function using either \pkg{Rcpp} or the \proglang{R} API.
 On the \proglang{R} side, the module is retrieved by using the
 `Module` function from \pkg{Rcpp}
 
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 inc <- '
 using namespace Rcpp;
 
@@ -389,7 +369,7 @@ as described in Section \ref{sec:modules-sourceCpp}.
 A module can contain any number of calls to `function` to register
 many internal functions to \proglang{R}. For example, these 6 functions:
 
-```{Rcpp yada-fun-def}
+```{Rcpp yada-fun-def, eval=FALSE}
 std::string hello() {
     return "hello";
 }
@@ -417,7 +397,7 @@ void bla2( int x, double y) {
 
 can be exposed with the following minimal code:
 
-```{Rcpp yada-fun-module}
+```{Rcpp yada-fun-module, eval=FALSE}
 RCPP_MODULE(yada) {
     using namespace Rcpp;
 
@@ -429,13 +409,10 @@ RCPP_MODULE(yada) {
     function("bla2"  , &bla2 );
 }
 ```
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction(c("yada-fun-def", "yada-fun-module"))
-```
 
 which can then be used from \proglang{R}:
 
-```{r eval=params$eval, results=params$results}
+```{r eval=FALSE}
 yada <- Module("yada", getDynLib(fx))
 yada$bar(2L)
 yada$foo(2L, 10.0)
@@ -462,7 +439,7 @@ are:
 In addition to the name of the function and the function pointer, it is possible
 to pass a short description of the function as the third parameter of `function`.
 
-```{Rcpp norm-doc}
+```{Rcpp norm-doc, eval=FALSE}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -477,10 +454,7 @@ RCPP_MODULE(mod) {
 
 The description is used when displaying the function to the \proglang{R} prompt:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("norm-doc")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod <- Module("mod", getDynLib(fx))
 show(mod$norm)
 ```
@@ -491,7 +465,7 @@ show(mod$norm)
 of the \proglang{R} function that encapsulates the \proglang{C++} function, by passing
 a `Rcpp::List` after the function pointer.
 
-```{Rcpp mod_formals}
+```{Rcpp mod_formals, eval=FALSE}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -509,10 +483,7 @@ RCPP_MODULE(mod_formals) {
 
 A simple usage example is provided below:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_formals")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod <- Module("mod_formals", getDynLib(fx))
 norm <- mod$norm
 norm()
@@ -523,7 +494,7 @@ args(norm)
 
 To set formal arguments without default values, simply omit the rhs.
 
-```{Rcpp mod_formals2}
+```{Rcpp mod_formals2, eval=FALSE}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -539,10 +510,7 @@ RCPP_MODULE(mod_formals2) {
 
 This can be used as follows:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_formals2")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod <- Module("mod_formals2", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -551,7 +519,7 @@ args(norm)
 The ellipsis (`...`) can be used to denote that additional arguments
 are optional; it does not take a default value.
 
-```{Rcpp mod_formals3}
+```{Rcpp mod_formals3, eval=FALSE}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -567,10 +535,7 @@ RCPP_MODULE(mod_formals3) {
 
 and from the \proglang{R} side:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_formals3")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod <- Module("mod_formals3", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -587,7 +552,7 @@ on the reference classes introduced in \proglang{R} 2.12.0.
 A class is exposed using the `class_` keyword. The `Uniform`
 class may be exposed to \proglang{R} as follows:
 
-```{Rcpp mod_uniform}
+```{Rcpp mod_uniform, eval=FALSE}
 using namespace Rcpp;
 class Uniform {
 public:
@@ -622,10 +587,7 @@ RCPP_MODULE(unif_module) {
 }
 ```
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_uniform")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 unif_module <- Module("unif_module",
                       getDynLib(fx))
 Uniform <- unif_module$Uniform
@@ -764,7 +726,7 @@ Using properties gives more flexibility in case field access has to be tracked
 or has impact on other fields. For example, this class keeps track of how many times
 the `x` field is read and written.
 
-```{Rcpp mod_bar}
+```{Rcpp mod_bar, eval=FALSE}
 class Bar {
 public:
 
@@ -804,10 +766,7 @@ RCPP_MODULE(mod_bar) {
 
 Here is a simple usage example:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_bar")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod_bar <- Module("mod_bar", getDynLib(fx))
 Bar <- mod_bar$Bar
 b <- new(Bar, 10)
@@ -890,7 +849,7 @@ static member function or a free function that returns a pointer to
 the target class. Typical use-cases include creating objects in a
 hierarchy:
 
-```{Rcpp mod_base}
+```{Rcpp mod_base, eval=FALSE}
 #include <Rcpp.h>
 using namespace Rcpp;
 
@@ -940,10 +899,7 @@ The `newBase` method returns a pointer to a `Base` object. Since that
 class is an abstract class, the objects are actually instances of
 `Derived1` or `Derived2`. The same behavior is now available in \proglang{R}:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_base")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 mod <- Module("mod", getDynLib(fx))
 Base <- mod$Base
 dv1 <- new(Base, "d1")
@@ -962,7 +918,7 @@ same class). This allows implementation of \proglang{R}-level
 
 For example, consider the \proglang{C++} class `World` exposed in module `yada`:
 
-```{Rcpp yada-world}
+```{Rcpp yada-world, eval=FALSE}
 class World {
 public:
     World() : msg("hello") {}
@@ -990,10 +946,7 @@ RCPP_MODULE(yada){
 
 The `show` method for `World` objects is then implemented as:
 
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("yada-world")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 yada <- Module("yada", getDynLib(fx))
 setMethod("show", yada$World , function(object) {
     msg <- paste("World object with message : ",
@@ -1020,7 +973,7 @@ where one of them has a method taking an instance of the other class
 as argument. In this case it is sufficient to use `RCPP_EXPOSED_AS` to
 enable the transparent conversion from \proglang{R} to \proglang{C++}:
 
-```{Rcpp exposed_as}
+```{Rcpp exposed_as, eval=FALSE}
 #include <Rcpp.h>
 
 class Foo {
@@ -1049,10 +1002,7 @@ RCPP_MODULE(Barl){
     .method("handleFoo", &Bar::handleFoo);
 }
 ```
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("exposed_as")
-```
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 Foo <- Module("Foo", getDynLib(fx))$Foo
 Bar <- Module("Barl", getDynLib(fx))$Bar
 foo <- new(Foo)
@@ -1068,7 +1018,7 @@ bar$handleFoo(foo)
 The following example illustrates how to use Rcpp modules to expose
 the class `std::vector<double>` from the STL.
 
-```{Rcpp mod_vec} 
+```{Rcpp mod_vec, eval=FALSE} 
 typedef std::vector<double> vec; 	
 void vec_assign(vec* obj, 
                 Rcpp::NumericVector data) {
@@ -1085,11 +1035,11 @@ Rcpp::NumericVector vec_asR( vec* obj ) {
 void vec_set(vec* obj, int i, double value) { 
    obj->at( i ) = value; 
 }
-// CHECK-PR: workaround complilation error with vecL:resize (C++11)
+// Fix for C++11, where we cannot directly expose 
+// member functions vec::resize and vec::push_back
 void vec_resize (vec* obj, int n) {
     obj->resize(n);
 }
-// CHECK-PR: workaround complilation error with vec::push_back (C++11)
 void vec_push_back (vec* obj, double value) {
     obj->push_back(value);
 }
@@ -1108,11 +1058,9 @@ RCPP_MODULE(mod_vec) {
     // exposing member functions
     .method("size", &vec::size)
     .method("max_size", &vec::max_size)
-    // .method("resize", &vec::resize) // CHECK-PR
     .method("capacity", &vec::capacity)
     .method("empty", &vec::empty)
     .method("reserve", &vec::reserve)
-    // .method("push_back", &vec::push_back) // CHECK-PR
     .method("pop_back", &vec::pop_back)
     .method("clear", &vec::clear)
 
@@ -1126,8 +1074,8 @@ RCPP_MODULE(mod_vec) {
     // argument
     .method("assign", &vec_assign)
     .method("insert", &vec_insert)
-    .method("resize", &vec_resize) // CHECK-PR
-    .method("push_back", &vec_push_back) // CHECK-PR
+    .method("resize", &vec_resize)
+    .method("push_back", &vec_push_back)
     .method("as.vector", &vec_asR)
 
     // special methods for indexing
@@ -1136,14 +1084,8 @@ RCPP_MODULE(mod_vec) {
     ;
 }
 ```
-```{r include=FALSE, eval=params$eval, results=params$results}
-fx <- chunk_cxxfunction("mod_vec")
-```
-```{r, eval=params$eval, results=params$results, collapse=TRUE}
-# CHECK-PR: do we need mustStart = TRUE ?
-mod_vec <- Module("mod_vec",
-                  getDynLib(fx),
-                  mustStart = TRUE)
+```{r, eval=FALSE}
+mod_vec <- Module("mod_vec", getDynLib(fx))
 vec <- mod_vec$vec
 v <- new(vec)
 v$reserve(50L)
@@ -1156,17 +1098,18 @@ v[[ 0L ]]
 v$as.vector()
 ```
 
-<!-- CHECK-PR: sourceCpp is pretty convenient, OK to add as new section? -->
-<!-- If not, the content of yada.cpp should be shown in the package section -->
 ## Loading modules via sourceCpp {#sec:modules-sourceCpp}
 
 As an alternative to the explicit creation of a `Module` object using the
 \pkg{inline} package via `cxxfunction` and `getDynLib`, it is possible to use
 the `sourceCpp` function, accepting \proglang{C++} source code as either a
-`.cpp` file or a character string. The main differences with this approach are:
+`.cpp` file or a character string and described in the \textsl{Rcpp attributes}
+vignette \citep{CRAN:Rcpp:Attributes}.
+
+The main differences with this approach are:
 
 - The `Rcpp.h` header file must be explicitly included.
-- The content of the module (\proglang{C++} functions and classes) are
+- The content of the module (\proglang{C++} functions and classes) is
 implicitly exposed and made available to \proglang{R} as individual objects, as
 opposed to being accessed from a `Module` object with the `$` extractor.
 
@@ -1176,7 +1119,7 @@ Note that this is similar to exposing modules in \proglang{R} packages using
 As an example, consider a file called `yada.cpp` containing the following
 \proglang{C++} code:
 
-```{Rcpp eval=params$eval}
+```{Rcpp, eval=FALSE}
 #include <Rcpp.h>
 std::string hello() {
     return "hello";
@@ -1213,14 +1156,14 @@ RCPP_MODULE(yada){
 }
 ```
 
-```{r}
+```{r, eval=FALSE}
 sourceCpp('yada.cpp')
 ```
 
 \proglang{C++} functions `hello`, `bla`, `bla2` and class `World` will be
 readily available in \proglang{R}:
 
-```{r, eval=params$eval, results=params$results}
+```{r, eval=FALSE}
 hello()
 bla()
 bla2(42, 0.42)
@@ -1239,18 +1182,13 @@ When using \textsl{Rcpp modules} in a packages, the client package needs to
 import \pkg{Rcpp}'s namespace. This is achieved by adding the
 following line to the `NAMESPACE` file.
 
-<!-- CHECK-PR: is this chunk needed at all? -->
-```{r, echo=FALSE,eval=TRUE}
-options( prompt = " ", continue = " " )
-```
-
-```{r}
+```{r, eval=FALSE}
 import(Rcpp)
 ```
 
 In some case we have found that explicitly naming a symbol can be preferable:
 
-```{r}
+```{r, eval=FALSE}
 import(Rcpp, evalCpp)
 ```
 
@@ -1274,14 +1212,14 @@ Then, `loadModule` is called in the package's \proglang{R} code to expose all
 \proglang{C++} functions and classes as objects `hello`, `bla`, `bla2`, `World`
 into the package namespace:
 
-```{r}
+```{r, eval=FALSE}
 loadModule("yada", TRUE)
 ```
 
 Provided the objects are also exported (see Section \ref{sec:package-exports} below), this makes them readily
 available in \proglang{R}:
 
-```{r}
+```{r, eval=FALSE}
 library(testmod)
 hello()
 bla()
@@ -1303,7 +1241,7 @@ loading all functions and classes from a module
 into a package namespace was achieved using the `loadRcppModules` function
 within the `.onLoad` body.
 
-```{r}
+```{r, eval=FALSE}
 .onLoad <- function(libname, pkgname) {
     loadRcppModules()
 }
@@ -1334,17 +1272,12 @@ and let them extract the functions and classes as needed. This uses lazy loading
 so that the module is only loaded the first time the user attempts to extract
 a function or a class with the dollar extractor.
 
-```{r}
+```{r, eval=FALSE}
 yada <- Module( "yada" )
 
 .onLoad <- function(libname, pkgname) {
     # placeholder
 }
-```
-
-<!-- CHECK-PR: is this chunk needed at all? -->
-```{r, echo=FALSE,eval=TRUE}
-options(prompt = "> ", continue = "+ ")
 ```
 
 Provided `yada` is properly exported, the functions and classes are
@@ -1368,7 +1301,7 @@ export(hello, bla, bla2, World)
 Creating a new package using \textsl{Rcpp modules} is easiest via the call to
 `Rcpp.package.skeleton()` with argument `module=TRUE`.
 
-```{r}
+```{r, eval=FALSE}
 Rcpp.package.skeleton("testmod", module = TRUE)
 ```
 
@@ -1381,7 +1314,7 @@ This will install code providing three example modules, exposed using
 `Module` class, allowing generation of a skeleton of an Rd
 file containing some information about the module.
 
-```{r}
+```{r, eval=FALSE}
 yada <- Module("yada")
 prompt(yada, "yada-module.Rd")
 ```

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -73,6 +73,7 @@ skip_final_break: true
 # Produce a pinp document
 output: pinp::pinp
 
+# CHECK-PR: Keep the option to run the examples? (look for params$eval)
 params:
     eval: FALSE
 
@@ -169,7 +170,7 @@ certain aspect of \textsl{Rcpp modules} and makes binding to simple functions
 such as this one even easier.  With \textsl{Rcpp attributes} we can just write
 
 ```cpp
-# include <Rcpp.h>
+#include <Rcpp.h>
 
 // [[Rcpp::export]]
 double norm(double x, double y) {
@@ -373,9 +374,10 @@ module was returned by the `cxxfunction()` (from the \pkg{inline}
 package) as callable R function `fx` from which we can extract the
 relevant pointer using `getDynLib()` (again from \pkg{inline}).
 
-Throughout the rest of the examples in this document, we always assume that the \proglang{C++}
-code defining a module is used to create an object `fx` via a similar call
-to `cxxfunction`.
+Throughout the rest of the examples in this document, we always assume that the
+\proglang{C++} code defining a module is used to create an object `fx` via a
+similar call to `cxxfunction`. As an alternative, one can also use `sourceCpp`
+as described in Section \ref{sec:modules-sourceCpp}.
 
 A module can contain any number of calls to `function` to register
 many internal functions to \proglang{R}. For example, these 6 functions:
@@ -973,7 +975,7 @@ private:
 };
 
 RCPP_MODULE(yada){
-    using namespace Rcpp ;
+    using namespace Rcpp;
 
     class_<World>("World")
     
@@ -1158,53 +1160,162 @@ v[[ 0L ]]
 v$as.vector()
 ```
 
+<!-- CHECK-PR: sourceCpp is pretty convenient, OK to add as new section? -->
+<!-- If not, the content of yada.cpp should be shown in the package section -->
+## Loading modules via sourceCpp {#sec:modules-sourceCpp}
+
+As an alternative to the explicit creation of a `Module` object using the
+\pkg{inline} package via `cxxfunction` and `getDynLib`, it is possible to use
+the `sourceCpp` function, accepting \proglang{C++} source code as either a
+`.cpp` file or a character string. The main differences with this approach are:
+
+- The `Rcpp.h` header file must be explicitly included.
+- The content of the module (\proglang{C++} functions and classes) are
+implicitly exposed and made available to \proglang{R} as individual objects, as
+opposed to being accessed from a `Module` object with the `$` extractor.
+
+Note that this is similar to exposing modules in \proglang{R} packages using
+`loadModule`, described in Section \ref{sec:package-namespace-loadModule} below.
+
+As an example, consider a file called `yada.cpp` containing the following
+\proglang{C++} code:
+
+```{Rcpp}
+#include <Rcpp.h>
+std::string hello() {
+    return "hello";
+}
+void bla() {
+    Rprintf("hello\\n");
+}
+void bla2( int x, double y) {
+    Rprintf("hello (x = %d, y = %5.2f)\\n", x, y);
+}
+
+class World {
+public:
+    World() : msg("hello") {}
+    void set(std::string msg) { this->msg = msg; }
+    std::string greet() { return msg; }
+
+private:
+    std::string msg;
+};
+
+RCPP_MODULE(yada){
+    using namespace Rcpp;
+
+    function("hello" , &hello);
+    function("bla"   , &bla);
+    function("bla2"  , &bla2);
+
+    class_<World>("World")
+    .constructor()
+    .method("greet", &World::greet)
+    .method("set",   &World::set)
+    ;
+}
+```
+
+```{r}
+sourceCpp('yada.cpp')
+```
+
+\proglang{C++} functions `hello`, `bla`, `bla2` and class `World` will be
+readily available in \proglang{R}:
+
+```{r, eval=params$eval}
+hello()
+bla()
+bla2(42, 0.42)
+w <- new(World)
+w$greet()
+w$set("hohoho")
+w$greet()
+```
+
 # Using modules in other packages {#sec:package}
 
-## Namespace import/export
-
-### Import all functions and classes
+## Namespace import
 
 When using \pkg{Rcpp} modules in a packages, the client package needs to
 import \pkg{Rcpp}'s namespace. This is achieved by adding the
 following line to the `NAMESPACE` file.
 
+<!-- CHECK-PR: is this chunk needed at all? -->
 ```{r, echo=FALSE,eval=TRUE}
 options( prompt = " ", continue = " " )
 ```
 
-```{r, eval=FALSE}
+```{r}
 import(Rcpp)
 ```
 
 In some case we have found that explicitly naming a symbol can be preferable:
 
-```{r, eval=FALSE}
+```{r}
 import(Rcpp, evalCpp)
 ```
 
-## Load the module
+## Load the module in the namespace
 
-### Deprecated older method using loadRcppModules
+### Load the module content via loadModule {#sec:package-namespace-loadModule}
 
-Note: This approach is deprecated as of Rcpp 0.12.5, and now triggers a warning
-message.  Eventually this function will be withdrawn.
+Starting with release 0.9.11, the preferred way for loading a module directly
+into a package namespace is by calling the `loadModule()` function, which takes
+the module name as an argument and exposes the content of the module
+(\proglang{C++} functions and classes) as individual objects in the namespace.
+It can be placed in any `.R` file in the package. This is useful as it allows to
+load the module from the same file as some auxiliary \proglang{R} functions
+using the module.
 
-The simplest way to load all functions and classes from a module directly
-into a package namespace used to be to use the `loadRcppModules` function
+Consider a package \pkg{testmod} defining a module `yada` in the source file
+`src/yada.cpp`, with the same content as defined above in
+Section \ref{sec:modules-sourceCpp} above
+
+Then, `loadModule` is called in the package's \proglang{R} code to expose all
+\proglang{C++} functions and classes as objects `hello`, `bla`, `bla2`, `World`
+into the package namespace:
+
+```{r}
+loadModule("yada", TRUE)
+```
+
+Provided the objects are also exported (see Section \ref{sec:package-exports} below), this makes them readily
+available in \proglang{R}:
+
+```{r}
+library(testmod)
+hello()
+bla()
+bla2(42, 0.42)
+w <- new(World)
+w$greet()
+w$set("hohoho")
+w$greet()
+```
+
+The `loadModule` function has an argument `what` to control which objects are
+exposed in the package namespace. The special value `TRUE` means that all
+objects are exposed.
+
+### Deprecated legacy method using loadRcppModules
+
+Prior to release 0.9.11, where `loadModule` was introduced, 
+loading all functions and classes from a module
+into a package namespace was achieved using the `loadRcppModules` function
 within the `.onLoad` body.
 
-```{r, eval=FALSE}
+```{r}
 .onLoad <- function(libname, pkgname) {
     loadRcppModules()
 }
 ```
 
-This will look in the package's DESCRIPTION file for the `RcppModules`
+This will look in the package's `DESCRIPTION` file for the `RcppModules`
 field, load each declared module and populate their contents into the
-package's namespace. For example, both the \pkg{testRcppModule} package
-(which is part of large unit test suite for \pkg{Rcpp}) and the package
-created via `Rcpp.package.skeleton("somename", module=TRUE)` have this
-declaration:
+package's namespace. For example, a package defining modules 
+`yada`, `stdVector`, `NumEx` would have this declaration:
 
 ```
 RcppModules: yada, stdVector, NumEx
@@ -1215,31 +1326,18 @@ with a default value of `TRUE`. With this default value, all content
 from the module is exposed directly in the package namespace. If set to
 `FALSE`, all content is exposed as components of the module.
 
-### Preferred current method using loadModule
-
-Starting with release 0.9.11, an alternative is provided by the
-`loadModule()` function which takes the module name as an argument.
-It can be placed in any `.R` file in the package. This is useful as it allows to load
-the module from the same file as some auxiliary \proglang{R} functions using the
-module. For the example module, the equivalent code to the `.onLoad()`
-use shown above then becomes
-
-```{r, eval=FALSE}
-loadModule("yada")
-loadModule("stdVector")
-loadModule("NumEx")
-```
-
-This feature is also used in the new Rcpp Classes introduced with Rcpp 0.9.11.
+Note: This approach is **deprecated** as of Rcpp 0.12.5, and now triggers a
+warning message. Eventually this function will be withdrawn.
 
 ### Just expose the module
 
-Alternatively, it is possible to just expose the module to the user of the package,
+Alternatively to exposing a module's content via `loadModule`,
+it is possible to just expose the module object to the users of the package,
 and let them extract the functions and classes as needed. This uses lazy loading
 so that the module is only loaded the first time the user attempts to extract
 a function or a class with the dollar extractor.
 
-```{r, eval=FALSE}
+```{r}
 yada <- Module( "yada" )
 
 .onLoad <- function(libname, pkgname) {
@@ -1247,24 +1345,38 @@ yada <- Module( "yada" )
 }
 ```
 
+<!-- CHECK-PR: is this chunk needed at all? -->
 ```{r, echo=FALSE,eval=TRUE}
 options(prompt = "> ", continue = "+ ")
+```
+
+Provided `yada` is properly exported, the functions and classes are
+accessed as e.g. `yada$hello`, `yada$World`.
+
+## Namespace exports {#sec:package-exports}
+
+The content of modules or the modules as a whole, exposed as objects in the
+package namespace, must be exported to be visible to users of the package. As
+for any other object, this is achieved by the appropriate `export()` or
+`exportPattern()` statements in the `NAMESPACE` file. For instance, the
+functions and classes in the `yada` module considered above can be exported as:
+
+```
+export(hello, bla, bla2, World)
 ```
 
 
 ## Support for modules in skeleton generator
 
-The `Rcpp.package.skeleton` function has been improved to help
-\pkg{Rcpp} modules. When the `module` argument is set to `TRUE`,
-the skeleton generator installs code that uses a simple module.
+Creating a new package using \textsl{Rcpp modules} is easiest via the call to
+`Rcpp.package.skeleton()` with argument `module=TRUE`.
 
-```{r, eval=FALSE}
+```{r}
 Rcpp.package.skeleton("testmod", module = TRUE)
 ```
 
-Creating a new package using \textsl{Rcpp modules} is easiest via the call to
-`Rcpp.package.skeleton()` with argument `module=TRUE` as a working
-package with three example Modules results.
+This will install code providing three example modules, exposed using
+`LoadModule`.
 
 ## Module documentation
 
@@ -1272,7 +1384,7 @@ package with three example Modules results.
 `Module` class, allowing generation of a skeleton of an Rd
 file containing some information about the module.
 
-```{r, eval=FALSE}
+```{r}
 yada <- Module("yada")
 prompt(yada, "yada-module.Rd")
 ```

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -74,8 +74,10 @@ skip_final_break: true
 output: pinp::pinp
 
 # CHECK-PR: Keep the option to run the examples? (look for params$eval)
+# Parameters defining the evaluation behavior (chunk options) 
 params:
     eval: FALSE
+    results: "hide"
 
 header-includes: >
   \newcommand{\proglang}[1]{\textsf{#1}}
@@ -99,6 +101,11 @@ knitr::opts_chunk$set(eval = FALSE)
 if (params$eval) {
     library(Rcpp)
     library(inline)
+    # convenience wrapper to extract code from chunks and call cxxfunction()
+    chunk_cxxfunction <- function(chunks) {
+        inc <- unlist(knitr::knit_code$get(chunks))
+        cxxfunction(signature(), plugin = "Rcpp", include = inc)
+    }
 }
 ```
 
@@ -351,7 +358,7 @@ the need for a wrapper function using either \pkg{Rcpp} or the \proglang{R} API.
 On the \proglang{R} side, the module is retrieved by using the
 `Module` function from \pkg{Rcpp}
 
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 inc <- '
 using namespace Rcpp;
 
@@ -422,14 +429,13 @@ RCPP_MODULE(yada) {
     function("bla2"  , &bla2 );
 }
 ```
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("yada-fun-def", "yada-fun-module")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction(c("yada-fun-def", "yada-fun-module"))
 ```
 
 which can then be used from \proglang{R}:
 
-```{r eval=params$eval, output=params$output}
+```{r eval=params$eval, results=params$results}
 yada <- Module("yada", getDynLib(fx))
 yada$bar(2L)
 yada$foo(2L, 10.0)
@@ -471,11 +477,10 @@ RCPP_MODULE(mod) {
 
 The description is used when displaying the function to the \proglang{R} prompt:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("norm-doc")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("norm-doc")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod <- Module("mod", getDynLib(fx))
 show(mod$norm)
 ```
@@ -504,11 +509,10 @@ RCPP_MODULE(mod_formals) {
 
 A simple usage example is provided below:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_formals")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_formals")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod <- Module("mod_formals", getDynLib(fx))
 norm <- mod$norm
 norm()
@@ -535,11 +539,10 @@ RCPP_MODULE(mod_formals2) {
 
 This can be used as follows:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_formals2")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_formals2")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod <- Module("mod_formals2", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -564,11 +567,10 @@ RCPP_MODULE(mod_formals3) {
 
 and from the \proglang{R} side:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_formals3")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_formals3")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod <- Module("mod_formals3", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -620,11 +622,10 @@ RCPP_MODULE(unif_module) {
 }
 ```
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_uniform")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_uniform")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 unif_module <- Module("unif_module",
                       getDynLib(fx))
 Uniform <- unif_module$Uniform
@@ -803,11 +804,10 @@ RCPP_MODULE(mod_bar) {
 
 Here is a simple usage example:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_bar")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_bar")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod_bar <- Module("mod_bar", getDynLib(fx))
 Bar <- mod_bar$Bar
 b <- new(Bar, 10)
@@ -940,11 +940,10 @@ The `newBase` method returns a pointer to a `Base` object. Since that
 class is an abstract class, the objects are actually instances of
 `Derived1` or `Derived2`. The same behavior is now available in \proglang{R}:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_base")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_base")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 mod <- Module("mod", getDynLib(fx))
 Base <- mod$Base
 dv1 <- new(Base, "d1")
@@ -991,11 +990,10 @@ RCPP_MODULE(yada){
 
 The `show` method for `World` objects is then implemented as:
 
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("yada-world")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("yada-world")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 yada <- Module("yada", getDynLib(fx))
 setMethod("show", yada$World , function(object) {
     msg <- paste("World object with message : ",
@@ -1051,11 +1049,10 @@ RCPP_MODULE(Barl){
     .method("handleFoo", &Bar::handleFoo);
 }
 ```
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("exposed_as")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("exposed_as")
 ```
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 Foo <- Module("Foo", getDynLib(fx))$Foo
 Bar <- Module("Barl", getDynLib(fx))$Bar
 foo <- new(Foo)
@@ -1139,11 +1136,10 @@ RCPP_MODULE(mod_vec) {
     ;
 }
 ```
-```{r include=FALSE, eval=params$eval}
-inc <- unlist(knitr::knit_code$get(c("mod_vec")))
-fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```{r include=FALSE, eval=params$eval, results=params$results}
+fx <- chunk_cxxfunction("mod_vec")
 ```
-```{r, eval=params$eval, collapse=TRUE}
+```{r, eval=params$eval, results=params$results, collapse=TRUE}
 # CHECK-PR: do we need mustStart = TRUE ?
 mod_vec <- Module("mod_vec",
                   getDynLib(fx),
@@ -1224,7 +1220,7 @@ sourceCpp('yada.cpp')
 \proglang{C++} functions `hello`, `bla`, `bla2` and class `World` will be
 readily available in \proglang{R}:
 
-```{r, eval=params$eval}
+```{r, eval=params$eval, results=params$results}
 hello()
 bla()
 bla2(42, 0.42)

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -181,7 +181,7 @@ double norm(double x, double y) {
 See the corresponding vignette \citep{CRAN:Rcpp:Attributes} for details, but
 read on for \textsl{Rcpp modules} which provide features not
 covered by \textsl{Rcpp attributes}, particularly when it comes to binding
-entire C++ classes and more.
+entire \proglang{C++} classes and more.
 
 ## Exposing classes using Rcpp
 
@@ -206,7 +206,7 @@ private:
 };
 ```
 
-To use this class from R, we at least need to expose the constructor and
+To use this class from \proglang{R}, we at least need to expose the constructor and
 the `draw` method. External pointers
 \citep{R:Extensions} are the perfect vessel for this, and using the
 `Rcpp:::XPtr` template from \pkg{Rcpp} we can expose the class
@@ -329,7 +329,7 @@ simplifies the way modules are actually loaded, as detailed in Section
 ## Exposing \proglang{C++} functions using Rcpp modules
 
 Consider the `norm` function from the previous section.
-We can expose it to \proglang{R} :
+We can expose it to \proglang{R}:
 
 ```cpp
 using namespace Rcpp;
@@ -371,7 +371,7 @@ mod <- Module("mod", getDynLib(fx))
 
 Note that this example assumed that the previous code segment defining the
 module was returned by the `cxxfunction()` (from the \pkg{inline}
-package) as callable R function `fx` from which we can extract the
+package) as callable \proglang{R} function `fx` from which we can extract the
 relevant pointer using `getDynLib()` (again from \pkg{inline}).
 
 Throughout the rest of the examples in this document, we always assume that the
@@ -448,7 +448,7 @@ are:
   can be managed by the `Rcpp::wrap` template.
 - The function name itself has to be unique in the module.
   In other words, no two functions with
-  the same name but different signatures are allowed. C++ allows overloading
+  the same name but different signatures are allowed. \proglang{C++} allows overloading
   functions. This might be added in future versions of modules.
 
 ### Documentation for exposed functions using Rcpp modules
@@ -469,7 +469,7 @@ RCPP_MODULE(mod) {
 }
 ```
 
-The description is used when displaying the function to the R prompt:
+The description is used when displaying the function to the \proglang{R} prompt:
 
 ```{r include=FALSE, eval=params$eval}
 inc <- unlist(knitr::knit_code$get(c("norm-doc")))
@@ -483,7 +483,7 @@ show(mod$norm)
 ### Formal arguments specification
 
 `function` also gives the possibility to specify the formal arguments
-of the R function that encapsulates the C++ function, by passing
+of the \proglang{R} function that encapsulates the \proglang{C++} function, by passing
 a `Rcpp::List` after the function pointer.
 
 ```{Rcpp mod_formals}
@@ -562,7 +562,7 @@ RCPP_MODULE(mod_formals3) {
 }
 ```
 
-and from the R side:
+and from the \proglang{R} side:
 
 ```{r include=FALSE, eval=params$eval}
 inc <- unlist(knitr::knit_code$get(c("mod_formals3")))
@@ -578,7 +578,7 @@ args(norm)
 ## Exposing \proglang{C++} classes using Rcpp modules
 
 Rcpp modules also provide a mechanism for exposing \proglang{C++} classes, based
-on the reference classes introduced in R 2.12.0.
+on the reference classes introduced in \proglang{R} 2.12.0.
 
 ### Initial example
 
@@ -648,7 +648,7 @@ Then constructors, fields and methods are exposed.
 ### Exposing constructors using Rcpp modules
 
 Public constructors that take from 0 and 6 parameters can be exposed
-to the R level using the `.constuctor` template method of `.class_`.
+to the \proglang{R} level using the `.constructor` template method of `class_`.
 
 Optionally, `.constructor` can take a description as the first argument.
 
@@ -658,7 +658,7 @@ Optionally, `.constructor` can take a description as the first argument.
 ```
 
 Also, the second argument can be a function pointer (called validator)
-matching the following type :
+matching the following type:
 
 ```cpp
 typedef bool (*ValidConstructor)(SEXP*,int);
@@ -668,7 +668,7 @@ The validator can be used to implement dispatch to the appropriate constructor,
 when multiple constructors taking the same number of arguments are exposed.
 The default validator always accepts the constructor as valid if it is passed
 the appropriate number of arguments. For example, with the call above, the default
-validator accepts any call from R with two `double` arguments (or
+validator accepts any call from \proglang{R} with two `double` arguments (or
 arguments that can be cast to `double`).
 
 TODO: include validator example here
@@ -676,7 +676,7 @@ TODO: include validator example here
 ### Exposing fields and properties
 
 `class_` has three ways to expose fields and properties, as
-illustrated in the example below :
+illustrated in the example below:
 
 ```cpp
 using namespace Rcpp;
@@ -708,15 +708,15 @@ RCPP_MODULE(mod_foo) {
 }
 ```
 
-The `.field` method exposes a public field with read/write access from R.
-`field` accepts an extra parameter to give a short description of the
+The `.field` method exposes a public field with read/write access from \proglang{R}.
+It accepts an extra parameter to give a short description of the
 field:
 
 ```cpp
   .field("x", &Foo::x, "documentation for x")
 ```
 
-The `.field_readonly` exposes a public field with read-only access from R.
+The `.field_readonly` exposes a public field with read-only access from \proglang{R}.
 It also accepts the description of the field.
 
 ```cpp
@@ -751,9 +751,9 @@ class and returning a \textbf{T}, for example:
 double z_get(Foo* foo) { return foo->get_z(); }
 ```
 
-Setters can be either a member function taking a `T` and returning void, such
+Setters can be either a member function taking a \textbf{T} and returning `void`, such
 as `set_z` above, or a free function taking a pointer to the target
-class and a \textbf{T} :
+class and a \textbf{T}:
 
 ```cpp
 void z_set(Foo* foo, double z) { foo->set_z(z); }
@@ -824,13 +824,13 @@ functions allowing the programmer to expose a method associated with the class.
 
 A legitimate method to be exposed by `.method` can be:
 
-- A public member function of the class, either const or non const, that
-  returns void or any type that can be handled by `Rcpp::wrap`, and that
+- A public member function of the class, either `const` or non-`const`, that
+  returns `void` or any type that can be handled by `Rcpp::wrap`, and that
   takes between 0 and 65 parameters whose types can be handled by `Rcpp::as`.
 - A free function that takes a pointer to the target class as its first
   parameter, followed by 0 or more (up to 65) parameters that can be handled by
   `Rcpp::as` and returning a type that can be handled by `Rcpp::wrap`
-  or void.
+  or `void`.
 
 ### Documenting methods
 
@@ -848,7 +848,7 @@ TODO: mention overloading, need good example.
 
 ### Const and non-const member functions
 
-`method` is able to expose both `const` and `non const`
+`.method` is able to expose both `const` and non-`const`
 member functions of a class. There are however situations where
 a class defines two versions of the same method, differing only in their
 signature by the `const`-ness. It is for example the case of the
@@ -860,8 +860,8 @@ reference back ( );
 const_reference back ( ) const;
 ```
 
-To resolve the ambiguity, it is possible to use `const_method`
-or `nonconst_method` instead of `method` in order
+To resolve the ambiguity, it is possible to use `.const_method`
+or `.nonconst_method` instead of `.method` in order
 to restrict the candidate methods.
 
 ### Special methods
@@ -938,7 +938,7 @@ RCPP_MODULE(mod) {
 
 The `newBase` method returns a pointer to a `Base` object. Since that
 class is an abstract class, the objects are actually instances of
-`Derived1` or `Derived2`. The same behavior is now available in R:
+`Derived1` or `Derived2`. The same behavior is now available in \proglang{R}:
 
 ```{r include=FALSE, eval=params$eval}
 inc <- unlist(knitr::knit_code$get(c("mod_base")))
@@ -1180,7 +1180,7 @@ Note that this is similar to exposing modules in \proglang{R} packages using
 As an example, consider a file called `yada.cpp` containing the following
 \proglang{C++} code:
 
-```{Rcpp}
+```{Rcpp eval=params$eval}
 #include <Rcpp.h>
 std::string hello() {
     return "hello";
@@ -1234,11 +1234,12 @@ w$set("hohoho")
 w$greet()
 ```
 
+
 # Using modules in other packages {#sec:package}
 
 ## Namespace import
 
-When using \pkg{Rcpp} modules in a packages, the client package needs to
+When using \textsl{Rcpp modules} in a packages, the client package needs to
 import \pkg{Rcpp}'s namespace. This is achieved by adding the
 following line to the `NAMESPACE` file.
 
@@ -1398,7 +1399,7 @@ the `Module()` function as well.
 # Future extensions {#sec:future}
 
 `Boost.Python` has many more features that we would like to port
-to Rcpp modules : class inheritance, default arguments, enum
+to \textsl{Rcpp modules}: class inheritance, default arguments, enum
 types, ...
 
 # Known shortcomings {#sec:misfeatures}
@@ -1408,7 +1409,7 @@ There are some things \textsl{Rcpp modules} is not good at:
 - serialization and deserialization of objects: modules are
   implemented via an external pointer using a memory location, which is
   non-constant and varies between session. Objects have to be re-created,
-  which is different from the (de-)serialization that R offers. So these
+  which is different from the (de-)serialization that \proglang{R} offers. So these
   objects cannot be saved from session to session.
 - multiple inheritance: currently, only simple class structures are
   representable via \textsl{Rcpp modules}.

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -154,7 +154,7 @@ functions such as the `norm` function shown above to \proglang{R}.
 
 We should note that \pkg{Rcpp} now has \textsl{Rcpp attributes} which extends
 certain aspect of \textsl{Rcpp modules} and makes binding to simple functions
-such as this one even easier.  With \textsl{Rcpp attribues} we can just write
+such as this one even easier.  With \textsl{Rcpp attributes} we can just write
 
 ```cpp
 # include <Rcpp.h>
@@ -166,7 +166,7 @@ double norm(double x, double y) {
 ```
 
 See the corresponding vignette \citep{CRAN:Rcpp:Attributes} for details, but
-read on for \textsl{Rcpp modules} which contains to provide features not
+read on for \textsl{Rcpp modules} which provide features not
 covered by \textsl{Rcpp attributes}, particularly when it comes to binding
 entire C++ classes and more.
 
@@ -240,7 +240,7 @@ they usually get wrapped as a slot of an S4 class.
 
 Using `cxxfunction()` from the \pkg{inline} package, we can build this
 example on the fly. Suppose the previous example code assigned to a text variable
-`unifModcode`, we could then do
+`unifModCode`, we could then do
 
 <!--
 DE 21 Sep 2013: there must a bug somewhere in the vignette processing
@@ -303,9 +303,15 @@ Rcpp modules provide a convenient and easy-to-use way
 to expose \proglang{C++} functions and classes to \proglang{R}, grouped
 together in a single entity.
 
-A Rcpp module is created in a `cpp` file using the `RCPP_MODULE`
+A Rcpp module is created in \proglang{C++} source code using the `RCPP_MODULE`
 macro, which then provides declarative code of what the module
 exposes to \proglang{R}.
+
+This section provides an extensive description of how Rcpp modules are defined
+in standalone \proglang{C++} code and loaded into \proglang{R}. Note however
+that defining and using Rcpp modules as part of other \proglang{R} packages
+simplifies the way modules are actually loaded, as detailed in Section
+\ref{sec:package} below.
 
 ## Exposing \proglang{C++} functions using Rcpp modules
 
@@ -353,21 +359,14 @@ mod <- Module("mod", getDynLib(fx))
 Note that this example assumed that the previous code segment defining the
 module was returned by the `cxxfunction()` (from the \pkg{inline}
 package) as callable R function `fx` from which we can extract the
-relevant pointer using `getDynLib()`.  In the case of using Rcpp modules
-via a package (which is detailed in Section \ref{sec:package} below), modules
-are actually loaded differently and we would have used
+relevant pointer using `getDynLib()` (again from \pkg{inline}).
 
-```{r, eval=FALSE}
-require(nameOfMyModulePackage)
-mod <- new( mod )
-mod$norm( 3, 4 )
-```
-
-where the module is loaded upon startup and we use the constructor
-directly. More details on this aspect follow below.
+Throughout the rest of the examples in this document, we always assume that the \proglang{C++}
+code defining a module is used to create an object `fx` via a similar call
+to `cxxfunction`.
 
 A module can contain any number of calls to `function` to register
-many internal functions to \proglang{R}. For example, these 6 functions :
+many internal functions to \proglang{R}. For example, these 6 functions:
 
 ```cpp
 std::string hello() {
@@ -413,32 +412,14 @@ RCPP_MODULE(yada) {
 which can then be used from \proglang{R}:
 
 ```{r, eval=FALSE}
-require(Rcpp)
-
-yd <- Module("yada", getDynLib(fx))
-yd$bar(2L)
-yd$foo(2L, 10.0)
-yd$hello()
-yd$bla()
-yd$bla1(2L)
-yd$bla2(2L, 5.0)
+yada <- Module("yada", getDynLib(fx))
+yada$bar(2L)
+yada$foo(2L, 10.0)
+yada$hello()
+yada$bla()
+yada$bla1(2L)
+yada$bla2(2L, 5.0)
 ```
-
-In the case of a package (as for example the one created by
-`Rcpp.package.skeleton()` with argument `module=TRUE`; more on that
-below), we can use
-
-```{r, eval=FALSE}
-require(myModulePackage)    ## if another name
-
-bar(2L)
-foo(2L, 10.0)
-hello()
-bla()
-bla1(2L)
-bla2(2L, 5.0)
-```
-
 
 The requirements for a function to be exposed to \proglang{R} via Rcpp modules
 are:
@@ -502,6 +483,7 @@ RCPP_MODULE(mod_formals) {
 A simple usage example is provided below:
 
 ```{r, eval=FALSE}
+mod <- Module("mod_formals", getDynLib(fx))
 norm <- mod$norm
 norm()
 norm(y = 2)
@@ -528,6 +510,7 @@ RCPP_MODULE(mod_formals2) {
 This can be used as follows:
 
 ```{r, eval=FALSE}
+mod <- Module("mod_formals2", getDynLib(fx))
 norm <- mod$norm
 args(norm)
 ```
@@ -552,6 +535,7 @@ RCPP_MODULE(mod_formals3) {
 and from the R side:
 
 ```{r, eval=FALSE}
+mod <- Module("mod_formals3", getDynLib(fx))
 norm <- mod$norm
 args(norm)
 ```
@@ -603,9 +587,8 @@ RCPP_MODULE(unif_module) {
 ```
 
 ```{r, eval=FALSE}
-## assumes   fx_unif <- cxxfunction(...)   ran
 unif_module <- Module("unif_module",
-                      getDynLib(fx_unif))
+                      getDynLib(fx))
 Uniform <- unif_module$Uniform
 u <- new(Uniform, 0, 10)
 u$draw(10L)
@@ -783,6 +766,7 @@ RCPP_MODULE(mod_bar) {
 Here is a simple usage example:
 
 ```{r, eval=FALSE}
+mod_bar <- Module("mod_bar", getDynLib(fx))
 Bar <- mod_bar$Bar
 b <- new(Bar, 10)
 b$x + b$x
@@ -915,6 +899,8 @@ class is an abstract class, the objects are actually instances of
 `Derived1` or `Derived2`. The same behavior is now available in R:
 
 ```{r, eval=FALSE}
+mod <- Module("mod", getDynLib(fx))
+Base <- mod$Base
 dv1 <- new(Base, "d1")
 dv1$name() # returns "Derived1"
 dv2 <- new(Base, "d2")
@@ -930,7 +916,7 @@ same class).
 
 This allows implementation of \proglang{R}-level
 (S4) dispatch. For example, one might implement the `show`
-method for \proglang{C++} `World` objects:
+method for \proglang{C++} `World` objects from the module `yada` created above:
 
 ```{r, eval=FALSE}
 setMethod("show", yada$World , function(object) {
@@ -950,11 +936,11 @@ general methods described in the _Rcpp Extending_ vignette, one can
 use the `RCPP_EXPOSED_AS` or `RCPP_EXPOSED_WRAP` macros.
 Alternatively the `RCPP_EXPOSED_CLASS` macro defines both `Rcpp::as`
 and `Rcpp::wrap` specializations. Do not use these macros together
-with the generic extension mechanisms.  Note that opposesd to the
+with the generic extension mechanisms.  Note that opposed to the
 generic methods, these macros can be used _after_ `Rcpp.h` has been
 loaded. Here an example of a pair of Rcpp modules exposed classes
 where one of them has a method taking an instance of the other class
-as argument. In this case it is suffcient to use `RCPP_EXPOSED_AS` to
+as argument. In this case it is sufficient to use `RCPP_EXPOSED_AS` to
 enable the transparent conversion from \proglang{R} to \proglang{C++}:
 
 ```cpp
@@ -988,8 +974,9 @@ RCPP_MODULE(Barl){
 ```
 
 ```{r, eval=FALSE}
-foo <- new(Foo)
-bar <- new(Bar)
+Barl <- Module("Barl", getDynLib(fx))
+foo <- new(Barl$Foo)
+bar <- new(Barl$Bar)
 bar$handleFoo(foo)
 #> Got a Foo!
 ```
@@ -1063,6 +1050,7 @@ RCPP_MODULE(mod_vec) {
 ```{r, eval=FALSE}
 # for code compiled on the fly using
 # cxxfunction() into 'fx_vec', we use
+#????? Why mustStart = TRUE ?????#
 mod_vec <- Module("mod_vec",
                   getDynLib(fx_vec),
                   mustStart = TRUE)
@@ -1220,7 +1208,7 @@ There are some things \textsl{Rcpp modules} is not good at:
   non-constant and varies between session. Objects have to be re-created,
   which is different from the (de-)serialization that R offers. So these
   objects cannot be saved from session to session.
-- mulitple inheritance: currently, only simple class structures are
+- multiple inheritance: currently, only simple class structures are
   representable via \textsl{Rcpp modules}.
 
 # Summary

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -912,18 +912,47 @@ dv2$name() # returns "Derived2"
 When a \proglang{C++} class is exposed by the `class_` template,
 a new S4 class is registered as well. The name of the S4 class is
 obfuscated in order to avoid name clashes (i.e. two modules exposing the
-same class).
+same class). This allows implementation of \proglang{R}-level
+(S4) dispatch.
 
-This allows implementation of \proglang{R}-level
-(S4) dispatch. For example, one might implement the `show`
-method for \proglang{C++} `World` objects from the module `yada` created above:
+For example, consider the \proglang{C++} class `World` exposed in module `yada`:
+
+```cpp
+class World {
+public:
+    World() : msg("hello") {}
+    void set(std::string msg) { this->msg = msg; }
+    std::string greet() { return msg; }
+
+private:
+    std::string msg;
+};
+
+RCPP_MODULE(yada){
+    using namespace Rcpp ;
+
+    class_<World>("World")
+    
+    // expose the default constructor
+    .constructor()
+
+    .method("greet", &World::greet)
+    .method("set", &World::set)
+    ;
+    
+}
+```
+
+The `show` method for `World` objects can then implemented as:
 
 ```{r, eval=FALSE}
+yada <- Module("yada", inline::getDynLib(fx))
 setMethod("show", yada$World , function(object) {
     msg <- paste("World object with message : ",
                  object$greet())
     writeLines(msg)
 } )
+yada$World$new() # implictly calls show
 ```
 
 TODO: mention R inheritance (John ?)

--- a/vignettes/Rcpp-modules.Rmd
+++ b/vignettes/Rcpp-modules.Rmd
@@ -73,6 +73,9 @@ skip_final_break: true
 # Produce a pinp document
 output: pinp::pinp
 
+params:
+    eval: FALSE
+
 header-includes: >
   \newcommand{\proglang}[1]{\textsf{#1}}
   \newcommand{\pkg}[1]{\textbf{#1}}
@@ -88,6 +91,15 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
+
+```{r setup, include=FALSE}
+# disable evaluation globally
+knitr::opts_chunk$set(eval = FALSE)
+if (params$eval) {
+    library(Rcpp)
+    library(inline)
+}
+```
 
 # Motivation
 
@@ -249,7 +261,7 @@ DE 21 Sep 2013: there must a bug somewhere in the vignette processing
              hence shortened example to not show code again
 -->
 
-```{r, eval=FALSE}
+```{r}
 f1 <- cxxfunction( , "", includes = unifModCode,
                   plugin = "Rcpp" )
 getDynLib(f1)  ## will display info about 'f1' 
@@ -258,7 +270,7 @@ getDynLib(f1)  ## will display info about 'f1'
 The following listing shows some \textsl{manual} wrapping to access the code,
 we will see later how this can be automated:
 
-```{r, eval=FALSE}
+```{r}
 setClass("Uniform",
          representation( pointer = "externalptr"))
 
@@ -338,7 +350,7 @@ the need for a wrapper function using either \pkg{Rcpp} or the \proglang{R} API.
 On the \proglang{R} side, the module is retrieved by using the
 `Module` function from \pkg{Rcpp}
 
-```{r, eval=FALSE}
+```{r, eval=params$eval}
 inc <- '
 using namespace Rcpp;
 
@@ -368,7 +380,7 @@ to `cxxfunction`.
 A module can contain any number of calls to `function` to register
 many internal functions to \proglang{R}. For example, these 6 functions:
 
-```cpp
+```{Rcpp yada-fun-def}
 std::string hello() {
     return "hello";
 }
@@ -396,7 +408,7 @@ void bla2( int x, double y) {
 
 can be exposed with the following minimal code:
 
-```cpp
+```{Rcpp yada-fun-module}
 RCPP_MODULE(yada) {
     using namespace Rcpp;
 
@@ -408,10 +420,14 @@ RCPP_MODULE(yada) {
     function("bla2"  , &bla2 );
 }
 ```
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("yada-fun-def", "yada-fun-module")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
 
 which can then be used from \proglang{R}:
 
-```{r, eval=FALSE}
+```{r eval=params$eval, output=params$output}
 yada <- Module("yada", getDynLib(fx))
 yada$bar(2L)
 yada$foo(2L, 10.0)
@@ -438,7 +454,7 @@ are:
 In addition to the name of the function and the function pointer, it is possible
 to pass a short description of the function as the third parameter of `function`.
 
-```cpp
+```{Rcpp norm-doc}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -453,7 +469,11 @@ RCPP_MODULE(mod) {
 
 The description is used when displaying the function to the R prompt:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("norm-doc")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod <- Module("mod", getDynLib(fx))
 show(mod$norm)
 ```
@@ -464,7 +484,7 @@ show(mod$norm)
 of the R function that encapsulates the C++ function, by passing
 a `Rcpp::List` after the function pointer.
 
-```cpp
+```{Rcpp mod_formals}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -482,7 +502,11 @@ RCPP_MODULE(mod_formals) {
 
 A simple usage example is provided below:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_formals")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod <- Module("mod_formals", getDynLib(fx))
 norm <- mod$norm
 norm()
@@ -493,7 +517,7 @@ args(norm)
 
 To set formal arguments without default values, simply omit the rhs.
 
-```cpp
+```{Rcpp mod_formals2}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -509,7 +533,11 @@ RCPP_MODULE(mod_formals2) {
 
 This can be used as follows:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_formals2")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod <- Module("mod_formals2", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -518,7 +546,7 @@ args(norm)
 The ellipsis (`...`) can be used to denote that additional arguments
 are optional; it does not take a default value.
 
-```cpp
+```{Rcpp mod_formals3}
 using namespace Rcpp;
 
 double norm(double x, double y) {
@@ -534,7 +562,11 @@ RCPP_MODULE(mod_formals3) {
 
 and from the R side:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_formals3")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod <- Module("mod_formals3", getDynLib(fx))
 norm <- mod$norm
 args(norm)
@@ -551,7 +583,7 @@ on the reference classes introduced in R 2.12.0.
 A class is exposed using the `class_` keyword. The `Uniform`
 class may be exposed to \proglang{R} as follows:
 
-```cpp
+```{Rcpp mod_uniform}
 using namespace Rcpp;
 class Uniform {
 public:
@@ -586,7 +618,11 @@ RCPP_MODULE(unif_module) {
 }
 ```
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_uniform")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 unif_module <- Module("unif_module",
                       getDynLib(fx))
 Uniform <- unif_module$Uniform
@@ -725,7 +761,7 @@ Using properties gives more flexibility in case field access has to be tracked
 or has impact on other fields. For example, this class keeps track of how many times
 the `x` field is read and written.
 
-```cpp
+```{Rcpp mod_bar}
 class Bar {
 public:
 
@@ -765,7 +801,11 @@ RCPP_MODULE(mod_bar) {
 
 Here is a simple usage example:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_bar")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod_bar <- Module("mod_bar", getDynLib(fx))
 Bar <- mod_bar$Bar
 b <- new(Bar, 10)
@@ -848,7 +888,7 @@ static member function or a free function that returns a pointer to
 the target class. Typical use-cases include creating objects in a
 hierarchy:
 
-```cpp
+```{Rcpp mod_base}
 #include <Rcpp.h>
 using namespace Rcpp;
 
@@ -898,7 +938,11 @@ The `newBase` method returns a pointer to a `Base` object. Since that
 class is an abstract class, the objects are actually instances of
 `Derived1` or `Derived2`. The same behavior is now available in R:
 
-```{r, eval=FALSE}
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_base")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
 mod <- Module("mod", getDynLib(fx))
 Base <- mod$Base
 dv1 <- new(Base, "d1")
@@ -917,7 +961,7 @@ same class). This allows implementation of \proglang{R}-level
 
 For example, consider the \proglang{C++} class `World` exposed in module `yada`:
 
-```cpp
+```{Rcpp yada-world}
 class World {
 public:
     World() : msg("hello") {}
@@ -943,10 +987,14 @@ RCPP_MODULE(yada){
 }
 ```
 
-The `show` method for `World` objects can then implemented as:
+The `show` method for `World` objects is then implemented as:
 
-```{r, eval=FALSE}
-yada <- Module("yada", inline::getDynLib(fx))
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("yada-world")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
+yada <- Module("yada", getDynLib(fx))
 setMethod("show", yada$World , function(object) {
     msg <- paste("World object with message : ",
                  object$greet())
@@ -972,7 +1020,7 @@ where one of them has a method taking an instance of the other class
 as argument. In this case it is sufficient to use `RCPP_EXPOSED_AS` to
 enable the transparent conversion from \proglang{R} to \proglang{C++}:
 
-```cpp
+```{Rcpp exposed_as}
 #include <Rcpp.h>
 
 class Foo {
@@ -1001,11 +1049,15 @@ RCPP_MODULE(Barl){
     .method("handleFoo", &Bar::handleFoo);
 }
 ```
-
-```{r, eval=FALSE}
-Barl <- Module("Barl", getDynLib(fx))
-foo <- new(Barl$Foo)
-bar <- new(Barl$Bar)
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("exposed_as")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval}
+Foo <- Module("Foo", getDynLib(fx))$Foo
+Bar <- Module("Barl", getDynLib(fx))$Bar
+foo <- new(Foo)
+bar <- new(Bar)
 bar$handleFoo(foo)
 #> Got a Foo!
 ```
@@ -1017,7 +1069,7 @@ bar$handleFoo(foo)
 The following example illustrates how to use Rcpp modules to expose
 the class `std::vector<double>` from the STL.
 
-```cpp
+```{Rcpp mod_vec} 
 typedef std::vector<double> vec; 	
 void vec_assign(vec* obj, 
                 Rcpp::NumericVector data) {
@@ -1034,6 +1086,14 @@ Rcpp::NumericVector vec_asR( vec* obj ) {
 void vec_set(vec* obj, int i, double value) { 
    obj->at( i ) = value; 
 }
+// CHECK-PR: workaround complilation error with vecL:resize (C++11)
+void vec_resize (vec* obj, int n) {
+    obj->resize(n);
+}
+// CHECK-PR: workaround complilation error with vec::push_back (C++11)
+void vec_push_back (vec* obj, double value) {
+    obj->push_back(value);
+}
 
 RCPP_MODULE(mod_vec) {
     using namespace Rcpp;
@@ -1049,11 +1109,11 @@ RCPP_MODULE(mod_vec) {
     // exposing member functions
     .method("size", &vec::size)
     .method("max_size", &vec::max_size)
-    .method("resize", &vec::resize)
+    // .method("resize", &vec::resize) // CHECK-PR
     .method("capacity", &vec::capacity)
     .method("empty", &vec::empty)
     .method("reserve", &vec::reserve)
-    .method("push_back", &vec::push_back)
+    // .method("push_back", &vec::push_back) // CHECK-PR
     .method("pop_back", &vec::pop_back)
     .method("clear", &vec::clear)
 
@@ -1067,6 +1127,8 @@ RCPP_MODULE(mod_vec) {
     // argument
     .method("assign", &vec_assign)
     .method("insert", &vec_insert)
+    .method("resize", &vec_resize) // CHECK-PR
+    .method("push_back", &vec_push_back) // CHECK-PR
     .method("as.vector", &vec_asR)
 
     // special methods for indexing
@@ -1075,23 +1137,22 @@ RCPP_MODULE(mod_vec) {
     ;
 }
 ```
-
-```{r, eval=FALSE}
-# for code compiled on the fly using
-# cxxfunction() into 'fx_vec', we use
-#????? Why mustStart = TRUE ?????#
+```{r include=FALSE, eval=params$eval}
+inc <- unlist(knitr::knit_code$get(c("mod_vec")))
+fx <- cxxfunction(signature(), plugin = "Rcpp", include = inc)
+```
+```{r, eval=params$eval, collapse=TRUE}
+# CHECK-PR: do we need mustStart = TRUE ?
 mod_vec <- Module("mod_vec",
-                  getDynLib(fx_vec),
+                  getDynLib(fx),
                   mustStart = TRUE)
 vec <- mod_vec$vec
-# and that is not needed in a package
-# setup as e.g. one created
-# via Rcpp.package.skeleton(..., module=TRUE)
 v <- new(vec)
 v$reserve(50L)
 v$assign(1:10)
 v$push_back(10)
 v$size()
+v$resize(30L)
 v$capacity()
 v[[ 0L ]]
 v$as.vector()


### PR DESCRIPTION
Review of the Rcpp-modules vignette, with major focus on the usage in packages, as a follow-up of https://github.com/RcppCore/Rcpp/issues/976#issuecomment-512537482

A (not so short) summary of the changes:

- Replaced sparse references to packages across a few existing examples in the _Rpp Modules_ section with a pointer to the specific section at beginning.

- Introduced a new sub-section about usaging `sourceCpp()` as an alternative to `cxxfuntion()` + `getDynLib()`.

- Package section reviewed with focus on recommended loading via `loadModule()`
    - A more practical example has been included
    - The section about the deprecated loading was left as-is
    - Namespace exports are also covered.

- Improvements and harmomization of existing examples in section _Rcpp Modules_
    - General review to make it easier for a user to follow the examples.
    - All examples now assume `fx` (clearly stated) and explicitly call `Module()`, to make them close to self-contained.
    - Include `World` class module in S4 dispatch example for completeness.
    - Make sure all examples (with R code) are runnable, and optionally enable running them
        - Non-included chunks creating the assumed relevant `fx` object based on the C++ code in previous named chunk(s).
        - The document has gained parameters `eval` and `results` in the YAML header to control evaluating the examples on demand (e.g. _Knit with parameters..._).
        - This is pretty non-intrusive and can be easily removed.
    - Running the examples revealed compilation errors with the final `std::vector` example, which I fixed with a **workaround to be discussed**.

- Fixed a few tyops + batch cosmetic alignment:
    - `\proglang` all the way.
    - `\textsl{Rcpp modules}` everywhere but in their own section.
    - Aligned and fixed usage of C++ elements in inline text.

I left a few explicit comments marked as `CHECK-PR` to have some pointers for the PR discussion.