### PR TITLE
remove erroneous PreserveObject call in String::wrap

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-05-17  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/String.h: don't preserve returned SEXP in wrap
+	* inst/include/RcppCommon.h: simplify
+
 2020-04-30  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -532,7 +532,6 @@ namespace Rcpp {
         RCPP_STRING_DEBUG("wrap<String>()");
         Shield<SEXP> res(Rf_allocVector(STRSXP, 1));
         SEXP data = object.get_sexp();
-        Rcpp_PreserveObject(data);
         SET_STRING_ELT(res, 0, data);
         return res;
     }

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -101,22 +101,13 @@ namespace Rcpp {
     }
 
     inline SEXP Rcpp_ReplaceObject(SEXP x, SEXP y) {
-        if (Rf_isNull(x)) {
+
+        // if we are setting to the same SEXP as we already have, do nothing
+        if (x != y) {
+            Rcpp_ReleaseObject(x);
             Rcpp_PreserveObject(y);
-        } else if (Rf_isNull(y)) {
-            Rcpp_ReleaseObject(x); 	// #nocov
-        } else {
-            // if we are setting to the same SEXP as we already have, do nothing
-            if (x != y) {
-
-                // the previous SEXP was not NULL, so release it
-                Rcpp_ReleaseObject(x);
-
-                // the new SEXP is not NULL, so preserve it
-                Rcpp_PreserveObject(y);
-
-            }
         }
+
         return y;
     }
 


### PR DESCRIPTION
Part of https://github.com/RcppCore/Rcpp/issues/1081.

This PR fixes an issue where `String::wrap()` would un-necessarily call `Rcpp_PreserveObject()`, thereby 'leaking' the SEXP returned to R (basically, not allowing the R GC to ever collect that object).

Unfortunately it doesn't fix https://github.com/RcppCore/Rcpp/issues/1081 but I do think it's at least part of the issue.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
