### PR TITLE
avoid including empty string in R CMD SHLIB call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 2020-03-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci-dev/Dockerfile: Also install the 'codetools' package
+2020-03-31	Kevin Ushey	<kevin@rstudio.com>
+
+	* R/Attributes.R: Fix for sourceCpp() on Windows w/R-devel
 
 2020-03-24  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 2020-03-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci-dev/Dockerfile: Also install the 'codetools' package
-2020-03-31	Kevin Ushey	<kevin@rstudio.com>
+
+2020-03-31 Kevin Ushey  <kevin@rstudio.com>
 
 	* R/Attributes.R: Fix for sourceCpp() on Windows w/R-devel
 

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -127,17 +127,24 @@ sourceCpp <- function(file = "",
             file.remove(context$previousDynlibPath)
         }                                                       # #nocov end
 
+        # grab components we need to build command
+        r <- paste(R.home("bin"), "R", sep = .Platform$file.sep)
+        lib  <- context$dynlibFilename
+        deps <- context$cppDependencySourcePaths
+        src  <- context$cppSourceFilename
+
         # prepare the command (output if we are in showOutput mode)
-        cmd <- paste(R.home(component="bin"), .Platform$file.sep, "R ",
-                     "CMD SHLIB ",
-                     ifelse(windowsDebugDLL, "-d ", ""),
-                     "-o ", shQuote(context$dynlibFilename), " ",
-                     ifelse(rebuild, "--preclean ", ""),
-                     ifelse(dryRun, "--dry-run ", ""),
-                     paste(shQuote(context$cppDependencySourcePaths),
-                           collapse = " "), " ",
-                     shQuote(context$cppSourceFilename), " ",
-                     sep="")
+        cmd <- paste(
+            r, "CMD", "SHLIB",
+            if (windowsDebugDLL) "-d",
+            if (rebuild) "--preclean",
+            if (dryRun) "--dry-run",
+            "-o", shQuote(lib),
+            if (length(deps))
+                paste(shQuote(deps), collapse = " "),
+            shQuote(src)
+        )
+
         if (showOutput)
             cat(cmd, "\n")										# #nocov
 

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -134,7 +134,7 @@ sourceCpp <- function(file = "",
         src  <- context$cppSourceFilename
 
         # prepare the command (output if we are in showOutput mode)
-        cmd <- paste(
+        args <- c(
             r, "CMD", "SHLIB",
             if (windowsDebugDLL) "-d",
             if (rebuild) "--preclean",
@@ -145,6 +145,7 @@ sourceCpp <- function(file = "",
             shQuote(src)
         )
 
+        cmd <- paste(args, collapse = " ")
         if (showOutput)
             cat(cmd, "\n")										# #nocov
 


### PR DESCRIPTION
### Pull Request Template for Rcpp

Closes https://github.com/RcppCore/Rcpp/issues/1061; ensures that we only include non-empty elements when constructing the command string.

In particular, `shQuote(character())` does return an empty quoted string on Windows:

```
> shQuote(character())
[1] "\"\""
```

so we need to check the length of the option 'dependencies' vector before including it in the generated command.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
