### PR TITLE
Explicitly call abs as a function in DataFrame.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-04-15 Uwe Korn <mail@uwekorn.com>
+
+	* inst/include/Rcpp/DataFrame.h: Explicit call to scalar std::abs
+
 2020-04-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -79,7 +79,7 @@ namespace Rcpp{
             if (Rf_isNull(rn))
                 return 0;
             if (TYPEOF(rn) == INTSXP && LENGTH(rn) == 2 && INTEGER(rn)[0] == NA_INTEGER)
-                return abs(INTEGER(rn)[1]);
+                return std::abs(INTEGER(rn)[1]);
             return LENGTH(rn);
         }
 


### PR DESCRIPTION
When building with `clang` (in this case on Windows), the call to `abs` is expanded to the vectorised form although we call it with a scalar value. Explicitly requesting `std::abs` prohibits this expansion.

For reference, the original error:

```
/C/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Library/bin/clang++.exe  -std=gnu++14 -I"C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/lib/R/include" -D
NDEBUG -DNDEBUG -I"%BUILD_PREFIX%\Library/include" -I"%BUILD_PREFIX%/include" -O2 -D_CRT_SECURE_NO_WARNINGS -DARROW_R_WITH_ARROW -fuse-ld=lld -I"C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848
759312/_h_env/Lib/R/library/Rcpp/include"   -I"C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/lib/R/../../Library/mingw-w64/include"     -O2 -Wall -gdwarf-2 -march=x86-64 -mtune=
generic -c recordbatch.cpp -o recordbatch.o
In file included from recordbatch.cpp:18:
In file included from ././arrow_types.h:145:
In file included from C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp.h:57:
C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp/DataFrame.h:82:24: error: no matching function for call to 'abs'
                return abs(INTEGER(rn)[1]);
                       ^~~
recordbatch.cpp:100:47: note: in instantiation of member function 'Rcpp::DataFrame_Impl<PreserveStorage>::nrow' requested here
  return arrow::RecordBatch::Make(schema, tbl.nrow(), std::move(arrays));
                                              ^
C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp/sugar/functions/math.h:42:19: note: candidate function not viable: no known conversion from 'int'
      to 'SEXP' (aka 'SEXPREC *') for 1st argument
VECTORIZED_MATH_1(abs,::fabs)
                  ^
C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp/sugar/block/Vectorized_Math.h:91:9: note: expanded from macro 'VECTORIZED_MATH_1'
        __NAME__( SEXP x){ return __NAME__( NumericVector( x ) ) ; }             \
        ^
C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp/sugar/functions/math.h:42:19: note: candidate template ignored: could not match
      'VectorBase<14, NA, type-parameter-0-1>' against 'int'
C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/Lib/R/library/Rcpp/include\Rcpp/sugar/functions/math.h:42:19: note: candidate template ignored: could not match
      'VectorBase<13, NA, type-parameter-0-1>' against 'int'
1 error generated.
make: *** [recordbatch.o] Error 1C:/Users/Administrator/miniconda3/conda-bld/r-arrow_1586848759312/_h_env/lib/R/etc/x64/Makeconf:215: recipe for target 'recordbatch.o' failed
```

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
