### PR TITLE
correct package skeleton behavior (closes #1087)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2020-06-05  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 	* R/Rcpp.package.skeleton.R: Remove a remaining NAMESPACE entry for
 	a temporary function symbol; ensure an exportPattern is set
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-06-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Rcpp.package.skeleton.R: Remove a remaining NAMESPACE entry for
+	a temporary function symbol; ensure an exportPattern is set
+
 2020-05-18  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.4.11
-Date: 2020-05-18
+Version: 1.0.4.12
+Date: 2020-06-05
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 - 2019  Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2009 - 2020  Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -27,7 +27,6 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
                                   license = "GPL (>= 2)") {
 
     havePkgKitten <- requireNamespace("pkgKitten", quietly=TRUE)
-
 
     call <- match.call()
     call[[1]] <- as.name("package.skeleton")
@@ -115,6 +114,9 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
     } else {
         writeLines('importFrom(Rcpp, evalCpp)', ns)
         message(" >> added importFrom(Rcpp, evalCpp) directive to NAMESPACE" )
+    }
+    if (!any(grepl("^exportPattern", lines))) {
+        writeLines("exportPattern(\"^[[:alpha:]]+\")", ns)
     }
     close( ns )
 
@@ -206,6 +208,11 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
         rm("Rcpp.fake.fun", envir = env)
         unlink(file.path(root, "R"  , "Rcpp.fake.fun.R"))
         unlink(file.path(root, "man", "Rcpp.fake.fun.Rd"))
+
+        ## cleansing NAMESPACE of fake function entry
+        lines <- readLines(NAMESPACE)
+        lines <- lines[!grepl("^export.*fake\\.fun", lines)]
+        writeLines(lines, NAMESPACE)
     }
 
     if (isTRUE(remove_hello_world)) {

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.4"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,11)
-#define RCPP_DEV_VERSION_STRING "1.0.4.11"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,4,12)
+#define RCPP_DEV_VERSION_STRING "1.0.4.12"
 
 #endif


### PR DESCRIPTION
This is in relation to #1087 and the fact that the 'package creation helper' (both functions such as `Rcpp.package.skeleton()` and `RcppArmadillo.package.skeleton()` _and_ the functionality accessible from RStudio via File -> New Project -> Package) suffers from an issue in NAMESPACE.

The fix is simple and gets to it based on my testing today, but someone else should have a look at it.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
