### PR TITLE
fix include of <execinfo.h>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-15  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/exceptions_impl.h: Ensure <execinfo.h> is included
+	into global namespace; refactor detection of demangler support
+
 2020-03-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Date, Version): Release 1.0.4


### PR DESCRIPTION
Closes https://github.com/RcppCore/Rcpp/issues/1046.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
