### PR TITLE
Added support for std::string_view to Rcpp::as

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-05-28  Adam Cozzette  <acozzette@google.com>
+
+        * inst/include/Rcpp/as.h: Added support for std::string_view
+        * inst/include/Rcpp/traits/r_type_traits.h: Idem
+
 2020-05-18  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/as.h
+++ b/inst/include/Rcpp/as.h
@@ -71,6 +71,10 @@ namespace Rcpp {
             return as_string<T>(x, typename Rcpp::traits::is_wide_string<T>::type());
         }
 
+        template <typename T> T as(SEXP x, ::Rcpp::traits::r_type_string_view_tag) {
+            return check_single_string(x);
+        }
+
         template <typename T> T as(SEXP x, ::Rcpp::traits::r_type_RcppString_tag) {
             if (! ::Rf_isString(x)) {
                 const char* fmt = "Expecting a single string value: "

--- a/inst/include/Rcpp/traits/r_type_traits.h
+++ b/inst/include/Rcpp/traits/r_type_traits.h
@@ -23,6 +23,10 @@
 #ifndef Rcpp__traits__r_type_traits__h
 #define Rcpp__traits__r_type_traits__h
 
+#if defined(__cpp_lib_string_view)
+#include <string_view>
+#endif
+
 namespace Rcpp{
 namespace traits{
 
@@ -37,6 +41,12 @@ struct r_type_primitive_tag{} ;
  * to std::string
  */
 struct r_type_string_tag{} ;
+
+/**
+ * Identifies that the associated type can be implicitly converted
+ * to std::string_view
+ */
+struct r_type_string_view_tag{} ;
 
 /**
  * Default
@@ -148,6 +158,10 @@ template<> struct r_type_traits<unsigned int>{ typedef r_type_primitive_tag r_ca
 template<> struct r_type_traits<float>{ typedef r_type_primitive_tag r_category ; } ;
 template<> struct r_type_traits<const char*>{ typedef r_type_string_tag r_category ; } ;
 template<> struct r_type_traits<const wchar_t*>{ typedef r_type_string_tag r_category ; } ;
+
+#if defined(__cpp_lib_string_view)
+template<> struct r_type_traits<std::string_view>{ typedef r_type_string_view_tag r_category ; } ;
+#endif
 
 /* long */
 template<> struct r_type_traits<long>{ typedef r_type_primitive_tag r_category ; } ;


### PR DESCRIPTION
Fixes #1084.

This commit adds support for std::string_view to Rcpp::as. The
std::string_view type is only available starting with C++17, but I
guarded it with the necessary ifdef so that we do not rely on it unless
it's available.