### PR TITLE
Fix Rcpp_list2 issue (closes #1053)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
 2020-03-18  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/lang.h: Define Rcpp_list{2,3,4,5} in Rcpp namespace
+	* DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
+	* inst/include/Rcpp/lang.h: Define Rcpp_list{2,3,4,5} in the Rcpp
+	namespace
+
+	* DESCRIPTION: Remove versioned depends on R (>= 3.0.0) from 2013
 
 2020-03-17  Davis Vaughan  <davis@rstudio.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,14 @@
+2020-03-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/lang.h: Define Rcpp_list{2,3,4,5} in Rcpp namespace
+
 2020-03-17  Davis Vaughan  <davis@rstudio.com>
 
 	* inst/include/Rcpp/lang.h: Inline Rcpp_list6() to support R 3.3.
 
 2020-03-17  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+	* DESCRIPTION (Version, Date): Roll minor version (twice)
         * inst/include/Rcpp/config.h: Idem
 
         * inst/NEWS.Rd: Updated

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.4.2
-Date: 2020-03-17
+Version: 1.0.4.3
+Date: 2020-03-18
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
@@ -14,7 +14,6 @@ Description: The 'Rcpp' package provides R functions as well as C++ classes whic
  Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013,
  <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018,
  <doi:10.1080/00031305.2017.1375990>); see 'citation("Rcpp")' for details.
-Depends: R (>= 3.0.0)
 Imports: methods, utils
 Suggests: tinytest, inline, rbenchmark, pkgKitten (>= 0.1.2)
 URL: http://www.rcpp.org, http://dirk.eddelbuettel.com/code/rcpp.html, https://github.com/RcppCore/Rcpp

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,6 +11,8 @@
       proper include behavior (Kevin in \ghpr{1047} fixing \ghit{1046}).
       \item A missing \code{Rcpp_list6} definition was added to support
       R 3.3.* builds (Davis Vaughan in \ghpr{1049} fixing \ghit{1048}).
+      \item Missing \code{Rcpp_list{2,3,4,5} definition were added to
+      the Rcpp namespace (Dirk fixing \ghit{1053}).
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.4"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,2)
-#define RCPP_DEV_VERSION_STRING "1.0.4.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,3)
+#define RCPP_DEV_VERSION_STRING "1.0.4.3"
 
 #endif

--- a/inst/include/Rcpp/lang.h
+++ b/inst/include/Rcpp/lang.h
@@ -21,6 +21,7 @@
 #ifndef Rcpp__lang_h
 #define Rcpp__lang_h
 
+#define Rcpp_list1 Rf_list1
 #define Rcpp_lang1 Rf_lang1
 #define Rcpp_lang2 Rf_lang2
 #define Rcpp_lang3 Rf_lang3
@@ -31,13 +32,6 @@
 #define Rcpp_lcons Rf_lcons
 
 namespace Rcpp {
-
-inline SEXP Rcpp_list1(SEXP x0) {
-    PROTECT(x0);
-    x0 = Rf_cons(x0);
-    UNPROTECT(1);
-    return x0;
-}
 
 inline SEXP Rcpp_list2(SEXP x0, SEXP x1) {
     PROTECT(x0);

--- a/inst/include/Rcpp/lang.h
+++ b/inst/include/Rcpp/lang.h
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
+
 // lang.h: Rcpp R/C++ interface class library -- extra lang_* functions
 //
-// Copyright (C) 2011 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2011 - 2020 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -22,21 +21,53 @@
 #ifndef Rcpp__lang_h
 #define Rcpp__lang_h
 
-#define Rcpp_list1 Rf_list1
 #define Rcpp_lang1 Rf_lang1
-#define Rcpp_list2 Rf_list2
 #define Rcpp_lang2 Rf_lang2
-#define Rcpp_list3 Rf_list3
 #define Rcpp_lang3 Rf_lang3
-#define Rcpp_list4 Rf_list4
 #define Rcpp_lang4 Rf_lang4
-#define Rcpp_list5 Rf_list5
 #define Rcpp_lang5 Rf_lang5
 #define Rcpp_lang6 Rf_lang6
 
 #define Rcpp_lcons Rf_lcons
 
 namespace Rcpp {
+
+inline SEXP Rcpp_list1(SEXP x0) {
+    PROTECT(x0);
+    x0 = Rf_cons(x0);
+    UNPROTECT(1);
+    return x0;
+}
+
+inline SEXP Rcpp_list2(SEXP x0, SEXP x1) {
+    PROTECT(x0);
+    x0 = Rf_cons(x0, Rcpp_list1(x1));
+    UNPROTECT(1);
+    return x0;
+}
+
+inline SEXP Rcpp_list3(SEXP x0, SEXP x1, SEXP x2) {
+    PROTECT(x0);
+    x0 = Rf_cons(x0, Rcpp_list2(x1, x2));
+    UNPROTECT(1);
+    return x0;
+}
+
+inline SEXP Rcpp_list4(SEXP x0, SEXP x1, SEXP x2, SEXP x3) {
+    PROTECT(x0);
+    x0 = Rf_cons(x0, Rcpp_list3(x1, x2, x3));
+    UNPROTECT(1);
+    return x0;
+}
+
+inline SEXP Rcpp_list5(SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4) {
+    PROTECT(x0);
+    x0 = Rf_cons(x0, Rcpp_list4(x1, x2, x3, x4));
+    UNPROTECT(1);
+    return x0;
+}
+
+
 
 // `Rf_lang6()` is available on R 3.3, but `Rf_list6()` is not
 inline SEXP Rcpp_list6( SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4, SEXP x5 )
@@ -330,4 +361,3 @@ inline SEXP Rcpp_lang20( SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4, SEXP x5, S
 }
 
 #endif
-


### PR DESCRIPTION
This adds definitions for `Rcpp_list2()` to `Rcpp_list5()`.  At least one BioConductor package explicitly referenced `Rcpp::Rcpp_list2()` and we broke that in 1.0.4.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
