### PR TITLE
Clear external pointer before calling finalizer

### DIFF
--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -37,7 +37,8 @@ void finalizer_wrapper(SEXP p) {
         T* ptr = (T*) R_ExternalPtrAddr(p);
         RCPP_DEBUG_3("finalizer_wrapper<%s>(SEXP p = <%p>). ptr = %p", DEMANGLE(T), p, ptr)
 
-        // Clear before finalizing to avoid interesting behavior,
+        // Clear before finalizing to avoid interesting behavior
+        // like access of freed memory,
         // e.g. https://github.com/r-dbi/RPostgres/issues/167
         R_ClearExternalPtr(p);
 
@@ -181,6 +182,7 @@ public:
             // default C++ finalizer is since delete NULL is a no-op).
             // This clears the external pointer just before calling the finalizer,
             // to avoid interesting behavior with co-dependent finalizers,
+            // like access of freed memory,
             // e.g. https://github.com/r-dbi/RPostgres/issues/167.
             finalizer_wrapper<T,Finalizer>(Storage::get__());
         }


### PR DESCRIPTION
Closes https://github.com/r-dbi/RPostgres/issues/167.

Apologies for the terse pull request, I've been chasing the reason for the downstream problem for some time now.

The issue manifests itself in segmentation faults that depend on the registration order of finalizers. When the external pointer is cleared too late (i.e. after the Rcpp finalizer is run), a situation arises where my code receives an `XPtr` that claims to be valid but where the containing object already has been deleted.

The PR at hand fixes the downstream problem. Happy to provide more information as needed.