### PR TITLE
Use an explicit vector rather than R_alloc in sample

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-04-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/sugar/functions/sample.h: Replace R_alloc() with
+	a standard vector allocation to reduce memory consumption in sample
+
 2020-04-16  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -38,6 +38,11 @@
       \item The exceptions test is now partially skipped on Solaris as
       it already is on Windows (Dirk in \ghpr{1065}).
     }
+    \item Changes in Rcpp Sugar:
+    \itemize{
+      \item Two \code{sample()} objects are now standard vectors and not
+      \code{R_alloc} created (Dirk in \ghpr{1075} fixing \ghpr{1074}).
+    }
   }
 }
 

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -348,7 +348,7 @@ inline Vector<INTSXP> EmpiricalSample(int n, int size, bool replace, bool one_ba
         return ans;
     }
 
-    int* x = reinterpret_cast<int*>(R_alloc(n, sizeof(int)));
+    IntegerVector x(n);
     for (int i = 0; i < n; i++) {
         x[i] = i;
     }
@@ -378,7 +378,7 @@ inline Vector<RTYPE> EmpiricalSample(int size, bool replace, const Vector<RTYPE>
         return ans;
     }
 
-    int* x = reinterpret_cast<int*>(R_alloc(n, sizeof(int)));
+    IntegerVector x(n);
     for (int i = 0; i < n; i++) {
         x[i] = i;
     }

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -348,7 +348,7 @@ inline Vector<INTSXP> EmpiricalSample(int n, int size, bool replace, bool one_ba
         return ans;
     }
 
-    IntegerVector x(n);
+    IntegerVector x = no_init(n);
     for (int i = 0; i < n; i++) {
         x[i] = i;
     }
@@ -378,7 +378,7 @@ inline Vector<RTYPE> EmpiricalSample(int size, bool replace, const Vector<RTYPE>
         return ans;
     }
 
-    IntegerVector x(n);
+    IntegerVector x = no_init(n);
     for (int i = 0; i < n; i++) {
         x[i] = i;
     }


### PR DESCRIPTION
As discussed in #1074, the behavior of `R_alloc()` seems to be less than ideal, and a simple replacement of an `IntegerVector` instantiation appears to help in two places.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
