### PR TITLE
simple change to define a Docker target for R 3.6.3

### DIFF
--- a/docker/ci-3.6/Dockerfile
+++ b/docker/ci-3.6/Dockerfile
@@ -1,0 +1,17 @@
+## Emacs, make this -*- mode: sh; -*-
+
+FROM r-base:3.6.3
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
+      maintainer="Dirk Eddelbuettel <edd@debian.org>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && install.r inline pkgKitten rbenchmark tinytest
+
+ENV _R_CHECK_FORCE_SUGGESTS_ FALSE
+ENV _R_CHECK_TESTS_NLINES_ 0
+ENV RunAllRcppTests yes
+
+CMD ["bash"]


### PR DESCRIPTION
This simply provides another Docker container template for previous release, R 3.6.*

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [ ] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)

I'll add the ChangeLog entry once merged and rebase into the other PR.