### PR TITLE
Small update to XPtr removing C++11 syntax following PR #1012

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-11-13  Stephen Wade  <stephematician@gmail.com>
+
+	* inst/include/Rcpp/XPtr.h: Delete delegating constructor (follow-up #1012)
+	* inst/unitTests/runit.XPTr.R (test.XPtr): Reinsert self-tag test on Windows
+
 2019-11-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/unitTests/runit.packageversion.R: New test

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -58,20 +58,12 @@ public:
 
     typedef StoragePolicy<XPtr> Storage;
 
-#if defined(RCPP_USING_CXX11)
-
     /**
      * constructs a XPtr wrapping the external pointer (EXTPTRSXP SEXP)
      *
      * @param xp external pointer to wrap
      */
-    explicit XPtr(SEXP x) {
-        if (TYPEOF(x) != EXTPTRSXP) {
-            const char* fmt = "Expecting an external pointer: [type=%s].";
-            throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
-        }
-        Storage::set__(x);
-    };
+    explicit XPtr(SEXP x) { checked_set(x); };
 
     /**
      * constructs a XPtr wrapping the external pointer (EXTPTRSXP SEXP)
@@ -80,30 +72,11 @@ public:
      * @param tag tag to assign to external pointer
      * @param prot protected data to assign to external pointer
      */
-    explicit XPtr(SEXP x, SEXP tag, SEXP prot) : XPtr(x) {
-        R_SetExternalPtrTag( x, tag);
+    explicit XPtr(SEXP x, SEXP tag, SEXP prot) {
+        checked_set(x);
+        R_SetExternalPtrTag(x, tag);
         R_SetExternalPtrProtected(x, prot);
     };
-
-#else
-
-    /**
-     * constructs a XPtr wrapping the external pointer (EXTPTRSXP SEXP)
-     *
-     * @param xp external pointer to wrap
-     */
-    explicit XPtr(SEXP x, SEXP tag = R_NilValue, SEXP prot = R_NilValue) {
-        if (TYPEOF(x) != EXTPTRSXP) {
-            const char* fmt = "Expecting an external pointer: [type=%s].";
-            throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
-        }
-
-        Storage::set__(x);
-        R_SetExternalPtrTag( x, tag);
-        R_SetExternalPtrProtected(x, prot);
-    };
-
-#endif
 
     /**
      * creates a new external pointer wrapping the dumb pointer p.
@@ -213,6 +186,16 @@ public:
     }
 
     void update(SEXP) {}
+
+private:
+    inline void checked_set(SEXP x) {
+        if (TYPEOF(x) != EXTPTRSXP) {
+            const char* fmt = "Expecting an external pointer: [type=%s].";
+            throw ::Rcpp::not_compatible(fmt, Rf_type2char(TYPEOF(x)));
+        }
+        Storage::set__(x);
+    }
+
 };
 
 } // namespace Rcpp

--- a/inst/unitTests/runit.XPTr.R
+++ b/inst/unitTests/runit.XPTr.R
@@ -20,8 +20,6 @@
 
 .runThisTest <- Sys.getenv("RunAllRcppTests") == "yes"
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-
 if (.runThisTest) {
 
     .setUp <- Rcpp:::unitTestSetup("XPtr.cpp")
@@ -33,10 +31,8 @@ if (.runThisTest) {
         front <- xptr_2(xp)
         checkEquals( front, 1L, msg = "check usage of external pointer" )
 
-        if (!isWindows) {
-            xptr_self_tag(xp)
-            checkEquals(xptr_has_self_tag(xp), T, msg = "check external pointer tag preserved")
-        }
+        xptr_self_tag(xp)
+        checkEquals(xptr_has_self_tag(xp), T, msg = "check external pointer tag preserved")
 
         checkTrue(xptr_release(xp), msg = "check release of external pointer")
 


### PR DESCRIPTION
Removes the delegating constructor call in the XPtr constructor, thus the constructors no longer rely on C++11 syntax and still maintain the behaviour in PR #1003. The calls to Storage::__set are moved into the new checked_set (private) member of XPtr, and checked_set is called by both constructors.

I've tested this with newer Rtools (3.3 and 3.4 via rhub) and some linux builds (gcc 5), but not older Rtools - so can't 100% confirm it will build on older gcc.