### PR TITLE
Update Attributes.R (closes #1017)

### DIFF
--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -244,7 +244,7 @@ cppFunction <- function(code,
 
     # process depends
     if (!is.null(depends) && length(depends) > 0) {             # #nocov start
-        depends <- paste(depends, sep=", ")
+        depends <- paste(depends, collapse=", ")
         scaffolding <- paste("// [[Rcpp::depends(", depends, ")]]", sep="")
         scaffolding <- c(scaffolding, "", .linkingToIncludes(depends, FALSE),
                          recursive=TRUE)                        # #nocov end


### PR DESCRIPTION
When passing multiple "depends" arguments to "cppFunction" e.g.
```
cppFunction(code, depends = c("package1", "package2"))
```
this was producing code with scaffolding:
```
// [[Rcpp:depends(package1)]]
// [[Rcpp:depends(package2)]]
#include <package1.h>
#include <Rcpp.h>
```
rather than
```
// [[Rcpp:depends(package1, package2)]]
#include <package1.h>
#include <package2.h>
#include <Rcpp.h>
```
