### PR TITLE
fix #968 with a single argument XPtr constructor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-10-19  Stephen Wade  <stephematician@gmail.com>
+
+	* inst/include/Rcpp/XPtr.h: XPtr constructor split up, a single
+	argument does not modify tags and protected data of the external pointer
+	* inst/unitTests/cpp/Xptr.cpp: Added test
+	* inst/unitTests/runit.XPtr.R: Idem
+
 2019-10-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Added CRAN + BioConductor badges for reverse depends,

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -63,13 +63,22 @@ public:
      *
      * @param xp external pointer to wrap
      */
-    explicit XPtr(SEXP x, SEXP tag = R_NilValue, SEXP prot = R_NilValue) {
+    explicit XPtr(SEXP x) {
         if (TYPEOF(x) != EXTPTRSXP) {
             const char* fmt = "Expecting an external pointer: [type=%s].";
             throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
         }
-
         Storage::set__(x);
+    };
+
+    /**
+     * constructs a XPtr wrapping the external pointer (EXTPTRSXP SEXP)
+     *
+     * @param xp external pointer to wrap
+     * @param tag tag to assign to external pointer 
+     * @param prot protected data to assign to external pointer
+     */
+    explicit XPtr(SEXP x, SEXP tag, SEXP prot) : XPtr(x) {
         R_SetExternalPtrTag( x, tag);
         R_SetExternalPtrProtected(x, prot);
     };

--- a/inst/unitTests/cpp/XPtr.cpp
+++ b/inst/unitTests/cpp/XPtr.cpp
@@ -47,6 +47,17 @@ int xptr_2( XPtr< std::vector<int> > p){
 }
 
 // [[Rcpp::export]]
+void xptr_self_tag( XPtr< std::vector<int> > p ){
+    XPtr< std::vector<int> > self_tag(wrap(p), wrap(p), R_NilValue) ;
+}
+
+// [[Rcpp::export]]
+bool xptr_has_self_tag( XPtr< std::vector<int> > p ){
+    return wrap(p) == R_ExternalPtrTag(p);
+}
+
+
+// [[Rcpp::export]]
 bool xptr_release( XPtr< std::vector<int> > p) {
     p.release();
     return !p;

--- a/inst/unitTests/runit.XPTr.R
+++ b/inst/unitTests/runit.XPTr.R
@@ -31,6 +31,9 @@ if (.runThisTest) {
         front <- xptr_2(xp)
         checkEquals( front, 1L, msg = "check usage of external pointer" )
 
+        xptr_self_tag(xp)
+        checkEquals(xptr_has_self_tag(xp), T, msg = "check external pointer tag preserved")
+
         checkTrue(xptr_release(xp), msg = "check release of external pointer")
 
         checkTrue(xptr_access_released(xp), msg = "check access of released external pointer")


### PR DESCRIPTION
Cleaned up pull request 1002

as<> will no longer modify tags/protected data of an existing external pointer. Modifying the tags/protected data of an external pointer via the XPtr(SEXP,SEXP,SEXP) constructor is made more explicit by removing the two default arguments, and XPtr(SEXP) is implemented separately (as explicit) and does not modify the external pointer's tags/protected data.

Added a self-tag test which passed here. I was unable to test if downstream packages are affected by this change.