### PR TITLE
roll old versions from 3.4 + 3.5 to 3.5 + 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ jobs:
   include:
     - name: release
       env: DOCKER_CNTR="rcpp/ci" R="R" COVR="no"
-    - name: r-3.4
-      env: DOCKER_CNTR="rcpp/ci-3.4" R="R" COVR="no"
+    - name: r-3.6
+      env: DOCKER_CNTR="rcpp/ci-3.6" R="R" COVR="no"
     - name: r-3.5
       env: DOCKER_CNTR="rcpp/ci-3.5" R="R" COVR="no"
     - name: dev

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-06-07  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml (jobs): Replace R 3.4.3 with R 3.6.3 in matrix
+
 2020-06-05  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -57,6 +57,7 @@
       \item The exceptions test is now partially skipped on Solaris as
       it already is on Windows (Dirk in \ghpr{1065}).
       \item The default CI runner was upgraded to R 4.0.0 (Dirk).
+      \item The CI matrix spans R 3.5, 3.6, r-release and r-devel (Dirk).
     }
   }
 }


### PR DESCRIPTION
Fairly mechanical roll to new container for R 3.6.3

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
