### PR TITLE
protect call inside Rcpp::Environment<>::namespace_env()

### DIFF
--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -101,9 +101,8 @@ namespace Rcpp{
             if( ::Rf_inherits( x, "data.frame" )){
                 Parent::set__( x ) ;
             } else{
-                SEXP y = PROTECT(internal::convert_using_rfunction( x, "as.data.frame" )) ;
+                Shield<SEXP> y(internal::convert_using_rfunction( x, "as.data.frame" )) ;
                 Parent::set__( y ) ;
-                UNPROTECT(1);
             }
         }
 

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -101,8 +101,9 @@ namespace Rcpp{
             if( ::Rf_inherits( x, "data.frame" )){
                 Parent::set__( x ) ;
             } else{
-                SEXP y = internal::convert_using_rfunction( x, "as.data.frame" ) ;
+                SEXP y = PROTECT(internal::convert_using_rfunction( x, "as.data.frame" )) ;
                 Parent::set__( y ) ;
+                UNPROTECT(1);
             }
         }
 
@@ -130,7 +131,7 @@ namespace Rcpp{
             obj.erase(strings_as_factors_index) ;
             names.erase(strings_as_factors_index) ;
             obj.attr( "names") = names ;
-            Shield<SEXP> call( Rf_lang3(as_df_symb, obj, wrap( strings_as_factors ) ) ) ;
+            Shield<SEXP> call( Rf_lang3(as_df_symb, obj, Rf_ScalarLogical(strings_as_factors) ) ) ;
             SET_TAG( CDDR(call),  strings_as_factors_symb ) ;
             Shield<SEXP> res(Rcpp_fast_eval(call, R_GlobalEnv));
             DataFrame_Impl out( res ) ;

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -374,7 +374,8 @@ namespace Rcpp{
             try{
                 SEXP getNamespaceSym = Rf_install("getNamespace");
                 Shield<SEXP> package_str( Rf_mkString(package.c_str()) );
-                env = Rcpp_fast_eval(Rf_lang2(getNamespaceSym, package_str), R_GlobalEnv);
+                Shield<SEXP> call( Rf_lang2(getNamespaceSym, package_str) );
+                env = Rcpp_fast_eval(call, R_GlobalEnv);
             } catch( ... ){
                 throw no_such_namespace( package  ) ;
             }

--- a/inst/include/Rcpp/r_cast.h
+++ b/inst/include/Rcpp/r_cast.h
@@ -31,7 +31,8 @@ namespace Rcpp {
             Armor<SEXP> res;
             try{
                 SEXP funSym = Rf_install(fun);
-                res = Rcpp_fast_eval(Rf_lang2(funSym, x), R_GlobalEnv);
+                Shield<SEXP> call(Rf_lang2(funSym, x));
+                res = Rcpp_fast_eval(call, R_GlobalEnv);
             } catch( eval_error& e) {
                 const char* fmt = "Could not convert using R function: %s.";
                 throw not_compatible(fmt, fun);


### PR DESCRIPTION
The result of `Rf_lang2()` is not protected so might be deleted by a garbage collection further down the line. 