### PR TITLE
Two more shields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-03-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Environment.h: Added two Shield<SEXP> wrappers
+	around Rf_langX calls
+
 2020-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .travis.yml (script): Run coverage as parallel step

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2020-03-24  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 	* inst/include/Rcpp/Environment.h: Added two Shield<SEXP> wrappers
 	around Rf_langX calls
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.4.4
-Date: 2020-03-22
+Version: 1.0.4.5
+Date: 2020-03-24
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -3,7 +3,7 @@
 // Environment.h: Rcpp R/C++ interface class library -- access R environments
 //
 // Copyright (C) 2009 - 2013  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2014 - 2019  Dirk Eddelbuettel, Romain Francois and Kevin Ushey
+// Copyright (C) 2014 - 2020  Dirk Eddelbuettel, Romain Francois and Kevin Ushey
 //
 // This file is part of Rcpp.
 //
@@ -33,8 +33,8 @@ namespace Rcpp{
             if( Rf_isEnvironment(x) ) return x ;
             SEXP asEnvironmentSym = Rf_install("as.environment");
             try {
-                Shield<SEXP> res(Rcpp_fast_eval(Rf_lang2(asEnvironmentSym, x), R_GlobalEnv));
-                return res ;
+                Shield<SEXP> call(Rf_lang2(asEnvironmentSym, x));
+                return Rcpp_fast_eval(call, R_GlobalEnv);
             } catch( const eval_error& ex) {
                 const char* fmt = "Cannot convert object to an environment: "
                                   "[type=%s; target=ENVSXP].";
@@ -393,9 +393,9 @@ namespace Rcpp{
          */
         Environment_Impl new_child(bool hashed) const {
             SEXP newEnvSym = Rf_install("new.env");
-            return Environment_Impl(Rcpp_fast_eval(Rf_lang3(newEnvSym, Rf_ScalarLogical(hashed), Storage::get__()), R_GlobalEnv));
+            Shield<SEXP> call(Rf_lang3(newEnvSym, Rf_ScalarLogical(hashed), Storage::get__()));
+            return Environment_Impl(Rcpp_fast_eval(call, R_GlobalEnv));
         }
-
 
         void update(SEXP){}
     };

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.4"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,4)
-#define RCPP_DEV_VERSION_STRING "1.0.4.4"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,5)
+#define RCPP_DEV_VERSION_STRING "1.0.4.5"
 
 #endif


### PR DESCRIPTION
Adds two more `Shield<SEXP>` around `Rf_lang2` results.

Thanks to @romainfrancois and @lionel- for spotting the need for it when the first of these was posted to r-devel.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
