### PR TITLE
define safe variant of short_file_name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-04-10  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/macros/macros.h: Safer definition of short_file_name
+	* inst/include/Rcpp/String.h: Idem
+	* inst/include/Rcpp/macros/debug.h: Idem
+	* src/api.cpp: Idem
+
 2020-04-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_exceptions.R: Skip parts of file if on Solaris

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -29,10 +29,10 @@
 
 #if RCPP_STRING_DEBUG_LEVEL > 0
     #define RCPP_STRING_DEBUG_FORMAT "%40s:%4d "
-    #define RCPP_STRING_DEBUG(MSG) Rprintf(RCPP_STRING_DEBUG_FORMAT "%s\n" , short_file_name(__FILE__), __LINE__, MSG);
-    #define RCPP_STRING_DEBUG_1(fmt, MSG) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , short_file_name(__FILE__), __LINE__, MSG);
-    #define RCPP_STRING_DEBUG_2(fmt, M1, M2) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2);
-    #define RCPP_STRING_DEBUG_3(fmt, M1, M2, M3) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3);
+    #define RCPP_STRING_DEBUG(MSG) Rprintf(RCPP_STRING_DEBUG_FORMAT "%s\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG);
+    #define RCPP_STRING_DEBUG_1(fmt, MSG) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG);
+    #define RCPP_STRING_DEBUG_2(fmt, M1, M2) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2);
+    #define RCPP_STRING_DEBUG_3(fmt, M1, M2, M3) Rprintf(RCPP_STRING_DEBUG_FORMAT fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3);
 #else
     #define RCPP_STRING_DEBUG(MSG)
     #define RCPP_STRING_DEBUG_1(fmt, MSG)

--- a/inst/include/Rcpp/macros/debug.h
+++ b/inst/include/Rcpp/macros/debug.h
@@ -33,12 +33,12 @@
 
 
 #if RCPP_DEBUG_LEVEL > 0
-    #define RCPP_DEBUG( MSG ) Rprintf( "%40s:%4d %s\n" , short_file_name(__FILE__), __LINE__, MSG ) ;
-    #define RCPP_DEBUG_1( fmt, MSG ) Rprintf( "%40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, MSG ) ;
-    #define RCPP_DEBUG_2( fmt, M1, M2 ) Rprintf( "%40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2 ) ;
-    #define RCPP_DEBUG_3( fmt, M1, M2, M3 ) Rprintf( "%40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3) ;
-    #define RCPP_DEBUG_4( fmt, M1, M2, M3, M4 ) Rprintf( "%40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3, M4) ;
-    #define RCPP_DEBUG_5( fmt, M1, M2, M3, M4, M5 ) Rprintf( "%40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3, M4, M5) ;
+    #define RCPP_DEBUG( MSG ) Rprintf( "%40s:%4d %s\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;
+    #define RCPP_DEBUG_1( fmt, MSG ) Rprintf( "%40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;
+    #define RCPP_DEBUG_2( fmt, M1, M2 ) Rprintf( "%40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2 ) ;
+    #define RCPP_DEBUG_3( fmt, M1, M2, M3 ) Rprintf( "%40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3) ;
+    #define RCPP_DEBUG_4( fmt, M1, M2, M3, M4 ) Rprintf( "%40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4) ;
+    #define RCPP_DEBUG_5( fmt, M1, M2, M3, M4, M5 ) Rprintf( "%40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4, M5) ;
 #else
     #define RCPP_DEBUG( MSG )
     #define RCPP_DEBUG_1( fmt, MSG )
@@ -52,49 +52,49 @@
     #define RCPP_DEBUG_MODULE( MSG ) {                                                                                             \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ){                                                                                                                 \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d %s\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, MSG ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d %s\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d %s\n" , short_file_name(__FILE__), __LINE__, MSG ) ;                                \
+            Rprintf( "[module () ] %40s:%4d %s\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;                                \
         }                                                                                                                          \
     }
     #define RCPP_DEBUG_MODULE_1( fmt, MSG ) {                                                                                      \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ){                                                                                                                 \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, MSG ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, MSG ) ;                                \
+            Rprintf( "[module () ] %40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, MSG ) ;                                \
         }                                                                                                                          \
     }
     #define RCPP_DEBUG_MODULE_2( fmt, M1, M2 ) {                                                                                      \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ){                                                                                                                 \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, M1, M2 ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2 ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2 ) ;                                \
+            Rprintf( "[module () ] %40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2 ) ;                                \
         }                                                                                                                          \
     }
     #define RCPP_DEBUG_MODULE_3( fmt, M1, M2, M3 ) {                                                                                      \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ){                                                                                                                 \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, M1, M2, M3 ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3 ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3 ) ;                                \
+            Rprintf( "[module () ] %40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3 ) ;                                \
         }                                                                                                                          \
     }
     #define RCPP_DEBUG_MODULE_4( fmt, M1, M2, M3, M4 ) {                                                                                      \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ) {                                                                                                                \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, M1, M2, M3, M4 ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4 ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3, M4 ) ;                                \
+            Rprintf( "[module () ] %40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4 ) ;                                \
         }                                                                                                                          \
     }
     #define RCPP_DEBUG_MODULE_5( fmt, M1, M2, M3, M4, M5 ) {                                                                                      \
         Rcpp::Module * mod__ = getCurrentScope() ;                                                                                 \
         if( mod__ ){                                                                                                                 \
-            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, short_file_name(__FILE__), __LINE__, M1, M2, M3, M4, M5 ) ;\
+            Rprintf( "[module (%s) <%p> ] %40s:%4d " fmt "\n" , mod__->name.c_str(), mod__, ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4, M5 ) ;\
         } else {                                                                                                                   \
-            Rprintf( "[module () ] %40s:%4d " fmt "\n" , short_file_name(__FILE__), __LINE__, M1, M2, M3, M4, M5 ) ;                                \
+            Rprintf( "[module () ] %40s:%4d " fmt "\n" , ::Rcpp::debug::short_file_name(__FILE__).c_str(), __LINE__, M1, M2, M3, M4, M5 ) ;                                \
         }                                                                                                                          \
     }
 #else

--- a/inst/include/Rcpp/macros/macros.h
+++ b/inst/include/Rcpp/macros/macros.h
@@ -22,6 +22,23 @@
 #ifndef Rcpp_macros_macros_h
 #define Rcpp_macros_macros_h
 
+#include <string>
+
+namespace Rcpp {
+namespace debug {
+
+inline std::string short_file_name(const char* file)
+{
+    std::string f(file);
+    size_t index = f.find("/include/");
+    if (index != std::string::npos)
+        f = f.substr(index + 9);
+    return f;
+}
+
+} // namespace debug
+} // namespace Rcpp
+
 #define RCPP_DECORATE(__FUN__) __FUN__##__rcpp__wrapper__
 #define RCPP_GET_NAMES(x) Rf_getAttrib(x, R_NamesSymbol)
 #define RCPP_GET_CLASS(x) Rf_getAttrib(x, R_ClassSymbol)

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -126,9 +126,15 @@ std::string demangle(const std::string& name) {
     #endif
 }
 
+// NOTE: remains registered but this routine is now effectively unused by Rcpp;
+// we retain it for backwards compatibility with any existing packages which
+// (explicitly or implicitly) rely on its existence. See also:
+// https://github.com/RcppCore/Rcpp/issues/1066
+
 // [[Rcpp::register]]
 const char* short_file_name(const char* file) {                 // #nocov start
-    std::string f(file);
+    static std::string f;
+    f = file;
     size_t index = f.find("/include/");
     if (index != std::string::npos) {
         f = f.substr(index + 9);


### PR DESCRIPTION
### Pull Request Template for Rcpp

Closes https://github.com/RcppCore/Rcpp/issues/1066. This PR comes with two pieces:

1. A "safe" definition of `short_file_name`, defined and used explicitly in the `Rcpp::debug` namespace;

2. A re-worked version of the "old" (+ registered) `short_file_name`, which now uses a static buffer. I believe the method should be effectively un-used but I figured since it's a registered routine it's best to keep the API the same and just silence the compiler warning.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
