### PR TITLE
Add new vignette about packaging C++ libraries (closes #1077)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-04-30  Dirk Eddelbuettel  <edd@debian.org>
+
+	* vignettes/rmd/Rcpp-libraries.Rmd: Add new vignette source
+	* vignettes/rmd/Rcpp.bib: Complete references
+        * inst/bib/Rcpp.bib: Idem
+
 2020-04-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,140 +1,140 @@
 2020-04-30  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* vignettes/rmd/Rcpp-libraries.Rmd: Add new vignette source
-	* vignettes/rmd/Rcpp.bib: Complete references
+        * vignettes/rmd/Rcpp-libraries.Rmd: Add new vignette source
+        * vignettes/rmd/Rcpp.bib: Complete references
         * inst/bib/Rcpp.bib: Idem
 
 2020-04-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2020-04-25  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/sugar/functions/sample.h: Replace R_alloc() with
-	a standard vector allocation to reduce memory consumption in sample
+        * inst/include/Rcpp/sugar/functions/sample.h: Replace R_alloc() with
+        a standard vector allocation to reduce memory consumption in sample
 
-	* docker/ci/Dockerfile: Update for R 4.0.0 (with a temporary
-	diversion to rocker/r-base:4.0.0, and all-source installations)
+        * docker/ci/Dockerfile: Update for R 4.0.0 (with a temporary
+        diversion to rocker/r-base:4.0.0, and all-source installations)
 
-	* vignettes/rmd/Makefile: Add bibtex call to JSS 2011 paper builds
+        * vignettes/rmd/Makefile: Add bibtex call to JSS 2011 paper builds
 
 2020-04-16  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2020-04-15  Kevin Ushey  <kevinushey@gmail.com>
 
-	* inst/include/Rcpp/String.h: Avoid 'debug' namespace collisions
-	* inst/include/Rcpp/macros/debug.h: Idem
-	* inst/include/Rcpp/macros/macros.h: Idem
+        * inst/include/Rcpp/String.h: Avoid 'debug' namespace collisions
+        * inst/include/Rcpp/macros/debug.h: Idem
+        * inst/include/Rcpp/macros/macros.h: Idem
 
 2020-04-15  Uwe Korn  <mail@uwekorn.com>
 
-	* inst/include/Rcpp/DataFrame.h: Explicit call to scalar std::abs
+        * inst/include/Rcpp/DataFrame.h: Explicit call to scalar std::abs
 
 2020-04-11  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2020-04-10  Kevin Ushey  <kevinushey@gmail.com>
 
-	* inst/include/Rcpp/macros/macros.h: Safer definition of short_file_name
-	* inst/include/Rcpp/String.h: Idem
-	* inst/include/Rcpp/macros/debug.h: Idem
-	* src/api.cpp: Idem
+        * inst/include/Rcpp/macros/macros.h: Safer definition of short_file_name
+        * inst/include/Rcpp/String.h: Idem
+        * inst/include/Rcpp/macros/debug.h: Idem
+        * src/api.cpp: Idem
 
 2020-04-10  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/tinytest/test_exceptions.R: Skip parts of file if on Solaris
+        * inst/tinytest/test_exceptions.R: Skip parts of file if on Solaris
 
 2020-04-02  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/NEWS.rd: Mark as patch release 1.0.4.6
+        * inst/NEWS.rd: Mark as patch release 1.0.4.6
 
-	* inst/tinytest/test_exceptions.R: If running skip remainder of file
-	on Windows to not trigger failed test
+        * inst/tinytest/test_exceptions.R: If running skip remainder of file
+        on Windows to not trigger failed test
 
 2020-04-01  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2020-03-31  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/ci-dev/Dockerfile: Also install the 'codetools' package
+        * docker/ci-dev/Dockerfile: Also install the 'codetools' package
 
 2020-03-31 Kevin Ushey  <kevin@rstudio.com>
 
-	* R/Attributes.R: Fix for sourceCpp() on Windows w/R-devel
+        * R/Attributes.R: Fix for sourceCpp() on Windows w/R-devel
 
 2020-03-28  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/examples/RcppGibbs/RcppGibbs_Updated.R: Updated example
+        * inst/examples/RcppGibbs/RcppGibbs_Updated.R: Updated example
 
 2020-03-24  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* inst/include/Rcpp/Environment.h: Added two Shield<SEXP> wrappers
-	around Rf_langX calls
+        * inst/include/Rcpp/Environment.h: Added two Shield<SEXP> wrappers
+        around Rf_langX calls
 
 2020-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml (script): Run coverage as parallel step
+        * .travis.yml (script): Run coverage as parallel step
 
 2020-03-22  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* docker/ci-3.4/Dockerfile: Added
-	* docker/ci-3.5/Dockerfile: Idem
-	* docker/ci-dev/Dockerfile: Idem
+        * docker/ci-3.4/Dockerfile: Added
+        * docker/ci-3.5/Dockerfile: Idem
+        * docker/ci-dev/Dockerfile: Idem
 
-	* .travis.yml (jobs): Expand to matrix
+        * .travis.yml (jobs): Expand to matrix
 
 2020-03-22  Mattias Ellert  <mattias.ellert@physics.uu.se>
 
-	* inst/include/Rcpp/exceptions_impl.h: Add include guard,
-	Make sure RCPP_DEMANGLER_ENABLED is always defined,
-	Add missing inline qualifier
+        * inst/include/Rcpp/exceptions_impl.h: Add include guard,
+        Make sure RCPP_DEMANGLER_ENABLED is always defined,
+        Add missing inline qualifier
 
 2020-03-18  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* inst/include/Rcpp/lang.h: Define Rcpp_list{2,3,4,5} in the Rcpp
-	namespace
+        * inst/include/Rcpp/lang.h: Define Rcpp_list{2,3,4,5} in the Rcpp
+        namespace
 
-	* DESCRIPTION: Remove versioned depends on R (>= 3.0.0) from 2013
+        * DESCRIPTION: Remove versioned depends on R (>= 3.0.0) from 2013
 
 2020-03-17  Davis Vaughan  <davis@rstudio.com>
 
-	* inst/include/Rcpp/lang.h: Inline Rcpp_list6() to support R 3.3.
+        * inst/include/Rcpp/lang.h: Inline Rcpp_list6() to support R 3.3.
 
 2020-03-17  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version (twice)
+        * DESCRIPTION (Version, Date): Roll minor version (twice)
         * inst/include/Rcpp/config.h: Idem
 
         * inst/NEWS.Rd: Updated
 
 2020-03-15  Kevin Ushey  <kevinushey@gmail.com>
 
-	* inst/include/Rcpp/exceptions_impl.h: Ensure <execinfo.h> is included
-	into global namespace; refactor detection of demangler support
+        * inst/include/Rcpp/exceptions_impl.h: Ensure <execinfo.h> is included
+        into global namespace; refactor detection of demangler support
 
 2020-03-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Date, Version): Release 1.0.4
+        * DESCRIPTION (Date, Version): Release 1.0.4
 
         * inst/include/Rcpp/config.h: Idem
         * inst/NEWS.Rd: Idem
@@ -143,276 +143,276 @@
 
 2020-03-12  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/rmd/Rcpp.bib: Updated to current package versions
-	* inst/bib/Rcpp.bib: Idem
+        * vignettes/rmd/Rcpp.bib: Updated to current package versions
+        * inst/bib/Rcpp.bib: Idem
 
 2020-02-24  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/exceptions_impl.h: Remove spurious semicolon
+        * inst/include/Rcpp/exceptions_impl.h: Remove spurious semicolon
 
 2020-02-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/generated/Vector__create.h: Added #nocov tags
-	* inst/include/Rcpp/exceptions_impl.h: Idem
-	* src/api.cpp: Idem plus some whitespace realignment
+        * inst/include/Rcpp/generated/Vector__create.h: Added #nocov tags
+        * inst/include/Rcpp/exceptions_impl.h: Idem
+        * src/api.cpp: Idem plus some whitespace realignment
 
 2020-02-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Add a Debian badge
+        * README.md: Add a Debian badge
 
 2020-02-12  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* README.md: Added indirect CRAN use badge
+        * README.md: Added indirect CRAN use badge
 
 2020-02-09  Joshua Pritikin  <jpritikin@pobox.com>
 
-	* inst/include/Rcpp.h: Include exceptions_impl.h
-	* inst/include/Rcpp/exceptions.h: Make thread-safe
-	* inst/include/Rcpp/exceptions_impl.h: New home for code moved
-	from src/api.cpp
+        * inst/include/Rcpp.h: Include exceptions_impl.h
+        * inst/include/Rcpp/exceptions.h: Make thread-safe
+        * inst/include/Rcpp/exceptions_impl.h: New home for code moved
+        from src/api.cpp
 
 2020-01-05  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/exceptions.h: A few more #nocov tags
-	* inst/include/Rcpp/generated/Vector__create.h: Idem, plus whitespace
+        * inst/include/Rcpp/exceptions.h: A few more #nocov tags
+        * inst/include/Rcpp/generated/Vector__create.h: Idem, plus whitespace
 
 2020-01-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Attributes.R: A few more #nocov tags
+        * R/Attributes.R: A few more #nocov tags
 
 2020-01-01  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/module/Module.h: A few more #nocov tags
-	* inst/include/Rcpp/XPtr.h: Idem
-	* inst/include/Rcpp/vector/Vector.h: Idem
+        * inst/include/Rcpp/module/Module.h: A few more #nocov tags
+        * inst/include/Rcpp/XPtr.h: Idem
+        * inst/include/Rcpp/vector/Vector.h: Idem
 
 2019-12-31  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2019-12-29  Qiang Kou  <qkou@qkou.info>
 
-	* inst/include/Rcpp/vector/Matrix.h: Ensure scalar OP matrix do not
-	change right-hand side in operation
-	* inst/tinytest/test_matrix.R: New tests
-	* inst/tinytest/cpp/Matrix.cpp: Idem
+        * inst/include/Rcpp/vector/Matrix.h: Ensure scalar OP matrix do not
+        change right-hand side in operation
+        * inst/tinytest/test_matrix.R: New tests
+        * inst/tinytest/cpp/Matrix.cpp: Idem
 
 2019-12-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2019-12-18  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/XPtr.h: Additional null check, refactored
+        * inst/include/Rcpp/XPtr.h: Additional null check, refactored
 
 2019-12-17  Kirill Müller  <krlmlr@mailbox.org>
 
-	* inst/include/Rcpp/XPtr.h: Clear external pointer before finalizer
+        * inst/include/Rcpp/XPtr.h: Clear external pointer before finalizer
 
 2019-12-17  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Attributes.R (sourceCpp): Very minor cosmetic changes
+        * R/Attributes.R (sourceCpp): Very minor cosmetic changes
 
 2019-12-15  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2019-12-14  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Attributes.R (sourceCpp): Support new argument windowsDebugDLL to
-	create a debug DLL, supported on Windows only
-	* man/sourceCpp.Rd: Document it
+        * R/Attributes.R (sourceCpp): Support new argument windowsDebugDLL to
+        create a debug DLL, supported on Windows only
+        * man/sourceCpp.Rd: Document it
 
-	* src/date.cpp: A few more #nocov tage
+        * src/date.cpp: A few more #nocov tage
 
 2019-12-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* src/api.cpp: A few more #nocov tags
-	* src/attributes.cpp: Idem
-	* src/barrier.cpp: Idem
+        * src/api.cpp: A few more #nocov tags
+        * src/attributes.cpp: Idem
+        * src/barrier.cpp: Idem
 
 2019-12-08  Dirk Eddelbuettel  <edd@debian.org>
 
-	* tests/tinytest.R: Turn verbose tests on in dev and on Travis
+        * tests/tinytest.R: Turn verbose tests on in dev and on Travis
 
-	* inst/tinytest/test_client_package.R: Finer-grained skip messages
-	* inst/tinytest/test_module_client_package.R: Idem
-	* inst/tinytest/test_expose_class.R: Idem
-	* inst/tinytest/test_interface.R: Idem
-	* inst/tinytest/test_rcpp_package_skeleton.R: Idem
-	* inst/tinytest/test_reference.R: Idem
+        * inst/tinytest/test_client_package.R: Finer-grained skip messages
+        * inst/tinytest/test_module_client_package.R: Idem
+        * inst/tinytest/test_expose_class.R: Idem
+        * inst/tinytest/test_interface.R: Idem
+        * inst/tinytest/test_rcpp_package_skeleton.R: Idem
+        * inst/tinytest/test_reference.R: Idem
 
-	* inst/tinytest/test_*.R: Streamlined initial test and sourceCpp call
+        * inst/tinytest/test_*.R: Streamlined initial test and sourceCpp call
 
-	* src/attributes.cpp: Remove dangling '#nocov end'
+        * src/attributes.cpp: Remove dangling '#nocov end'
 
 2019-12-07  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* inst/tinytest/test_binary_package.R: Finer-grained skip messages
+        * inst/tinytest/test_binary_package.R: Finer-grained skip messages
 
-	* inst/tinytest/test_misc.R: Add commented-out test that fails
-	* tests/tinytest.R: Minor edit
+        * inst/tinytest/test_misc.R: Add commented-out test that fails
+        * tests/tinytest.R: Minor edit
 
-	* docker/ci/Dockerfile: Add curl and ssl -dev packages needed for covr
+        * docker/ci/Dockerfile: Add curl and ssl -dev packages needed for covr
 
 2019-12-05  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/rmd/Rcpp-FAQ.Rmd (Rcpp): Add entry about "'dataptr' (or
-	'enterRNGScope') not provided by Rcpp" recommending proper importFrom
+        * vignettes/rmd/Rcpp-FAQ.Rmd (Rcpp): Add entry about "'dataptr' (or
+        'enterRNGScope') not provided by Rcpp" recommending proper importFrom
 
 2019-12-03  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/ci/Dockerfile: Lighter builds as fewer Suggests:
-	* docker/plus/Dockerfile: Take packages moved from ci/Dockerfile
+        * docker/ci/Dockerfile: Lighter builds as fewer Suggests:
+        * docker/plus/Dockerfile: Take packages moved from ci/Dockerfile
 
 2019-12-01  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* DESCRIPTION (Suggests): Remove knitr, rmarkdown, pinp
-	* DESCRIPTION (VignetteBuilder): Remove knitr
+        * DESCRIPTION (Suggests): Remove knitr, rmarkdown, pinp
+        * DESCRIPTION (VignetteBuilder): Remove knitr
 
 2019-11-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/tinytest/test_embedded_r.R: Use sink to suppress noisy output,
-	reenable tests (still conditional on usual environment variable)
+        * inst/tinytest/test_embedded_r.R: Use sink to suppress noisy output,
+        reenable tests (still conditional on usual environment variable)
 
 2019-11-25  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/tinytest/cpp/Vector.cpp (no_op): Suppress compiler warning
+        * inst/tinytest/cpp/Vector.cpp (no_op): Suppress compiler warning
 
 2019-11-24  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Suggests): Add tinytest, remove RUnit
+        * DESCRIPTION (Suggests): Add tinytest, remove RUnit
 
-	* tests/doRUnit.R: Removed
-	* tests/tinytest.R: Added
+        * tests/doRUnit.R: Removed
+        * tests/tinytest.R: Added
 
-	* tests/tinytest.R: Converted from RUnit to tinytest
- 	* inst/tinytest/test_algorithm.R: Idem
- 	* inst/tinytest/test_as.R: Idem
-	* inst/tinytest/test_binary_package.R: Idem (but inactive for now)
-	* inst/tinytest/test_client_package.R: Idem (but inactive for now)
-	* inst/tinytest/test_dataframe.R: Idem
-	* inst/tinytest/test_date.R: Idem (but condition two test sets on TZ)
-	* inst/tinytest/test_dispatch.R: Idem
-	* inst/tinytest/test_embedded.R: Idem
-	* inst/tinytest/test_environments.R: Idem
-	* inst/tinytest/test_exceptions.R: Idem
-	* inst/tinytest/test_exceptions_nocall.R: Idem
-	* inst/tinytest/test_expose_class.R: Idem
-	* inst/tinytest/test_function.R: Idem
-	* inst/tinytest/test_interface.R: Idem (but inactive for now)
-	* inst/tinytest/test_internal_function.R: Idem
-	* inst/tinytest/test_internal_function_cpp11.R: Idem
-	* inst/tinytest/test_language.R: Idem
-	* inst/tinytest/test_listof.R: Idem
-	* inst/tinytest/test_matrix.R: Idem
-	* inst/tinytest/test_misc.R: Idem
-	* inst/tinytest/test_modref.R: Idem
-	* inst/tinytest/test_module.R: Idem
-	* inst/tinytest/test_module_client_package.R: Idem
-	* inst/tinytest/test_na.R: Idem
-	* inst/tinytest/test_quickanddirty.R: Idem
-	* inst/tinytest/test_rcpp_package_skeleton.R: Idem
-	* inst/tinytest/test_reference.R: Idem
-	* inst/tinytest/test_rmath.R: Idem
-	* inst/tinytest/test_robject.R: Idem
-	* inst/tinytest/test_s4.R: Idem
-	* inst/tinytest/test_stack.R: Idem
-	* inst/tinytest/test_stats.R: Idem
-	* inst/tinytest/test_string.R: Idem
-	* inst/tinytest/test_subset.R: Idem
-	* inst/tinytest/test_sugar.R: Idem
-	* inst/tinytest/test_sugar_var.R: Idem
-	* inst/tinytest/test_support.R: Idem
-	* inst/tinytest/test_system.R: Idem
-	* inst/tinytest/test_table.R: Idem
-	* inst/tinytest/test_vector.R: Idem
-	* inst/tinytest/test_vector_old.R: Idem
-	* inst/tinytest/test_wrap.R: Idem
-	* inst/tinytest/test_wstring.R: Idem
-	* inst/tinytest/test_xptr.R: Idem
+        * tests/tinytest.R: Converted from RUnit to tinytest
+        * inst/tinytest/test_algorithm.R: Idem
+        * inst/tinytest/test_as.R: Idem
+        * inst/tinytest/test_binary_package.R: Idem (but inactive for now)
+        * inst/tinytest/test_client_package.R: Idem (but inactive for now)
+        * inst/tinytest/test_dataframe.R: Idem
+        * inst/tinytest/test_date.R: Idem (but condition two test sets on TZ)
+        * inst/tinytest/test_dispatch.R: Idem
+        * inst/tinytest/test_embedded.R: Idem
+        * inst/tinytest/test_environments.R: Idem
+        * inst/tinytest/test_exceptions.R: Idem
+        * inst/tinytest/test_exceptions_nocall.R: Idem
+        * inst/tinytest/test_expose_class.R: Idem
+        * inst/tinytest/test_function.R: Idem
+        * inst/tinytest/test_interface.R: Idem (but inactive for now)
+        * inst/tinytest/test_internal_function.R: Idem
+        * inst/tinytest/test_internal_function_cpp11.R: Idem
+        * inst/tinytest/test_language.R: Idem
+        * inst/tinytest/test_listof.R: Idem
+        * inst/tinytest/test_matrix.R: Idem
+        * inst/tinytest/test_misc.R: Idem
+        * inst/tinytest/test_modref.R: Idem
+        * inst/tinytest/test_module.R: Idem
+        * inst/tinytest/test_module_client_package.R: Idem
+        * inst/tinytest/test_na.R: Idem
+        * inst/tinytest/test_quickanddirty.R: Idem
+        * inst/tinytest/test_rcpp_package_skeleton.R: Idem
+        * inst/tinytest/test_reference.R: Idem
+        * inst/tinytest/test_rmath.R: Idem
+        * inst/tinytest/test_robject.R: Idem
+        * inst/tinytest/test_s4.R: Idem
+        * inst/tinytest/test_stack.R: Idem
+        * inst/tinytest/test_stats.R: Idem
+        * inst/tinytest/test_string.R: Idem
+        * inst/tinytest/test_subset.R: Idem
+        * inst/tinytest/test_sugar.R: Idem
+        * inst/tinytest/test_sugar_var.R: Idem
+        * inst/tinytest/test_support.R: Idem
+        * inst/tinytest/test_system.R: Idem
+        * inst/tinytest/test_table.R: Idem
+        * inst/tinytest/test_vector.R: Idem
+        * inst/tinytest/test_vector_old.R: Idem
+        * inst/tinytest/test_wrap.R: Idem
+        * inst/tinytest/test_wstring.R: Idem
+        * inst/tinytest/test_xptr.R: Idem
 
-	* inst/tinytest/cpp/*: C++ support files for tests
-	* inst/tinytest/*: Other support files and directories from unitTests
+        * inst/tinytest/cpp/*: C++ support files for tests
+        * inst/tinytest/*: Other support files and directories from unitTests
 
-	* R/unitTests.R: Removed as tied to RUnit setuo
+        * R/unitTests.R: Removed as tied to RUnit setuo
 
-	* inst/tinytest/test_attributes.R: Added test for error with
-	non-existing package in cppFunction
+        * inst/tinytest/test_attributes.R: Added test for error with
+        non-existing package in cppFunction
 
 2019-11-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/ci/Dockerfile: Add tinytest to ci Docker image
+        * docker/ci/Dockerfile: Add tinytest to ci Docker image
 
 2019-11-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Attributes.R: Test for and report unavailable 'LinkingTo' package
+        * R/Attributes.R: Test for and report unavailable 'LinkingTo' package
 
 2019-11-19  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2019-11-18  Kun Ren  <mail@renkun.me>
 
-	* src/attributes.cpp: Add invisible param to export attribute (#1024)
-	* vignettes/rmd/Rcpp-attributes.Rmd: Add an section of Returning
-	invisible object
+        * src/attributes.cpp: Add invisible param to export attribute (#1024)
+        * vignettes/rmd/Rcpp-attributes.Rmd: Add an section of Returning
+        invisible object
 
 2019-11-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .github/ISSUE_TEMPLATE.md: Another small edit
-	* .github/PULL_REQUEST_TEMPLATE.md: Idem
+        * .github/ISSUE_TEMPLATE.md: Another small edit
+        * .github/PULL_REQUEST_TEMPLATE.md: Idem
 
 2019-11-13  Stephen Wade  <stephematician@gmail.com>
 
-	* inst/include/Rcpp/XPtr.h: Delete delegating ctor (follow-up #1012)
-	* inst/unitTests/runit.XPTr.R: Reinsert self-tag test on Windows
+        * inst/include/Rcpp/XPtr.h: Delete delegating ctor (follow-up #1012)
+        * inst/unitTests/runit.XPTr.R: Reinsert self-tag test on Windows
 
 2019-11-11  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/unitTests/runit.packageversion.R: New test
-	* inst/unitTests/cpp/rcppversion.cpp: Cpp portion of test
+        * inst/unitTests/runit.packageversion.R: New test
+        * inst/unitTests/cpp/rcppversion.cpp: Cpp portion of test
 
 2019-11-10  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .github/: Add files CONTRIBUTING.md, FUNDING.yml, ISSUE_TEMPLATE.md
-	and PULL_REQUEST_TEMPLATE.md
+        * .github/: Add files CONTRIBUTING.md, FUNDING.yml, ISSUE_TEMPLATE.md
+        and PULL_REQUEST_TEMPLATE.md
 
-	* inst/include/Rcpp/config.h: Correct RCPP_VERSION and
-	RCPP_DEV_VERSION to 1.0.3
+        * inst/include/Rcpp/config.h: Correct RCPP_VERSION and
+        RCPP_DEV_VERSION to 1.0.3
 
 2019-11-09  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
 2019-11-09  TJ McKinley  <t.mckinley@exeter.ac.uk>
 
-	* R/Attributes.R: Correct how cppFunction() deals with multiple
-	depends arguments
+        * R/Attributes.R: Correct how cppFunction() deals with multiple
+        depends arguments
 
 2019-11-08  Romain Francois  <romain@rstudio.com>
 
-	* inst/include/Rcpp/lang.h: Safer Rcpp_list* and Rcpp_lang*
-	* inst/include/Rcpp/Function.h: Add Function.invoke() for operator()
-	* inst/include/Rcpp/generated/Function__operator.h: Safer
-	Function.operator() using Function.invoke()
+        * inst/include/Rcpp/lang.h: Safer Rcpp_list* and Rcpp_lang*
+        * inst/include/Rcpp/Function.h: Add Function.invoke() for operator()
+        * inst/include/Rcpp/generated/Function__operator.h: Safer
+        Function.operator() using Function.invoke()
 
 2019-11-08  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Date, Version): Release 1.0.3
+        * DESCRIPTION (Date, Version): Release 1.0.3
 
         * inst/include/Rcpp/config.h: Idem
         * inst/NEWS.Rd: Idem
@@ -421,131 +421,131 @@
 
 2019-11-06  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/include/Rcpp/XPtr.h: Provided fallback for old constructor
-	when C++11 is not available (follow-up to #1003)
-	* inst/unitTests/runit.XPTr.R (test.XPtr): On Windows (as a proxy for
-	old compilers) do not test new feature
+        * inst/include/Rcpp/XPtr.h: Provided fallback for old constructor
+        when C++11 is not available (follow-up to #1003)
+        * inst/unitTests/runit.XPTr.R (test.XPtr): On Windows (as a proxy for
+        old compilers) do not test new feature
 
-	* tests/doRUnit.R: Protect printing to /tmp from Windows use
+        * tests/doRUnit.R: Protect printing to /tmp from Windows use
 
-	* vignettes/rmd/Rcpp.bib: Updated
-	* inst/bib/Rcpp.bib: Idem
+        * vignettes/rmd/Rcpp.bib: Updated
+        * inst/bib/Rcpp.bib: Idem
 
 2019-11-02  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/include/Rcpp/Reference.h: Shield Rf_mkstring inside Rf_lang2
-	* inst/include/Rcpp/Environment.h: Idem (inside Rf_lang4)
-	* inst/include/Rcpp/proxy/FieldProxy.h: Idem (inside Rf_lang3 and 4)
+        * inst/include/Rcpp/Reference.h: Shield Rf_mkstring inside Rf_lang2
+        * inst/include/Rcpp/Environment.h: Idem (inside Rf_lang4)
+        * inst/include/Rcpp/proxy/FieldProxy.h: Idem (inside Rf_lang3 and 4)
 
 2019-10-31  Romain Francois  <romain@rstudio.com>
 
-	* inst/include/Rcpp/DataFrame.h: Protect temporaries from gc
-	* inst/include/Rcpp/Environment.h: Idem
-	* inst/include/Rcpp/r_cast.h: Idem
+        * inst/include/Rcpp/DataFrame.h: Protect temporaries from gc
+        * inst/include/Rcpp/Environment.h: Idem
+        * inst/include/Rcpp/r_cast.h: Idem
 
 2019-10-27  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/unitTests/runit.exposeClass.R: Updated to pass with r-devel
+        * inst/unitTests/runit.exposeClass.R: Updated to pass with r-devel
 
-	* vignettes/rmd/Rcpp-FAQ.Rmd: Two new short section on speedier
-	compilation and lack of exceptions / stop() across shared libraries
+        * vignettes/rmd/Rcpp-FAQ.Rmd: Two new short section on speedier
+        compilation and lack of exceptions / stop() across shared libraries
 
 2019-10-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-package.Rnw: Another wrapper
-	* vignettes/Rcpp-jss-2011.Rnw: Idem
+        * vignettes/Rcpp-package.Rnw: Another wrapper
+        * vignettes/Rcpp-jss-2011.Rnw: Idem
 
-	* vignettes/Makefile: Refinements
-	* vignettes/rmd/Makefile: Idem
+        * vignettes/Makefile: Refinements
+        * vignettes/rmd/Makefile: Idem
 
-	* cleanup: Removed bashism, added invocation of make clean
+        * cleanup: Removed bashism, added invocation of make clean
 
 2019-10-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-*.Rnw: Wrappers around pdf/*pdf
-	* vignettes/Makefile: Added
+        * vignettes/Rcpp-*.Rnw: Wrappers around pdf/*pdf
+        * vignettes/Makefile: Added
 
 2019-10-21  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/rmd/*: Moved from parent directory
-	* vignettes/pdf/*: New target directory
+        * vignettes/rmd/*: Moved from parent directory
+        * vignettes/pdf/*: New target directory
 
 2019-10-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* vignettes/Rcpp-FAQ.Rmd: Turn off knitr cache
-	* vignettes/Rcpp-introduction.Rmd: Idem
+        * vignettes/Rcpp-FAQ.Rmd: Turn off knitr cache
+        * vignettes/Rcpp-introduction.Rmd: Idem
 
-	* vignettes/Makefile: Add simple Makefile
-	* .Rbuildignore: Exclude vignettes/Makefile
+        * vignettes/Makefile: Add simple Makefile
+        * .Rbuildignore: Exclude vignettes/Makefile
 
 2019-10-19  Stephen Wade  <stephematician@gmail.com>
 
-	* inst/include/Rcpp/XPtr.h: XPtr constructor split up, a single
-	argument does not modify tags and protected data of the external pointer
-	* inst/unitTests/cpp/Xptr.cpp: Added test
-	* inst/unitTests/runit.XPtr.R: Idem
+        * inst/include/Rcpp/XPtr.h: XPtr constructor split up, a single
+        argument does not modify tags and protected data of the external pointer
+        * inst/unitTests/cpp/Xptr.cpp: Added test
+        * inst/unitTests/runit.XPtr.R: Idem
 
 2019-10-14  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Added CRAN + BioConductor badges for reverse depends,
+        * README.md: Added CRAN + BioConductor badges for reverse depends,
 
 2019-10-11  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/exceptions.h: Condition use of typeid() on
-	absence of RCPP_NO_RTTI in two places
-	* inst/include/Rcpp/r/headers.h: RCPP_NO_RTTI implies RCPP_NO_MODULES
+        * inst/include/Rcpp/exceptions.h: Condition use of typeid() on
+        absence of RCPP_NO_RTTI in two places
+        * inst/include/Rcpp/r/headers.h: RCPP_NO_RTTI implies RCPP_NO_MODULES
 
 2019-10-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-attributes.Rmd: Correct two unevaluated knitr C++
-	chunks to mode 'Rcpp' rather than the (unregistered) C++ mode
-	* vignettes/Rcpp-extending.Rmd: Minor white-space tweak to avoid
-	paragraph-spacing warnings from latex and its mdframed style
-	* vignettes/Rcpp-modules.Rmd: Idem
-	* vignettes/Rcpp-sugar.Rmd: Idem
+        * vignettes/Rcpp-attributes.Rmd: Correct two unevaluated knitr C++
+        chunks to mode 'Rcpp' rather than the (unregistered) C++ mode
+        * vignettes/Rcpp-extending.Rmd: Minor white-space tweak to avoid
+        paragraph-spacing warnings from latex and its mdframed style
+        * vignettes/Rcpp-modules.Rmd: Idem
+        * vignettes/Rcpp-sugar.Rmd: Idem
 
 2019-10-01  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
 2019-09-30  Kevin Ushey  <kevinushey@gmail.com>
 
-	* inst/include/Rcpp.h: add RCPP_NO_MODULES
-	* inst/include/Rcpp/api/meat/is.h: Idem
-	* inst/include/Rcpp/api/meat/meat.h: Idem
+        * inst/include/Rcpp.h: add RCPP_NO_MODULES
+        * inst/include/Rcpp/api/meat/is.h: Idem
+        * inst/include/Rcpp/api/meat/meat.h: Idem
 
 2019-09-28  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Add a stackoverflow tag to indicate where to ask questions,
-	also updated package counts on CRAN and BioC for Rcpp users
+        * README.md: Add a stackoverflow tag to indicate where to ask questions,
+        also updated package counts on CRAN and BioC for Rcpp users
 
 2019-08-06  Riccardo Porreca  <riccardo.porreca@mirai-solutions.com>
 
-	* vignettes/Rcpp-modules.Rmd: Extensive review and edit improving the
-	Modules vignette
+        * vignettes/Rcpp-modules.Rmd: Extensive review and edit improving the
+        Modules vignette
 
 2019-08-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Add thre doi badges
+        * README.md: Add thre doi badges
 
-	* inst/NEWS.Rd: Two minor edits
+        * inst/NEWS.Rd: Two minor edits
 
 2019-07-21  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
 2019-07-21  Riccardo Porreca  <riccardo.porreca@mirai-solutions.com>
 
-	* R/Module.R: Use an explicit Rcpp:: in the initalize method for C++
-	classes wrapped inside modules to ensure proper initialization
+        * R/Module.R: Use an explicit Rcpp:: in the initalize method for C++
+        classes wrapped inside modules to ensure proper initialization
 
 2019-07-20  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -558,82 +558,82 @@
 
 2019-07-18  Pierrick Roger  <pk.roger@icloud.com>
 
-	* src/attributes.cpp: Correct parsing of default function values
-	* inst/unitTests/cpp/attributes.cpp: Added tests
-	* inst/unitTests/runit.attributes.R: Idem
+        * src/attributes.cpp: Correct parsing of default function values
+        * inst/unitTests/cpp/attributes.cpp: Added tests
+        * inst/unitTests/runit.attributes.R: Idem
 
 2019-07-16  Dirk Eddelbuettel  <edd@debian.org>
 
-	* debian/: Removed, see https://salsa.debian.org/edd/r-base/ instead
+        * debian/: Removed, see https://salsa.debian.org/edd/r-base/ instead
 
 2019-07-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp.bib: Updated
-	* inst/bib/Rcpp.bib: Idem
+        * vignettes/Rcpp.bib: Updated
+        * inst/bib/Rcpp.bib: Idem
 
 2019-05-05  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .Rbuildignore: Small tweak
+        * .Rbuildignore: Small tweak
 
 2019-04-27  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Use getRcppVersion()
+        * R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Use getRcppVersion()
 
 2019-04-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* R/tools.R (getRcppVersion): More idiomatic code
+        * R/tools.R (getRcppVersion): More idiomatic code
 
 2019-04-25  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/tools.R (getRcppVersion): Export R (and dev) package version
-	* man/getRcppVersion.Rd: Documentation for new function
+        * R/tools.R (getRcppVersion): Export R (and dev) package version
+        * man/getRcppVersion.Rd: Documentation for new function
 
-	* inst/include/Rcpp/config.h (RCPP_VERSION_STRING): New version
-	and development version string #define
-	* src/api.cpp (getRcppVersionStrings): Expose new versions strings
-	* src/internal.h: Register new version string exporter
-	* src/rcpp_init.cpp (callEntries[]): Idem
+        * inst/include/Rcpp/config.h (RCPP_VERSION_STRING): New version
+        and development version string #define
+        * src/api.cpp (getRcppVersionStrings): Expose new versions strings
+        * src/internal.h: Register new version string exporter
+        * src/rcpp_init.cpp (callEntries[]): Idem
 
-	* inst/unitTests/runit.misc.R (test.getRcppVersion): test new function
+        * inst/unitTests/runit.misc.R (test.getRcppVersion): test new function
 
 2019-03-23  Ralf Stubner  <ralf.stubner@daqana.com>
 
-	* vignettes/Rcpp-modules.Rmd: Describe RCPP_EXPOSED_* macros
-	* vignettes/Rcpp-extending.Rmd: Reference Modules extensions
+        * vignettes/Rcpp-modules.Rmd: Describe RCPP_EXPOSED_* macros
+        * vignettes/Rcpp-extending.Rmd: Reference Modules extensions
 
 2019-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/NEWS.Rd: Updated
+        * inst/NEWS.Rd: Updated
 
 2019-03-20  James J Balamuta  <balamut2@illinois.edu>
 
-	* inst/include/Rcpp/sugar/functions/unique.h: Added decreasing
-	parameter to control sort.
-	* inst/unitTests/runit.sugar.R: Added sort_unique() tests
-	* inst/unitTests/cpp/sugar.cpp: Ditto
+        * inst/include/Rcpp/sugar/functions/unique.h: Added decreasing
+        parameter to control sort.
+        * inst/unitTests/runit.sugar.R: Added sort_unique() tests
+        * inst/unitTests/cpp/sugar.cpp: Ditto
 
 2019-03-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* src/date.cpp: Renamed from Date.cpp
-	* src/module.cpp: Renamed from Module.cpp
-	* src/rcpp_init.cpp: Renamed from Rcpp_init.cpp
+        * src/date.cpp: Renamed from Date.cpp
+        * src/module.cpp: Renamed from Module.cpp
+        * src/rcpp_init.cpp: Renamed from Rcpp_init.cpp
 
 2019-03-19  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* tests/doRUnit.R: On Travis always set RunAllRcppTests
+        * tests/doRUnit.R: On Travis always set RunAllRcppTests
 
-	* docker/ci/Dockerfile: Set environment variables container-wide
+        * docker/ci/Dockerfile: Set environment variables container-wide
 
 2019-03-18  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/macros/macros.h (END_RCPP_RETURN_ERROR): Add
-	UNPROTECT to reference nprot, also check for stop_sym
+        * inst/include/Rcpp/macros/macros.h (END_RCPP_RETURN_ERROR): Add
+        UNPROTECT to reference nprot, also check for stop_sym
 
 2019-03-17  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -646,77 +646,77 @@
 
 2019-03-16  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): Roll minor version
+        * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/unitTests/runit.sugar.R: Set the sample() behaviour to R 3.5.0
-	as R 3.6.0 has a breaking change (for the better)
+        * inst/unitTests/runit.sugar.R: Set the sample() behaviour to R 3.5.0
+        as R 3.6.0 has a breaking change (for the better)
 
 2019-03-13  Romain François <romain@purrple.cat>
 
-	* inst/include/Rcpp/macros/macros.h: Add UNPROTECT to please rchk
+        * inst/include/Rcpp/macros/macros.h: Add UNPROTECT to please rchk
 
 2019-03-12  Romain François <romain@purrple.cat>
 
-	* inst/include/Rcpp/api/meat/proxy.h: AttributeProxy::set() with
-	Shield<> and a few related uses of Shield<> to please rchk
-	* inst/include/Rcpp/clone.h: Idem
-	* inst/include/Rcpp/proxy/AttributeProxy.h: Idem
-	* inst/include/Rcpp/proxy/NamesProxy.h: Idem
-	* inst/include/Rcpp/vector/Matrix.h: Idem
-	* inst/include/Rcpp/vector/Vector.h: Idem
+        * inst/include/Rcpp/api/meat/proxy.h: AttributeProxy::set() with
+        Shield<> and a few related uses of Shield<> to please rchk
+        * inst/include/Rcpp/clone.h: Idem
+        * inst/include/Rcpp/proxy/AttributeProxy.h: Idem
+        * inst/include/Rcpp/proxy/NamesProxy.h: Idem
+        * inst/include/Rcpp/vector/Matrix.h: Idem
+        * inst/include/Rcpp/vector/Vector.h: Idem
 
 2019-02-25  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml (after_success): Setting CODECOV_TOKEN to reenable
-	codecov.io coverage as detailed by Ralf in GitHub issue #941
+        * .travis.yml (after_success): Setting CODECOV_TOKEN to reenable
+        codecov.io coverage as detailed by Ralf in GitHub issue #941
 
 2019-02-16  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/sugar/functions/cbind.h: Converted CRLF to CR
+        * inst/include/Rcpp/sugar/functions/cbind.h: Converted CRLF to CR
 
 2019-02-15  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/README: Moved stale file to local/
-	* inst/THANKS: Idem
+        * inst/README: Moved stale file to local/
+        * inst/THANKS: Idem
 
 2019-02-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): New minor version
+        * DESCRIPTION (Version, Date): New minor version
 
 2019-02-11  Kevin Ushey  <kevinushey@gmail.com>
 
-	* R/Attributes.R: better handle pre-existing RcppExports.cpp,
-	RcppExports.R when calling compileAttributes()
+        * R/Attributes.R: better handle pre-existing RcppExports.cpp,
+        RcppExports.R when calling compileAttributes()
 
 2019-02-09  Ralf Stubner  <ralf.stubner@daqana.com>
 
-	* Rcpp-modules.Rmd: Added example for .factory
+        * Rcpp-modules.Rmd: Added example for .factory
 
 2019-01-31  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/protection/Shelter.h (Rcpp): Only increase
-	nprotected count if object is not NULL (suggested by Stepan Sindelar)
+        * inst/include/Rcpp/protection/Shelter.h (Rcpp): Only increase
+        nprotected count if object is not NULL (suggested by Stepan Sindelar)
 
 2018-12-26  Zhuoer Dong  <dongzhuoer@mail.nankai.edu.cn>
 
-	* vignettes/Rcpp-quickref.Rmd: Fix three bugs: use `Named()`, define
-	`glob`, `glob.ls(TRUE)`.
+        * vignettes/Rcpp-quickref.Rmd: Fix three bugs: use `Named()`, define
+        `glob`, `glob.ls(TRUE)`.
 
 2018-12-01  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/Attributes.R: Added new 'c++2a' plugin for '-std=c++2a'
-	compilation standard supported by g++ 8 or later
+        * R/Attributes.R: Added new 'c++2a' plugin for '-std=c++2a'
+        compilation standard supported by g++ 8 or later
 
 2018-11-11  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/vector/Subsetter.h (check_indices): More
-	informative error message as suggested by KK
+        * inst/include/Rcpp/vector/Subsetter.h (check_indices): More
+        informative error message as suggested by KK
 
 2018-11-09  William Nolan  <will@landale.net>
 
         * inst/include/Rcpp/vector/Subsetter.h: Fixed to use R_xlen_t instead
-	of int for indexing and added warning when indexing by IntegerVector
-	(only for large enough vectors)
+        of int for indexing and added warning when indexing by IntegerVector
+        (only for large enough vectors)
 
 2018-11-05  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -729,78 +729,78 @@
 
 2018-11-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Date, Version): Roll minor version
-	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+        * DESCRIPTION (Date, Version): Roll minor version
+        * inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
 
-	* README.md: Updated stated package and test numbers
+        * README.md: Updated stated package and test numbers
 
 2018-10-25  Kevin Ushey  <kevinushey@gmail.com>
 
-	* inst/include/Rcpp/String.h: Use Rf_mkCharLenCE() as appropriate
-	* inst/unitTests/cpp/String.cpp: Add unit tests
-	* inst/unitTests/runit.String.R: Add unit tests
+        * inst/include/Rcpp/String.h: Use Rf_mkCharLenCE() as appropriate
+        * inst/unitTests/cpp/String.cpp: Add unit tests
+        * inst/unitTests/runit.String.R: Add unit tests
 
 2018-10-12  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Date, Version): Roll minor version
-	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+        * DESCRIPTION (Date, Version): Roll minor version
+        * inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
 
-	* tests/doRUnit.R: Simplified to something similar to what
-	RcppArmadillo (and other packages) had for a while now
+        * tests/doRUnit.R: Simplified to something similar to what
+        RcppArmadillo (and other packages) had for a while now
 
-	* vignettes/Rcpp-unitTests.Rnw: Removed as less useful now
+        * vignettes/Rcpp-unitTests.Rnw: Removed as less useful now
 
 2018-10-08  JJ Allaire  <jj@rstudio.com>
 
-	* R/Attributes.R: Sort the files scanned for attributes in the C locale
-	for stable output across systems.
+        * R/Attributes.R: Sort the files scanned for attributes in the C locale
+        for stable output across systems.
 
 2018-10-07  Ralf Stubner  <ralf.stubner@daqana.com>
 
         * vignettes/Rcpp-extending.Rmd: Correct EXPORT to EXPOSED in displays
-	of the corresponding macro, and remove two spurious semicolons
+        of the corresponding macro, and remove two spurious semicolons
 
 2018-10-02  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Date, Version): Roll minor version
-	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+        * DESCRIPTION (Date, Version): Roll minor version
+        * inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
 
 2018-10-02  Romain Francois  <romain@rstudio.com>
 
-	* inst/include/Rcpp/vector/Matrix.h: Init nrow in Matrix(no_init) ctor
-	* inst/unitTests/runit.Matrix.R: New test
-	* inst/unitTests/cpp/Matrix.cpp: Idem
+        * inst/include/Rcpp/vector/Matrix.h: Init nrow in Matrix(no_init) ctor
+        * inst/unitTests/runit.Matrix.R: New test
+        * inst/unitTests/cpp/Matrix.cpp: Idem
 
 2018-09-30  Dirk Eddelbuettel  <edd@debian.org>
 
-	* man/RcppUnitTests.Rd: Remove \details{} with conditional code which
-	R-devel (as of Sep 28) warns about as empty
+        * man/RcppUnitTests.Rd: Remove \details{} with conditional code which
+        R-devel (as of Sep 28) warns about as empty
 
 2018-09-28  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml (env): Set distinct build and check options to skip
-	tests of vignettes
+        * .travis.yml (env): Set distinct build and check options to skip
+        tests of vignettes
 
 2018-09-27  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version
 
-	* inst/include/Rcpp/date_datetime/Date.h: Remove the empty destructor
-	to make g++-9 (prerelease) happy [CRAN request]
+        * inst/include/Rcpp/date_datetime/Date.h: Remove the empty destructor
+        to make g++-9 (prerelease) happy [CRAN request]
 
-	* inst/unitTests/runit.Matrix.R: Correct typo
+        * inst/unitTests/runit.Matrix.R: Correct typo
 
 2018-09-27  Romain Francois  <romain@rstudio.com>
 
-	* inst/include/Rcpp/vector/Matrix.h: Fix Matrix(no_init(int,int))
-	constructor
-	* inst/unitTests/runit.Matrix.R: test for above
-	* inst/unitTests/cpp/Matrix.cpp: same
+        * inst/include/Rcpp/vector/Matrix.h: Fix Matrix(no_init(int,int))
+        constructor
+        * inst/unitTests/runit.Matrix.R: test for above
+        * inst/unitTests/cpp/Matrix.cpp: same
 
 2018-09-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/ci/Dockerfile: Set env var RunAllRcppTests=yes
-	* .travis.yml: Do not set env var here as needed in Docker
+        * docker/ci/Dockerfile: Set env var RunAllRcppTests=yes
+        * .travis.yml: Do not set env var here as needed in Docker
 
 2018-09-21  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -810,95 +810,95 @@
         * vignettes/Rcpp.bib: Idem
         * inst/include/Rcpp/config.h: Idem
 
-	* R/RcppLdpath.R (RcppLdPath, RcppLdFlags, CxxFlags, RcppCxx0xFlags):
-	After discussion with CRAN, do not mark as .Deprecated() as too many
-	packages are involved. This will need to be phased in more slowly.
+        * R/RcppLdpath.R (RcppLdPath, RcppLdFlags, CxxFlags, RcppCxx0xFlags):
+        After discussion with CRAN, do not mark as .Deprecated() as too many
+        packages are involved. This will need to be phased in more slowly.
 
 2018-09-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-FAQ.Rmd: Set 'eval=FALSE' on another
-	RcppArmadillo example to not create a build-time dependency
+        * vignettes/Rcpp-FAQ.Rmd: Set 'eval=FALSE' on another
+        RcppArmadillo example to not create a build-time dependency
 
 2018-09-18  JJ Allaire  <jj@rstudio.com>
 
-	* src/attributes.cpp: Add support for [[Rcpp::init]] attribute
-	* vignettes/Rcpp-attributes.Rmd: Documentation for [[Rcpp::init]]
-	attribute
+        * src/attributes.cpp: Add support for [[Rcpp::init]] attribute
+        * vignettes/Rcpp-attributes.Rmd: Documentation for [[Rcpp::init]]
+        attribute
 
 2018-09-17  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/r/headers.h: Define STRICT_R_HEADERS, but until
-	September 2019 protect by defining RCPP_NO_STRICT_HEADERS
+        * inst/include/Rcpp/r/headers.h: Define STRICT_R_HEADERS, but until
+        September 2019 protect by defining RCPP_NO_STRICT_HEADERS
 
-	* .travis.yml (env): Switch to rcpp/ci for ci use
+        * .travis.yml (env): Switch to rcpp/ci for ci use
 
 2018-09-15  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/ci/Dockerfile: Move Dockerfile to docker/ci
-	* docker/run/Dockerfile: Add deployment Dockerfile
-	* docker/plus/Dockerfile: Add 'plus-sized' Dockerfile suitable for
-	different add-on packages requiring Rcpp{Armadillo,Eigen,GSL} or BH
+        * docker/ci/Dockerfile: Move Dockerfile to docker/ci
+        * docker/run/Dockerfile: Add deployment Dockerfile
+        * docker/plus/Dockerfile: Add 'plus-sized' Dockerfile suitable for
+        different add-on packages requiring Rcpp{Armadillo,Eigen,GSL} or BH
 
 2018-09-02  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml: Switch to rcpp/rcpp-testing container
+        * .travis.yml: Switch to rcpp/rcpp-testing container
 
 2018-08-29  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml: Use Dockerfile
+        * .travis.yml: Use Dockerfile
 
 2018-08-28  Dirk Eddelbuettel  <edd@debian.org>
 
-	* docker/Dockerfile: Add Dockerfile for use by Travis CI
+        * docker/Dockerfile: Add Dockerfile for use by Travis CI
 
 2018-08-27  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
-	* man/Rcpp-deprecated.Rd: Fix two-char typo/thinko in \link{}
+        * man/Rcpp-deprecated.Rd: Fix two-char typo/thinko in \link{}
 
 2018-07-29  Dirk Eddelbuettel  <edd@debian.org>
 
-	* README.md: Refreshed via some edits and updates
+        * README.md: Refreshed via some edits and updates
 
         * DESCRIPTION (Version, Date): Roll minor version
         * inst/include/Rcpp/config.h: Idem
 
 2018-07-28  Dirk Eddelbuettel  <edd@debian.org>
 
-	* R/RcppLdpath.R (RcppLdPath, RcppLdFlags, CxxFlags, RcppLdFlags)
-	(RcppCxx0xFlags): Marked as deprecated
+        * R/RcppLdpath.R (RcppLdPath, RcppLdFlags, CxxFlags, RcppLdFlags)
+        (RcppCxx0xFlags): Marked as deprecated
 
-	* man/Rcpp-deprecated.Rd: Add exported functions LdFlags() and
-	RcppLdFlags() as deprecated
-	* man/RcppLdFlags.Rd: Idem
+        * man/Rcpp-deprecated.Rd: Add exported functions LdFlags() and
+        RcppLdFlags() as deprecated
+        * man/RcppLdFlags.Rd: Idem
 
 2018-07-27  Dirk Eddelbuettel  <edd@debian.org>
 
-	* man/loadRcppModules-deprecated.Rd: Fix typo; was deprecated in
-	0.12.5, not 0.16.5 which does not exist
+        * man/loadRcppModules-deprecated.Rd: Fix typo; was deprecated in
+        0.12.5, not 0.16.5 which does not exist
 
 2018-07-26  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-FAQ.Rmd: Use collapse: true
-	* vignettes/Rcpp-introduction.Rmd: Idem
+        * vignettes/Rcpp-FAQ.Rmd: Use collapse: true
+        * vignettes/Rcpp-introduction.Rmd: Idem
 
 2018-07-25  Dirk Eddelbuettel  <edd@debian.org>
 
-	* vignettes/Rcpp-extending.Rmd: Use collapse: true
+        * vignettes/Rcpp-extending.Rmd: Use collapse: true
 
 2018-07-24  Martin Lysy  <mlysy@uwaterloo.ca>
 
         * R/loadRcppClass.R: Search in R module for 'Class' instead of
-	'CppClass'.
+        'CppClass'.
         * R/exposeClass.R: Fixed 'rename' argument to work as expected.
         * inst/unitTests/runit.exposeClass.R: Added unit tests for the
-	above.
+        above.
 
 2018-07-23  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/bib/Rcpp.bib: More updates
+        * inst/bib/Rcpp.bib: More updates
         * vignettes/Rcpp.bib: Idem
 
 2018-07-21  Dirk Eddelbuettel  <edd@debian.org>
@@ -909,25 +909,25 @@
         * vignettes/Rcpp.bib: Idem
         * inst/include/Rcpp/config.h: Idem
 
-	* vignettes/Rcpp.bib: Updated other references
-	* inst/bib/Rcpp.bib: Idem
+        * vignettes/Rcpp.bib: Updated other references
+        * inst/bib/Rcpp.bib: Idem
 
-	* inst/unitTests/runit.sugar.R: Additional min, max unit tests
-	* inst/unitTests/cpp/sugar.cpp: Idem
+        * inst/unitTests/runit.sugar.R: Additional min, max unit tests
+        * inst/unitTests/cpp/sugar.cpp: Idem
 
 2018-07-20  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/include/Rcpp/sugar/functions/max.h: Also consider case of an
-	empty vector
-	* inst/include/Rcpp/sugar/functions/min.h: Idem
+        * inst/include/Rcpp/sugar/functions/max.h: Also consider case of an
+        empty vector
+        * inst/include/Rcpp/sugar/functions/min.h: Idem
 
 2018-07-19  Jack Wasey  <jack@jackwasey.com>
 
         * inst/include/Rcpp/r_cast.h: Error and abort if debugging for STRSXP
 2018-07-24  Martin Lysy  <mlysy@uwaterloo.ca>
-	* R/loadRcppClass.R: Search in R module for 'Class' instead of 'CppClass'.
-	* R/exposeClass.R: Fixed 'rename' argument to work as expected.
-	* inst/unitTests/runit.exposeClass.R: Added unit tests for the above.
+        * R/loadRcppClass.R: Search in R module for 'Class' instead of 'CppClass'.
+        * R/exposeClass.R: Fixed 'rename' argument to work as expected.
+        * inst/unitTests/runit.exposeClass.R: Added unit tests for the above.
 
 2018-07-12  Dirk Eddelbuettel  <edd@debian.org>
 
@@ -936,8 +936,8 @@
 
 2018-07-12  Jack Wasey  <jack@jackwasey.com>
 
-	* R/Attributes.R: Use case-insensitive sort of filenames to make
-	RcppExports more deterministic
+        * R/Attributes.R: Use case-insensitive sort of filenames to make
+        RcppExports more deterministic
 
 2018-07-10  Lionel Henry  <lionel@rstudio.com>
 
@@ -950,8 +950,8 @@
 
 2018-07-09  Dirk Eddelbuettel  <edd@debian.org>
 
-	* src/Date.cpp: Skip 'tm_gmtoff' on AIX as well (thanks to PR 876
-	by @ayappanec)
+        * src/Date.cpp: Skip 'tm_gmtoff' on AIX as well (thanks to PR 876
+        by @ayappanec)
 
 2018-07-05  Lionel Henry  <lionel@rstudio.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2020-04-30  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 	* vignettes/rmd/Rcpp-libraries.Rmd: Add new vignette source
 	* vignettes/rmd/Rcpp.bib: Complete references
         * inst/bib/Rcpp.bib: Idem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.4.9
-Date: 2020-04-26
+Version: 1.0.4.10
+Date: 2020-04-30
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -37,7 +37,9 @@
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The pdf file of the earlier introduction is again typeset
-      with bibliographic information. (Dirk)
+      with bibliographic information (Dirk).
+      \item A new vignette describing how to package C++ libraries has
+      been added (Dirk in \ghpr{1078} fixing \ghit{1077}).
     }
     \item Changes in Rcpp Deployment:
     \itemize{

--- a/inst/bib/Rcpp.bib
+++ b/inst/bib/Rcpp.bib
@@ -450,6 +450,8 @@
   title =	 {Eigen v3},
   year =	 2012,
   url =		 {http://eigen.tuxfamily.org},
+  ; see http://eigen.tuxfamily.org/index.php?title=BibTeX
+  ; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 }
 
 @Manual{GSL,

--- a/inst/bib/Rcpp.bib
+++ b/inst/bib/Rcpp.bib
@@ -72,6 +72,15 @@
   url =          {http://www.icce.rug.nl/documents/cplusplus/}
 }
 
+@Manual{CRAN:BH,
+  title =        {BH: Boost C++ Header Files},
+  author =       {Dirk Eddelbuettel and John W. Emerson and Michael
+                  J. Kane},
+  year =         {2019},
+  note =         {R package version 1.69.0-1},
+  url =          {https://CRAN.R-project.org/package=BH},
+}
+
 @Manual{CRAN:Matrix,
   title =	 {\pkg{Matrix}: Sparse and Dense Matrix Classes and Methods},
   author =	 {Douglas Bates and Martin Maechler},
@@ -299,6 +308,15 @@
   url =		 CRAN # "package=minqa"
 }
 
+@Manual{CRAN:pkgKitten,
+  title =        {pkgKitten: Create Simple Packages Which Do not Upset
+                  R Package Checks},
+  author =       {Dirk Eddelbuettel},
+  year =         {2019},
+  note =         {R package version 0.1.5},
+  url =          CRAN # "package=pkgKitten"
+}
+
 @Manual{CRAN:profvis,
   title =        {profvis: Interactive Visualizations for Profiling R Code},
   author =       {Winston Chang and Javier Luraschi},
@@ -412,6 +430,8 @@
   address =	 {New York},
   isbn =	 {978-1-4614-6867-7}
 }
+; see http://eigen.tuxfamily.org/index.php?title=BibTeX
+; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 
 @article{Efron:1979:Bootstrap,
   URL =          {http://www.jstor.org/stable/2958830},
@@ -431,8 +451,6 @@
   year =	 2012,
   url =		 {http://eigen.tuxfamily.org},
 }
-; see http://eigen.tuxfamily.org/index.php?title=BibTeX
-; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 
 @Manual{GSL,
   title = 	{{GNU} {S}cientific {L}ibrary {R}eference {M}anual},
@@ -836,6 +854,7 @@
   address =	 {London},
 }
 
+
 @Book{Venables+Ripley:2000:SProgramming,
   author = 	 {Willian N. Venables and Brian D. Ripley},
   title = 	 {S Programming},
@@ -844,6 +863,7 @@
   series = 	 {Statistics and Computing},
   address = 	 {New York}
 }
+
 
 @Book{Venables+Ripley:2002:MASS,
   title =        {Modern Applied Statistics with S},
@@ -854,4 +874,31 @@
   year =         2002,
   note =         {ISBN 0-387-95457-0},
   url =          {http://www.stats.ox.ac.uk/pub/MASS4},
+}
+
+@misc{arxiv:corels,
+  title =        {Learning Certifiably Optimal Rule Lists for
+                  Categorical Data},
+  author =       {Elaine Angelino and Nicholas Larus-Stone and Daniel
+                  Alabi and Margo Seltzer and Cynthia Rudin},
+  year =         2017,
+  howpublished = {\href{http://www.arxiv.org/1704.01701}{arXiv:1704.01701}},
+  archivePrefix ={arXiv},
+  primaryClass = {stat.ML}
+}
+
+@Misc{github:corels,
+  author =       {Nicholas Laurus-Stone},
+  title =        {corels: {Learning Certifiably Optimal Rule Lists}},
+  howpublished = {\url{https://github.com/nlarusstone/corels}. Also online at \url{https://corels.eecs.harvard.edu/corels/}},
+  month =        06,
+  year =         2019
+}
+
+@Misc{github:rcppcorels,
+  author =       {Dirk Eddelbuettel},
+  title =        {RcppCorels: R binding for the 'Certifiably Optimal RulE ListS (Corels)' Learner},
+  howpublished = {\url{https://github.com/eddelbuettel/rcppcorels}},
+  month =        11,
+  year =         2019
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.4"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,9)
-#define RCPP_DEV_VERSION_STRING "1.0.4.9"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,10)
+#define RCPP_DEV_VERSION_STRING "1.0.4.10"
 
 #endif

--- a/vignettes/Makefile
+++ b/vignettes/Makefile
@@ -10,6 +10,7 @@ rnwsources  = 		Rcpp-attributes.Rnw \
 			Rcpp-FAQ.Rnw \
 			Rcpp-introduction.Rnw \
 			Rcpp-jss-2011.Rnw \
+			Rcpp-libraries.Rnw \
 			Rcpp-modules.Rnw \
 			Rcpp-package.Rnw \
 			Rcpp-quickref.Rnw \
@@ -20,6 +21,7 @@ rnwvignettes  = 	Rcpp-attributes.pdf \
 			Rcpp-FAQ.pdf \
 			Rcpp-introduction.pdf \
 			Rcpp-jss-2011.pdf \
+			Rcpp-libraries.pdf \
 			Rcpp-modules.pdf \
 			Rcpp-package.pdf \
 			Rcpp-quickref.pdf \

--- a/vignettes/Rcpp-libraries.Rnw
+++ b/vignettes/Rcpp-libraries.Rnw
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{pdfpages}
+%\VignetteIndexEntry{Rcpp-libraries}
+%\VignetteKeywords{Rcpp, Package, Library}
+%\VignettePackage{Rcpp}
+%\VignetteEncoding{UTF-8}
+
+\begin{document}
+\includepdf[pages=-, fitpaper=true]{pdf/Rcpp-libraries.pdf}
+\end{document}

--- a/vignettes/rmd/Rcpp-libraries.Rmd
+++ b/vignettes/rmd/Rcpp-libraries.Rmd
@@ -1,0 +1,394 @@
+---
+title: Thirteen Simple Steps for Creating An R Package with an External C++ Library
+
+# Use letters for affiliations
+author:
+  - name: Dirk Eddelbuettel
+    affiliation: 1
+
+address:
+  - code: 1
+    address: Department of Statistics, University of Illinois, Urbana-Champaign, IL, USA
+
+# For footer text  TODO(fold into template, allow free form two-authors)
+lead_author_surname: Eddelbuettel
+
+# Place DOI URL or CRAN Package URL here
+#doi: "https://cran.r-project.org/package=anytime"
+
+# Abstract
+abstract: |
+  We desribe how we extend R with an external C++ code library by using the Rcpp
+  package. Our working example uses the recent machine learning library and application
+  'Corels' providing optimal yet easily interpretable rule lists \citep{arxiv:corels}
+  which we bring to R in the form of the \pkg{RcppCorels} package
+  \citep{github:rcppcorels}. We discuss each step in the process, and derive a set of
+  simple rules and recommendations which are illustrated with the concrete example.
+
+
+# Font size of the document, values of 9pt (default), 10pt, 11pt and 12pt
+fontsize: 9pt
+
+# Optional: Force one-column layout, default is two-column
+two_column: true
+
+# Optional: Enables lineno mode, but only if one_column mode is also true
+#lineno: true
+
+# Optional: Enable one-sided layout, default is two-sided
+#one_sided: true
+
+# Optional: Enable section numbering, default is unnumbered
+#numbersections: true
+
+# Optional: Specify the depth of section number, default is 5
+#secnumdepth: 5
+
+# Optional: Skip inserting final break between acknowledgements, default is false
+skip_final_break: true
+
+# Optional: Bibliography
+# bibliography: references
+
+# Optional: Enable a 'Draft' watermark on the document
+watermark: false
+
+# Customize footer, eg by referencing the vignette
+footer_contents: "Thirteen Steps for R and C++ Library Packages"
+
+# Produce a pinp document
+output:
+  pinp::pinp:
+    collapse: true
+    keep_tex: false
+
+header-includes: >
+  \newcommand{\proglang}[1]{\textsf{#1}}
+  \newcommand{\pkg}[1]{\textbf{#1}}
+
+vignette: >
+  %\VignetteIndexEntry{Rcpp-Libraries}
+  %\VignetteKeywords{Rcpp, Package, Library}
+  %\VignettePackage{Rcpp}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r initialsetup, include=FALSE}
+knitr::opts_chunk$set(cache=TRUE)
+cwd <- getwd()
+```
+
+# Introduction
+
+The process of building a new package with Rcpp can range from the very easy---a single
+simple C++ function---to the very complex. If, and how, external resources are utilised
+makes a big difference as this too can range from the very simple---making use of a
+header-only library, or directly including a few C++ source files without further
+dependencies---to the very complex. <!-- A recent example of a very involved build with
+dependencies on several external libraries which may not be packaged is the \pkg{arrow}
+package \citep{CRAN:arrow}. -->
+
+Yet a lot of the important action happens in the middle ground. Packages may bring their
+own source code, but also depend on just one or two external libraries. This paper
+describes one such approach in detail: how we turned the Corels application
+\citep{arxiv:corels,github:corels} (provided as a standalone C++-based executable) into an
+R-callable package \pkg{RcppCorels} \citep{github:rcppcorels} via \pkg{Rcpp}
+\citep{CRAN:Rcpp,JSS:Rcpp}.
+
+# The Thirteen Key Steps
+
+## Ensure Use of a Suitable license
+
+Before embarking on such a journey, it is best to ensure that the licensing framework is
+suitable. Many different open-source licenses exists, yet a few key ones dominate and can
+generally be used _with each other_.  There is however a fair amount of possible legalese
+involved, so it is useful to check inter-license compatibility, as well as general
+usability of the license in question. Several sites can help via license recommendations,
+and checks for interoperability. One example is the site at
+[choosealicense.com](https://choosealicense.com/) (which is backed by GitHub) can help, as
+can [tldrlegal.com](https://tldrlegal.com/).  License choice is a complex topic, and
+general recommendations are difficult to make besides the key point of sticking to
+already-established and known licenses.
+
+## Ensure the Software builds
+
+In order to see how hard it may to combine an external entity, either a program a library,
+with R, it helps to ensure that the external entity actually still builds and runs.
+
+This may seem like a small and obvious steps, but experience suggests that it worth
+asserting the ability to build with current tools, and possibly also with more than one
+compiler or build-system. Consideration to other platforms used by R also matter a great
+deal as one of the strengths of the R package system is its ability to cover the three key
+operating system families.
+
+## Ensure it still works
+
+This may seem like a variation on the previous point, but besides the ability to _build_
+we also need to ensure the ability to _run_ the software.  If the external entity has
+tests and demo, it is highly recommended to run them. If there are reference results, we
+should ensure that they are still obtained, and also that the run-time performance it
+still (at a minimum) reasonable.
+
+## Ensure it is compelling
+
+This is of course a very basic litmus test: is the new software relevant?  Is is helpful?
+Would others benefit from having it packaged and maintained?
+
+## Start an Rcpp package
+
+The first step in getting a new package combing R and C++ is often the creation of a new
+Rcpp package.  There are several helper functions to choose from. A natural first choice
+is `Rcpp.package.skeleton()` from the \pkg{Rcpp} package \citep{CRAN:Rcpp}. It can be
+improved by having the optional helper package \pkg{pkgKitten} \citep{CRAN:pkgKitten}
+around as its `kitten()` function smoothes some rougher edges left by the underlying Base
+R function `package.skeleton()`. This step is shown below in then appendix, and
+corresponds to the first commit, followed by a first edit of file `DESCRIPTION`.
+
+Any code added by the helper functions, often just a simple `helloWorld()` variant, can be
+run to ensure that the package is indeed functional. More importantly, at this stage, we
+can also start building the package as a compressed tar archive and run the R checker on
+it.
+
+## Integrate External Package
+
+Given a basic package with C++ support, we can now turn to integrating the external
+package.  This complexity of this step can, as alluded to earlier, vary from very easy to
+very complex.  Simple cases include just dependending on library headers which can either
+be copied to the package, or be provided by another package such as \pkg{BH}
+\citep{CRAN:BH}. It may also be a dependency on a fairly standard library available on
+most if not all systems.  The graphics formats bmp, jpeg or png may be example; text
+formats like JSON or XML are another.  One difficulty, though, may be that _run-time_
+support does not always guarantee _compile-time_ support. In these cases, a `-dev` or
+`-devel` package may need to be installed.
+
+In the concrete case of Corels, we
+
+- copied all existing C++ source and header files over into the `src/` directory;
+- renamed all header files from `*.hh` to `*.h` to comply with an R preference;
+- create a minimal `src/Makevars` file, initially with link instructions for GMP later relaxed to
+  conditional use of GMP (see below);
+- moved `main.cc` to a subdirectory as we cannot build with another `main()` function (and R will not include files from subdirectories);
+- added a minimal R-callable function along with a `logger` instance.
+
+Here, the last step was needed as the file `main.cc` provided a global instance referred
+to from other files. Hence, a minimal R-callable wrapper is being added at this stage
+(shown in the appendix as well). Actual functionality will be added later.
+
+We will come back to the step concerning the link instructions.
+
+As this point we have a package for R also containing the library we want to add.
+
+## Make the External Code compliant with R Policies
+
+R has fairly strict guidelines, defined both in the _CRAN Repository Policy_ document at
+the CRAN website, and in the manual _Writing R Extension_.  Certain standard C and C++
+functions are not permitted as their use could interfere with running code from R.  This
+includes somewhat obvious recommendations ("do not call `abort`" as it would terminate the
+R sessions) but extends to not using native print methods in order to cooperate better
+with the input and output facilities of R. So here, and reflecting that last aspect, we
+changed all calls to `printf()` to calls to `Rprintf()`.  Similarly, R prefers its own
+(well-tested) random-number generators so we replaced one (scaled) call to `random() /
+RAND_MAX` with the equivalent call to R's `unif_rand()`.  We also avoided one use of
+`stdout` in `rulelib.h`.
+
+The requirement for such changes may seem excessive at first, but the value added stemming
+from consistent application of the CRAN Policies is appreciated by most R users.
+
+## Complete the Interface
+
+In order to further test the package, and of course also for actual use, we need to expose
+the key parameters and arguments. Corels parsed command-line arguments; we can translate
+this directly into suitable arguments for the main function.  At a first pass, we created the
+following interface:
+
+```c++
+// [[Rcpp::export]]
+bool corels(std::string rules_file,
+            std::string labels_file,
+            std::string log_dir,
+            std::string meta_file = "",
+            bool run_bfs = false,
+            bool calculate_size = false,
+            bool run_curiosity = false,
+            int curiosity_policy = 0,
+            bool latex_out = false,
+            int map_type = 0,
+            int verbosity = 0,
+            int max_num_nodes = 100000,
+            double regularization = 0.01,
+            int logging_frequency = 1000,
+            int ablation = 0) {
+
+  // actual function body omitted
+}
+```
+
+Rcpp facilities the integration by adding another wrapper exposing all the function
+arguments, and setting up required arguments without default (the first three) along with
+optional arguments given a default.  The user can now call `corels()` from R with three
+required arguments (the two input files plus the log directory) as well as number of
+optional arguments.
+
+## Add Sample Data
+
+R package can access data files that are shipped with them.  That is very useful feature,
+and we therefore also copy in the files include in the Corels repository and its `data/`
+directory.
+
+```{r}
+fs::dir_tree("../../../rcppcorels/inst/sample_data")
+```
+
+## Set up working example
+
+Combining the two preceding steps, we can now offer an illustrative example. It is
+included in the helpd page for function `corels()` and can be run from R via
+`example("corels")`.
+
+```r
+library(RcppCorels)
+
+.sysfile <- function(f)   # helper function
+  system.file("sample_data",f,package="RcppCorels")
+
+rules_file <- .sysfile("compas_train.out")
+label_file <- .sysfile("compas_train.label")
+meta_file <- .sysfile("compas_train.minor")
+logdir <- tempdir()
+
+stopifnot(file.exists(rules_file),
+          file.exists(labels_file),
+          file.exists(meta_file),
+          dir.exists(logdir))
+
+corels(rules_file, labels_file, logdir, meta_file,
+       verbosity = 100,
+       regularization = 0.015,
+       curiosity_policy = 2,   # by lower bound
+       map_type = 1) 	       # permutation map
+
+cat("See ", logdir, " for result file.")
+```
+
+In the example, we pass the two required arguments for rules and labels files, the
+optional argument for the 'meta' file as well as an added required argument for the output
+directory.  R policy prohibits writing in user-directories, we default to using the
+temporary directory of the current session, and report its value at the end.  For other
+arguments default values are used.
+
+## Finesse Library Dependencies
+
+One common difficulty when bringing an extermal library to R via a package consists in dealing with
+an external dependency. In the case of 'Corels', the GNU GMP library for multi-precision arithmetic
+is an optional extension which, if available, improves and accelerates internal processing.
+
+The simplest approach is to declare a compile-time variable in the `src/Makevars` file. Using
+`-DGMP` _defines_ the `GMP` variable at the level of the C and C++ code. One can then condition on
+the variable. A very standard approach, also used here is `#if defined(GMP) ... #else ... #endif`
+where one of the two code branches is in effect depending on whether the `GMP` variable is defined
+or not.
+
+In order to detect presence of a required (or optional) library, tools like 'autoconf' or 'cmake'
+are often used.  For example, one can rely of an existing 'autoconf' macro provided by the GMP
+documentation to detect presence of the the GNU GMP header and library. We are making use of this
+facility here to deploy GMP when it is available.  As 'Corels' can be built with and without GMP,
+the build and installation succeeds either way---but deployment of the more-featureful variant with
+use GMP is automated.
+
+## Finalise License and Copyright
+
+It is good (and common) practice to clearly attribute authorship. Here, credit is given to
+the 'Corels' team and authors as well as to the authors of the underlying 'rulelib' code
+used by 'Corels' via the file `inst/AUTHORS` (which will be installed as `AUTHORS` with
+the package. In addition, the file `inst/LICENSE` clarifies the GNU GPL-3 license for 'RcppCorels' and 'Corels', and the MIT license for 'rulelib'.
+
+## Additional Bonus: Some more 'meta' files
+
+Several files help to improve the package. For example, `.Rbuildignore` allows to exclude
+listed files from the resulting R package keeping it well-defined. Similarly, `.gitignore`
+can exclude files from being added to the `git` repository.  We also like `.editorconfig`
+for consistent editing default across a range of modern editors.
+
+# Summary
+
+We describe s series of steps to turn the standalone library 'Corels' describes by
+\citet{arxiv:corels} into a R package \pkg{RcppCorels} using the facilities offered by
+\pkg{Rcpp} \citep{CRAN:Rcpp}.  Along the way, we illustrate key aspects of the R package
+standards and CRAN Repository Policy proving a template for other research software
+wishing to provide their implementations in a form that is accessibly by R users.
+
+
+\bibliography{Rcpp}
+\bibliographystyle{jss}
+
+\newpage
+\onecolumn
+
+## Appendix 1: Creating the basic package
+
+```sh
+edd@rob:~/git$ r --packages Rcpp --eval 'Rcpp.package.skeleton("RcppCorels")'
+
+Attaching package: ‘utils’
+
+The following objects are masked from ‘package:Rcpp’:
+
+    .DollarNames, prompt
+
+Creating directories ...
+Creating DESCRIPTION ...
+Creating NAMESPACE ...
+Creating Read-and-delete-me ...
+Saving functions and data ...
+Making help files ...
+Done.
+Further steps are described in './RcppCorels/Read-and-delete-me'.
+
+Adding Rcpp settings
+ >> added Imports: Rcpp
+ >> added LinkingTo: Rcpp
+ >> added useDynLib directive to NAMESPACE
+ >> added importFrom(Rcpp, evalCpp) directive to NAMESPACE
+ >> added example src file using Rcpp attributes
+ >> added Rd file for rcpp_hello_world
+ >> compiled Rcpp attributes
+edd@rob:~/git$
+edd@rob:~/git$ mv RcppCorels/ rcppcorels  # prefer lowercase directories
+edd@rob:~/git$
+```
+
+## Appendix 2: A Minimal src/Makevars
+
+In the file shown here, use of GMP is unconditional: we define `GMP` as a compiler flag, and
+instruct the linker to link with the GMP library.
+
+```sh
+
+CXX_STD = CXX11
+
+PKG_CXXFLAGS = -I. -DGMP
+
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) -lgmp
+
+```
+
+## Appendix 3: A Placeholder Wrapper
+
+```c++
+
+#include "queue.h"
+
+#include <Rcpp.h>
+
+/*
+ * Logs statistics about the execution of the algorithm and dumps it to a file.
+ * To turn off, pass verbosity <= 1
+ */
+NullLogger* logger;
+
+// [[Rcpp::export]]
+bool corels() {
+  return true;                  // more to fill in, naturally
+}
+```

--- a/vignettes/rmd/Rcpp-libraries.Rmd
+++ b/vignettes/rmd/Rcpp-libraries.Rmd
@@ -14,7 +14,7 @@ address:
 lead_author_surname: Eddelbuettel
 
 # Place DOI URL or CRAN Package URL here
-#doi: "https://cran.r-project.org/package=anytime"
+doi_footer: "https://arxiv.org/abs/1911.06416"
 
 # Abstract
 abstract: |

--- a/vignettes/rmd/Rcpp.bib
+++ b/vignettes/rmd/Rcpp.bib
@@ -450,6 +450,8 @@
   title =	 {Eigen v3},
   year =	 2012,
   url =		 {http://eigen.tuxfamily.org},
+  ; see http://eigen.tuxfamily.org/index.php?title=BibTeX
+  ; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 }
 
 @Manual{GSL,

--- a/vignettes/rmd/Rcpp.bib
+++ b/vignettes/rmd/Rcpp.bib
@@ -72,6 +72,15 @@
   url =          {http://www.icce.rug.nl/documents/cplusplus/}
 }
 
+@Manual{CRAN:BH,
+  title =        {BH: Boost C++ Header Files},
+  author =       {Dirk Eddelbuettel and John W. Emerson and Michael
+                  J. Kane},
+  year =         {2019},
+  note =         {R package version 1.69.0-1},
+  url =          {https://CRAN.R-project.org/package=BH},
+}
+
 @Manual{CRAN:Matrix,
   title =	 {\pkg{Matrix}: Sparse and Dense Matrix Classes and Methods},
   author =	 {Douglas Bates and Martin Maechler},
@@ -299,6 +308,15 @@
   url =		 CRAN # "package=minqa"
 }
 
+@Manual{CRAN:pkgKitten,
+  title =        {pkgKitten: Create Simple Packages Which Do not Upset
+                  R Package Checks},
+  author =       {Dirk Eddelbuettel},
+  year =         {2019},
+  note =         {R package version 0.1.5},
+  url =          CRAN # "package=pkgKitten"
+}
+
 @Manual{CRAN:profvis,
   title =        {profvis: Interactive Visualizations for Profiling R Code},
   author =       {Winston Chang and Javier Luraschi},
@@ -412,6 +430,8 @@
   address =	 {New York},
   isbn =	 {978-1-4614-6867-7}
 }
+; see http://eigen.tuxfamily.org/index.php?title=BibTeX
+; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 
 @article{Efron:1979:Bootstrap,
   URL =          {http://www.jstor.org/stable/2958830},
@@ -431,8 +451,6 @@
   year =	 2012,
   url =		 {http://eigen.tuxfamily.org},
 }
-; see http://eigen.tuxfamily.org/index.php?title=BibTeX
-; replaced 'howpublished' with 'url' and updated year to 2011, and again to 2012
 
 @Manual{GSL,
   title = 	{{GNU} {S}cientific {L}ibrary {R}eference {M}anual},
@@ -836,6 +854,7 @@
   address =	 {London},
 }
 
+
 @Book{Venables+Ripley:2000:SProgramming,
   author = 	 {Willian N. Venables and Brian D. Ripley},
   title = 	 {S Programming},
@@ -844,6 +863,7 @@
   series = 	 {Statistics and Computing},
   address = 	 {New York}
 }
+
 
 @Book{Venables+Ripley:2002:MASS,
   title =        {Modern Applied Statistics with S},
@@ -854,4 +874,31 @@
   year =         2002,
   note =         {ISBN 0-387-95457-0},
   url =          {http://www.stats.ox.ac.uk/pub/MASS4},
+}
+
+@misc{arxiv:corels,
+  title =        {Learning Certifiably Optimal Rule Lists for
+                  Categorical Data},
+  author =       {Elaine Angelino and Nicholas Larus-Stone and Daniel
+                  Alabi and Margo Seltzer and Cynthia Rudin},
+  year =         2017,
+  howpublished = {\href{http://www.arxiv.org/1704.01701}{arXiv:1704.01701}},
+  archivePrefix ={arXiv},
+  primaryClass = {stat.ML}
+}
+
+@Misc{github:corels,
+  author =       {Nicholas Laurus-Stone},
+  title =        {corels: {Learning Certifiably Optimal Rule Lists}},
+  howpublished = {\url{https://github.com/nlarusstone/corels}. Also online at \url{https://corels.eecs.harvard.edu/corels/}},
+  month =        06,
+  year =         2019
+}
+
+@Misc{github:rcppcorels,
+  author =       {Dirk Eddelbuettel},
+  title =        {RcppCorels: R binding for the 'Certifiably Optimal RulE ListS (Corels)' Learner},
+  howpublished = {\url{https://github.com/eddelbuettel/rcppcorels}},
+  month =        11,
+  year =         2019
 }


### PR DESCRIPTION
As discussed in #1077, we have a [new vignette candidate](https://arxiv.org/abs/1911.06416). And there seems to be some support for including it. 

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
