### PR TITLE
Feature/simpler description

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-12-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Suggests): Remove knitr, rmarkdown, pinp
+	* DESCRIPTION (VignetteBuilder): Remove knitr
+
 2019-11-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_embedded_r.R: Use sink to suppress noisy output,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2019-12-01  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 	* DESCRIPTION (Suggests): Remove knitr, rmarkdown, pinp
 	* DESCRIPTION (VignetteBuilder): Remove knitr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.3.2
-Date: 2019-11-19
+Version: 1.0.3.3
+Date: 2019-12-01
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,7 @@ Description: The 'Rcpp' package provides R functions as well as C++ classes whic
  <doi:10.1080/00031305.2017.1375990>); see 'citation("Rcpp")' for details.
 Depends: R (>= 3.0.0)
 Imports: methods, utils
-Suggests: tinytest, inline, rbenchmark, knitr, rmarkdown, pinp, pkgKitten (>= 0.1.2)
-VignetteBuilder: knitr
+Suggests: tinytest, inline, rbenchmark, pkgKitten (>= 0.1.2)
 URL: http://www.rcpp.org, http://dirk.eddelbuettel.com/code/rcpp.html, https://github.com/RcppCore/Rcpp
 License: GPL (>= 2)
 BugReports: https://github.com/RcppCore/Rcpp/issues

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.3"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,3,2)
-#define RCPP_DEV_VERSION_STRING "1.0.3.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,3,3)
+#define RCPP_DEV_VERSION_STRING "1.0.3.3"
 
 #endif


### PR DESCRIPTION
Now that the vignettes are pre-made and included as pdf files wrapped by tiny Rnw wrappers, we no longer need knitr, rmarkdown and pinp in the Suggests.  (They are still used 'off-site' to produce the pdf files included in the tarball.)  This makes the dependency graph a little simpler.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
