### PR TITLE
skip remainder of one test file if on Solaris

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-04-10  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_exceptions.R: Skip parts of file if on Solaris
+
 2020-04-02  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/NEWS.rd: Mark as patch release 1.0.4.6

--- a/inst/tinytest/test_exceptions.R
+++ b/inst/tinytest/test_exceptions.R
@@ -20,6 +20,7 @@ if (Sys.getenv("RunAllRcppTests") != "yes") exit_file("Set 'RunAllRcppTests' to 
 
 ## used below
 .onWindows <- .Platform$OS.type == "windows"
+.onSolaris <- Sys.info()[["sysname"]] == "SunOS"
 
 Rcpp::sourceCpp("cpp/exceptions.cpp")
 
@@ -51,6 +52,7 @@ expect_identical(condition$message, "Inadmissible value")
 expect_identical(class(condition), c("Rcpp::exception", "C++Error", "error", "condition"))
 
 if (.onWindows) exit_file("Skipping remainder of file on Windows")
+if (.onSolaris) exit_file("Skipping remainder of file on Solaris")
 
 expect_true(!is.null(condition$cppstack))
 


### PR DESCRIPTION
Skip exceptions tests after line 55 just like Windows does

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
