### PR TITLE
test for and report unavailable package in linkingto (closes #1026)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-11-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R: Test for and report unavailable 'LinkingTo' package
+
 2019-11-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -962,6 +962,11 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
         # otherwise check for standard Rcpp::interfaces generated include
         else if (!pluginsOnly) {
             pkgPath <- find.package(package, NULL, quiet=TRUE)
+            if (length(pkgPath) == 0) {
+                stop(paste("Package '", package, "' referenced from ",
+                           "LinkingTo directive is not available.", sep=""),
+                     call. = FALSE)
+            }
             pkgHeader <- paste(package, ".h", sep="")
             pkgHeaderPath <- file.path(pkgPath, "include",  pkgHeader)
             if (file.exists(pkgHeaderPath)) {


### PR DESCRIPTION
This addresses #1026 and checks against an empty path for `LinkingTo` if a non-exsting package is referenced from `cppFunction(..., depends=...)`.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
