### PR TITLE
Exceptions impl fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-03-22  Mattias Ellert  <mattias.ellert@physics.uu.se>
+
+	* inst/include/Rcpp/exceptions_impl.h: Add include guard,
+	Make sure RCPP_DEMANGLER_ENABLED is always defined,
+	Add missing inline qualifier
+
 2020-03-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/exceptions_impl.h
+++ b/inst/include/Rcpp/exceptions_impl.h
@@ -18,6 +18,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
+#ifndef Rcpp__exceptions_impl__h
+#define Rcpp__exceptions_impl__h
+
 // disable demangler on platforms where we have no support
 #ifndef RCPP_DEMANGLER_ENABLED
 # if defined(_WIN32)     || \
@@ -102,3 +105,4 @@ namespace Rcpp {
 
 }
 
+#endif

--- a/inst/include/Rcpp/exceptions_impl.h
+++ b/inst/include/Rcpp/exceptions_impl.h
@@ -37,6 +37,8 @@
 # elif defined(__GNUC__)  || defined(__clang__)
 #  include <execinfo.h>
 #  define RCPP_DEMANGLER_ENABLED 1
+# else
+#  define RCPP_DEMANGLER_ENABLED 0
 # endif
 #endif
 

--- a/inst/include/Rcpp/exceptions_impl.h
+++ b/inst/include/Rcpp/exceptions_impl.h
@@ -46,7 +46,7 @@ namespace Rcpp {
 
     // Extract mangled name e.g. ./test(baz+0x14)[0x400962]
 #if RCPP_DEMANGLER_ENABLED
-    static std::string demangler_one(const char* input) {       // #nocov start
+    static inline std::string demangler_one(const char* input) {  // #nocov start
 
         static std::string buffer;
 


### PR DESCRIPTION
Some fixes for inst/include/Rcpp/exceptions_impl.h
- the header file should have an include guard like all the other headers.
- The RCPP_DEMANGLER_ENABLED should always have a value - missing #else
- demangler_one should have an inline qualifier. Without this ROOT's R interface complains:

Processing /builddir/build/BUILD/root-6.20.02/tutorials/r/Function.C...
IncrementalExecutor::executeFunction: symbol '_ZN4RcppL13demangler_oneEPKc' unresolved 
while linking [cling interface function]!
You are probably missing the definition of Rcpp::demangler_one(char const*)
Maybe you need to load the corresponding shared library?

With the inline qualifier this error disappears.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
