### PR TITLE
new test for version number consistency (fixes #1021)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-11-11  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/unitTests/runit.packageversion.R: New test
+	* inst/unitTests/cpp/rcppversion.cpp: Cpp portion of test 
+
 2019-11-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/: Add files CONTRIBUTING.md, FUNDING.yml, ISSUE_TEMPLATE.md
@@ -12,7 +17,7 @@
 
 2019-11-09  TJ McKinley  <t.mckinley@exeter.ac.uk>
 
-	* R/Attributes.R: Correct how cppFunction() deal with multiple
+	* R/Attributes.R: Correct how cppFunction() deals with multiple
 	depends arguments
 	
 2019-11-08  Romain Francois  <romain@rstudio.com>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -21,6 +21,11 @@
       \item The \code{.github/} directory now has more explicit guidance on
       contributinh, issues, and pull requests (Dirk).
     }
+    \item Changes in Rcpp Deployment:
+    \itemize{
+      \item Added unit test to check if C++ version remains remains aligned
+      with the package number (Dirk in \ghpr{1022} fixing \ghit{1021}).
+    }
   }
 }
 

--- a/inst/unitTests/cpp/rcppversion.cpp
+++ b/inst/unitTests/cpp/rcppversion.cpp
@@ -1,0 +1,21 @@
+#include <Rcpp.h>
+
+// [[Rcpp::export]]
+Rcpp::List checkVersion(Rcpp::IntegerVector v) {
+
+    // incoming, we expect v to have been made by
+    //     as.integer(unlist(strsplit(as.character(packageVersion("Rcpp")), "\\.")))
+    // yielding eg
+    //     c(1L, 0L, 3L, 1L)
+
+    // ensure that length is four, after possibly appending 0
+    if (v.size() == 3) v.push_back(0);
+    if (v.size() != 4) Rcpp::stop("Expect vector with four elements.");
+
+    return Rcpp::List::create(Rcpp::Named("def_ver")     = RCPP_VERSION,
+                              Rcpp::Named("def_str")     = RCPP_VERSION_STRING,
+                              Rcpp::Named("cur_ver")     = Rcpp_Version(v[0], v[1], v[2]),
+                              Rcpp::Named("def_dev_ver") = RCPP_DEV_VERSION,
+                              Rcpp::Named("def_dev_str") = RCPP_DEV_VERSION_STRING,
+                              Rcpp::Named("cur_dev_ver") = RcppDevVersion(v[0], v[1], v[2], v[3]));
+}

--- a/inst/unitTests/runit.packageversion.R
+++ b/inst/unitTests/runit.packageversion.R
@@ -1,0 +1,59 @@
+#!/usr/bin/env r
+#
+# Copyright (C) 2019       	 Dirk Eddelbuettel
+#
+# This file is part of Rcpp.
+#
+# Rcpp is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Rcpp is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+.runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
+
+if (.runThisTest) {
+
+    .setUp <- Rcpp:::unitTestSetup("rcppversion.cpp")
+
+    test.PackageVersion <- function() {
+
+        ## we take packageVersion, make it a character variable, split
+        ## it by dots and turn it to ints
+        ##
+        ## note that v could now be a three or four element vector
+        ## depending on what the package version is
+        pv <- packageVersion("Rcpp")
+        pvstr <- as.character(pv)
+        v <- as.integer(unlist(strsplit(pvstr, "\\.")))
+
+        ## construct a release string from the first three elements, ie "1.0.3" from 1.0.3.1
+        relstr <- as.character(as.package_version(paste(v[1:3], collapse=".")))
+
+        ## call C++ function returning list of six values, three each for 'release' and 'dev' version
+        res <- checkVersion(v)
+
+        ## basic check: is the #defined version equal to the computed version (issue #1014)
+        checkEquals(res$cur_ver, res$def_ver, msg="current computed version equal defined version")
+
+        ## basic check: is #defined string version equal to computed string version (adjusting for rel)
+        checkEquals(relstr, res$def_str, msg="current computed version equal defined dev string")
+
+        ## additional checks if we are a dev version
+        if (length(v) == 4) {
+            checkEquals(res$cur_dev_ver, res$def_dev_ver,
+                        msg="current computed dev version greater equal defined dev version")
+
+            ## basic check: is #defined string version equal to computed string
+            checkEquals(pvstr, res$def_dev_str,
+                        msg="current computed version equal defined dev string")
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #1021, the entries in `config.h` can become disconnected from `packageVersio()`. This PR ties them back together via a simple set of unit tests.

