### PR TITLE
Implement push_back and push_front for DataFrame.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,13 @@
         * inst/NEWS.Rd: Idem
         * vignettes/rmd/Rcpp.bib: Idem
         * inst/bib/Rcpp.bib: Idem
+2020-07-01 Walter Somerville <waltersom@gmail.com>
+	
+	* inst/include/Rcpp/DataFrame.h: Implement explict push_back and
+	push_front for DataFrame, which takes care to set the class and
+	row.names attributes.
+	* inst/tinyTest/test_dataframe.R Add in tests for push_back/push_front
+	* inst/tinyTest/cpp/DataFrame.cpp
 
 2020-06-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2020-07-09  Walter Somerville  <waltersom@gmail.com>
+
+	* inst/include/Rcpp/DataFrame.h: Warn when data.frame has varying length
+	* inst/tinyTest/cpp/DataFrame.cpp: Test added
+	* inst/tinyTest/test_dataframe.R: Idem
+
+2020-07-07  Walter Somerville  <waltersom@gmail.com>
+
+	* inst/include/Rcpp/DataFrame.h: Implement explict push_back and
+	push_front for DataFrame, which takes care to set the class and
+	row.names attributes.
+	* inst/tinyTest/test_dataframe.R: Add in tests for push_back/push_front
+	* inst/tinyTest/cpp/DataFrame.cpp: Idem
+
 2020-07-06  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version
@@ -17,13 +31,6 @@
         * inst/NEWS.Rd: Idem
         * vignettes/rmd/Rcpp.bib: Idem
         * inst/bib/Rcpp.bib: Idem
-2020-07-01 Walter Somerville <waltersom@gmail.com>
-	
-	* inst/include/Rcpp/DataFrame.h: Implement explict push_back and
-	push_front for DataFrame, which takes care to set the class and
-	row.names attributes.
-	* inst/tinyTest/test_dataframe.R: Add in tests for push_back/push_front
-	* inst/tinyTest/cpp/DataFrame.cpp: Idem
 
 2020-06-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,8 +22,8 @@
 	* inst/include/Rcpp/DataFrame.h: Implement explict push_back and
 	push_front for DataFrame, which takes care to set the class and
 	row.names attributes.
-	* inst/tinyTest/test_dataframe.R Add in tests for push_back/push_front
-	* inst/tinyTest/cpp/DataFrame.cpp
+	* inst/tinyTest/test_dataframe.R: Add in tests for push_back/push_front
+	* inst/tinyTest/cpp/DataFrame.cpp: Idem
 
 2020-06-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -85,38 +85,26 @@ namespace Rcpp{
 
 	template <typename T>
         void push_back( const T& object){
-            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
             Parent::push_back(object);
-            IntegerVector RowNames = Range(1, NewSize);
-            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
-            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+            set__(Parent::get__());
         }
 
         template <typename T>
         void push_back( const T& object, const std::string& name ){
-            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
             Parent::push_back(object, name);
-            IntegerVector RowNames = Range(1, NewSize);
-            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
-            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+            set__(Parent::get__());
         }
 
         template <typename T>
         void push_front( const T& object){
-            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
             Parent::push_front(object);
-            IntegerVector RowNames = Range(1, NewSize);
-            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
-            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+            set__(Parent::get__());
         }
 
         template <typename T>
         void push_front( const T& object, const std::string& name){
-            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
             Parent::push_front(object, name);
-            IntegerVector RowNames = Range(1, NewSize);
-            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
-            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+            set__(Parent::get__());
         }
                 
         // Offer multiple variants to accomodate both old interface here and signatures in other classes

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -142,7 +142,7 @@ namespace Rcpp{
                 }
             }
             for (it = Parent::begin(); it != Parent::end(); ++it) {
-                if (Rf_xlength(*it) > 1 && max_rows % Rf_xlength(*it) != 0) {
+                if (Rf_xlength(*it) == 0 || ( Rf_xlength(*it) > 1 && max_rows % Rf_xlength(*it) != 0 )) {
                     // We have a column that is not an integer fraction of the largest
                     invalid_column_size = true;
                 }

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -83,6 +83,42 @@ namespace Rcpp{
             return LENGTH(rn);
         }
 
+	template <typename T>
+        void push_back( const T& object){
+            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
+            Parent::push_back(object);
+            IntegerVector RowNames = Range(1, NewSize);
+            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
+            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+        }
+
+        template <typename T>
+        void push_back( const T& object, const std::string& name ){
+            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
+            Parent::push_back(object, name);
+            IntegerVector RowNames = Range(1, NewSize);
+            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
+            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+        }
+
+        template <typename T>
+        void push_front( const T& object){
+            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
+            Parent::push_front(object);
+            IntegerVector RowNames = Range(1, NewSize);
+            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
+            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+        }
+
+        template <typename T>
+        void push_front( const T& object, const std::string& name){
+            R_xlen_t NewSize = std::max(object.size(), static_cast<R_xlen_t>(nrow()));
+            Parent::push_front(object, name);
+            IntegerVector RowNames = Range(1, NewSize);
+            Rf_setAttrib(Parent::get__(), R_RowNamesSymbol, RowNames);
+            Rf_setAttrib(Parent::get__(), R_ClassSymbol, Rf_mkString("data.frame"));
+        }
+                
         // Offer multiple variants to accomodate both old interface here and signatures in other classes
         inline int nrows() const { return DataFrame_Impl::nrow(); }
         inline int rows()  const { return DataFrame_Impl::nrow(); }

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -94,3 +94,39 @@ IntegerVector DataFrame_nrow( DataFrame df){
 IntegerVector DataFrame_ncol( DataFrame df){
     return IntegerVector::create(df.ncol(), df.cols());
 }
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushBackNamed(){
+    NumericVector u(2);
+    NumericVector v(2);
+    DataFrame df = DataFrame::create(_["u"] = u);
+    df.push_back(v, "v");
+    return df;
+}
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushBackUnnamed(){
+    NumericVector u(2);
+    NumericVector v(2);
+    DataFrame df = DataFrame::create(_["u"] = u);
+    df.push_back(v);
+    return df;
+}
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushFrontNamed(){
+    NumericVector u(2);
+    NumericVector v(2);
+    DataFrame df = DataFrame::create(_["u"] = u);
+    df.push_front(v, "v");
+    return df;
+}
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushFrontUnnamed(){
+    NumericVector u(2);
+    NumericVector v(2);
+    DataFrame df = DataFrame::create(_["u"] = u);
+    df.push_front(v);
+    return df;
+}

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -177,8 +177,8 @@ DataFrame DataFrame_PushReplicateLength(){
   x[0] = 2;
 
   DataFrame df1 = DataFrame::create(_["u"] = u);
-  df1.push_back(v);
-  df1.push_back(x);
+  df1.push_back(v, "v");
+  df1.push_back(x, "x");
   return df1;
 }
 

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -130,3 +130,30 @@ DataFrame DataFrame_PushFrontUnnamed(){
     df.push_front(v);
     return df;
 }
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushFrontDataFrame(){
+  NumericVector u(2);
+  NumericVector v(2);
+  NumericVector w(2);
+  NumericVector x(2);
+
+  DataFrame df1 = DataFrame::create(_["u"] = u, _["v"] = v);
+  DataFrame df2 = DataFrame::create(_["w"] = w, _["x"] = x);
+  df1.push_front(df2);
+  return df1;
+}
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushBackDataFrame(){
+  NumericVector u(2);
+  NumericVector v(2);
+  NumericVector w(2);
+  NumericVector x(2);
+
+  DataFrame df1 = DataFrame::create(_["u"] = u, _["v"] = v);
+  DataFrame df2 = DataFrame::create(_["w"] = w, _["x"] = x);
+  df1.push_back(df2);
+  return df1;
+}
+

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -157,3 +157,27 @@ DataFrame DataFrame_PushBackDataFrame(){
   return df1;
 }
 
+// [[Rcpp::export]]
+DataFrame DataFrame_PushWrongSize(){
+  NumericVector u(2);
+  NumericVector v(3);
+
+  DataFrame df1 = DataFrame::create(_["u"] = u);
+  df1.push_back(v);
+  return df1;
+}
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushReplicateLength(){
+  NumericVector u(2);
+  NumericVector v(4);
+  NumericVector x(1);
+
+  u[0] = 1;
+  x[0] = 2;
+
+  DataFrame df1 = DataFrame::create(_["u"] = u);
+  df1.push_back(v);
+  df1.push_back(x);
+  return df1;
+}

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -181,3 +181,14 @@ DataFrame DataFrame_PushReplicateLength(){
   df1.push_back(x);
   return df1;
 }
+
+// [[Rcpp::export]]
+DataFrame DataFrame_PushZeroLength(){
+  NumericVector u(2);
+  NumericVector v(0);
+
+
+  DataFrame df1 = DataFrame::create(_["u"] = u);
+  df1.push_back(v);
+  return df1;
+}

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -77,7 +77,7 @@ expect_true( is.data.frame( DataFrame_PushBackNamed() ) )
 expect_equal( DataFrame_PushBackNamed(), df )
 
 #    test.DataFrame.PushBackUnamed <- function(){
-df <- data.frame( u = c(0, 0), c(0, 0), fix.empty.names = FALSE )
+df <- data.frame( u = c(0, 0), c(0, 0) )
 expect_true( is.data.frame( DataFrame_PushBackUnnamed() ) )
 expect_equal( DataFrame_PushBackUnnamed(), df )
 
@@ -87,6 +87,17 @@ expect_true( is.data.frame( DataFrame_PushFrontNamed() ) )
 expect_equal( DataFrame_PushFrontNamed(), df )
 
 #    test.DataFrame.PushFrontUnnamed <- function(){
-df <- data.frame( c(0, 0), u = c(0, 0), fix.empty.names = FALSE )
+df <- data.frame( c(0, 0), u = c(0, 0) )
 expect_true( is.data.frame( DataFrame_PushFrontUnnamed() ) )
 expect_equal( DataFrame_PushFrontUnnamed(), df )
+
+
+#    test.DataFrame.PushFrontDataFrame <- function(){
+df <- data.frame( w = c(0, 0), x = c(0, 0), u = c(0, 0), v = c(0, 0) )
+expect_true( is.data.frame( DataFrame_PushFrontDataFrame() ) )
+expect_equal( DataFrame_PushFrontDataFrame(), df )
+
+#    test.DataFrame.PushBackDataFrame <- function(){
+df <- data.frame( u = c(0, 0), v = c(0, 0), w = c(0, 0), x = c(0, 0) )
+expect_true( is.data.frame( DataFrame_PushBackDataFrame() ) )
+expect_equal( DataFrame_PushBackDataFrame(), df )

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -110,3 +110,6 @@ expect_warning( DataFrame_PushWrongSize() )
 df <- data.frame( u = c(1, 0), v = c(0, 0, 0, 0), x = c(2) )
 expect_true( is.data.frame( DataFrame_PushReplicateLength() ) )
 expect_equal( DataFrame_PushReplicateLength(), df )
+
+#    test.DataFrame.PushZeroLength <- function(){
+expect_warning( DataFrame_PushZeroLength())

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -101,3 +101,12 @@ expect_equal( DataFrame_PushFrontDataFrame(), df )
 df <- data.frame( u = c(0, 0), v = c(0, 0), w = c(0, 0), x = c(0, 0) )
 expect_true( is.data.frame( DataFrame_PushBackDataFrame() ) )
 expect_equal( DataFrame_PushBackDataFrame(), df )
+
+#    test.DataFrame.PushWrongSize <- function(){
+df <- data.frame( u = c(0, 0), v = c(0, 0), w = c(0, 0), x = c(0, 0) )
+expect_warning( DataFrame_PushWrongSize() )
+
+#    test.DataFrame.PushReplicateLength <- function(){
+df <- data.frame( u = c(1, 0), v = c(0, 0, 0, 0), x = c(2) )
+expect_true( is.data.frame( DataFrame_PushReplicateLength() ) )
+expect_equal( DataFrame_PushReplicateLength(), df )

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -70,3 +70,23 @@ expect_equal( DataFrame_nrow( df ), rep(nrow(df), 2) )
 #    test.DataFrame.ncol <- function(){
 df <- data.frame( x = 1:10, y = 1:10 )
 expect_equal( DataFrame_ncol( df ), rep(ncol(df), 2) )
+
+#    test.DataFrame.PushBackNamed <- function(){
+df <- data.frame( u = c(0, 0), v = c(0, 0) )
+expect_true( is.data.frame( DataFrame_PushBackNamed() ) )
+expect_equal( DataFrame_PushBackNamed(), df )
+
+#    test.DataFrame.PushBackUnamed <- function(){
+df <- data.frame( u = c(0, 0), c(0, 0), fix.empty.names = FALSE )
+expect_true( is.data.frame( DataFrame_PushBackUnnamed() ) )
+expect_equal( DataFrame_PushBackUnnamed(), df )
+
+#    test.DataFrame.PushFrontNamed <- function(){
+df <- data.frame( v = c(0, 0), u = c(0, 0) )
+expect_true( is.data.frame( DataFrame_PushFrontNamed() ) )
+expect_equal( DataFrame_PushFrontNamed(), df )
+
+#    test.DataFrame.PushFrontUnnamed <- function(){
+df <- data.frame( c(0, 0), u = c(0, 0), fix.empty.names = FALSE )
+expect_true( is.data.frame( DataFrame_PushFrontUnnamed() ) )
+expect_equal( DataFrame_PushFrontUnnamed(), df )


### PR DESCRIPTION
This explicitly defines push_back and push_back methods for DataFrame
which copies row.names and class attributes from the original object.

This fixes #1094 where these operations converted the object to a list.

Tests for this behavior are also implemented.


#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
