### PR TITLE
Feature/win debug dll (closes #1035)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2019-12-14  Dirk Eddelbuettel  <edd@debian.org>
 
+	* R/Attributes.R (sourceCpp): Support new argument windowsDebugDLL to
+	create a debug DLL, supported on Windows only
+	* man/sourceCpp.Rd: Document it
+
 	* src/date.cpp: A few more #nocov tage
 
 2019-12-13  Dirk Eddelbuettel  <edd@debian.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-12-15  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 2019-12-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/Attributes.R (sourceCpp): Support new argument windowsDebugDLL to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-12-17  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R (sourceCpp): Very minor cosmetic changes
+
 2019-12-15  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.3.4
-Date: 2019-12-07
+Version: 1.0.3.5
+Date: 2019-12-14
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -67,7 +67,7 @@ sourceCpp <- function(file = "",
     } else {
         if (windowsDebugDLL) {
             if (verbose) {
-                message("The 'windowsDebugDLL' toggle is ignored on "
+                message("The 'windowsDebugDLL' toggle is ignored on ",
                         "non-Windows platforms.")
             }
             windowsDebugDLL <- FALSE    # now we do not need to deal with OS choice below

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -65,8 +65,11 @@ sourceCpp <- function(file = "",
                  "is not permitted.")
         }
     } else {
-        if (verbose && windowsDebugDLL) {
-            message("The 'windowsDebugDLL' toggle is ignored on non-Windows platforms.")
+        if (windowsDebugDLL) {
+            if (verbose) {
+                message("The 'windowsDebugDLL' toggle is ignored on "
+                        "non-Windows platforms.")
+            }
             windowsDebugDLL <- FALSE    # now we do not need to deal with OS choice below
         }							# #nocov end
     }

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -63,12 +63,12 @@ sourceCpp <- function(file = "",
         if (grepl(' ', basename(file), fixed=TRUE)) {
             stop("The filename '", basename(file), "' contains spaces. This ",
                  "is not permitted.")
-        }                                                       # #nocov end
+        }
     } else {
         if (verbose && windowsDebugDLL) {
             message("The 'windowsDebugDLL' toggle is ignored on non-Windows platforms.")
-            windowsDebugDLL <- FALSE    # no we do not need to for OS below
-        }
+            windowsDebugDLL <- FALSE    # now we do not need to deal with OS choice below
+        }							# #nocov end
     }
 
     # get the context (does code generation as necessary)

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2012 - 2018  JJ Allaire, Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2012 - 2019  JJ Allaire, Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -27,7 +27,8 @@ sourceCpp <- function(file = "",
                       cleanupCacheDir = FALSE,
                       showOutput = verbose,
                       verbose = getOption("verbose"),
-                      dryRun = FALSE) {
+                      dryRun = FALSE,
+                      windowsDebugDLL = FALSE) {
 
     # use an architecture/version specific subdirectory of the cacheDir
     # (since cached dynlibs can now perist across sessions we need to be
@@ -63,6 +64,11 @@ sourceCpp <- function(file = "",
             stop("The filename '", basename(file), "' contains spaces. This ",
                  "is not permitted.")
         }                                                       # #nocov end
+    } else {
+        if (verbose && windowsDebugDLL) {
+            message("The 'windowsDebugDLL' toggle is ignored on non-Windows platforms.")
+            windowsDebugDLL <- FALSE    # no we do not need to for OS below
+        }
     }
 
     # get the context (does code generation as necessary)
@@ -121,6 +127,7 @@ sourceCpp <- function(file = "",
         # prepare the command (output if we are in showOutput mode)
         cmd <- paste(R.home(component="bin"), .Platform$file.sep, "R ",
                      "CMD SHLIB ",
+                     ifelse(windowsDebugDLL, "-d ", ""),
                      "-o ", shQuote(context$dynlibFilename), " ",
                      ifelse(rebuild, "--preclean ", ""),
                      ifelse(dryRun, "--dry-run ", ""),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,8 @@
     \itemize{
       \item Safer \code{Rcpp_list*}, \code{Rcpp_lang*} and
       \code{Function.operator()} (Romain in \ghpr{1014}, \ghit{1015}).
+      \item A number of \code{#nocov} markers were added (Dirk in
+      \ghprP1036}). 
     }
     \item Changes in Rcpp Attributes:
     \itemize{
@@ -17,6 +19,10 @@
       \ghit{1017}).
       \item Invisible return object are now supported via new option (Kun Ren
       in \ghpr{1025} fixing \ghit{1024}).
+      \item Unavailable packages referred to in \code{LinkingTo} are now
+      reported (Dirk in \ghpr{1027} fixing \ghit{1026}).
+      \item The \code{sourceCpp} function can now create a debug DLL on
+      Windows (Dirk in \ghpr{1037} fixing \ghit{ghit}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{
@@ -24,11 +30,16 @@
       contributinh, issues, and pull requests (Dirk).
       \item The Rcpp Attributes vignette describe the new invisible return
       objection option (Kun Ren in \ghpr{1025}).
+      \item Vignettes are now included as pre-made pdf files (Dirk in \ghpr{1029})
+      \item The Rcpp FAQ has new entry on the recommended
+      \code{importFrom} directive (Dirk in \ghpr{1031} fixing \ghit{1030}).
     }
     \item Changes in Rcpp Deployment:
     \itemize{
       \item Added unit test to check if C++ version remains remains aligned
       with the package number (Dirk in \ghpr{1022} fixing \ghit{1021}).
+      \item The unit test system was switched to tinytest (Dirk in
+      \ghpr{1028}, \ghpr{1032}, \ghpr{1033}).
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.3"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,3,4)
-#define RCPP_DEV_VERSION_STRING "1.0.3.4"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,3,5)
+#define RCPP_DEV_VERSION_STRING "1.0.3.5"
 
 #endif

--- a/man/sourceCpp.Rd
+++ b/man/sourceCpp.Rd
@@ -10,7 +10,8 @@ and RCPP_MODULE declarations. A shared library is then built and its exported fu
 \usage{
 sourceCpp(file = "", code = NULL, env = globalenv(), embeddedR = TRUE, rebuild = FALSE, 
           cacheDir = getOption("rcpp.cache.dir", tempdir()), cleanupCacheDir = FALSE,
-          showOutput = verbose, verbose = getOption("verbose"), dryRun = FALSE)
+          showOutput = verbose, verbose = getOption("verbose"), dryRun = FALSE,
+          windowsDebugDLL = FALSE)
 }
 \arguments{
   \item{file}{
@@ -43,6 +44,9 @@ sourceCpp(file = "", code = NULL, env = globalenv(), embeddedR = TRUE, rebuild =
   \item{dryRun}{
     \code{TRUE} to do a dry run (showing commands that would be used rather than
 actually executing the commands).
+}
+  \item{windowsDebugDLL}{
+    \code{TRUE} to create a debug DLL on Windows (and ignored on other platforms).
 }
 }
 \details{


### PR DESCRIPTION
See the discussion and resolution in #1035 -- this addresses a narrow need for debugging when using windows and `sourceCpp()`.   

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
- [x] User confirmed issue as addressed