### PR TITLE
Remove obsolete and confusing comment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-08-20  Mattias Ellert  <mattias.ellert@physics.uu.se>
+
+        * inst/include/Rcpp/lang.h: Remove obsolete and confusing comment
+
 2020-08-05  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/lang.h
+++ b/inst/include/Rcpp/lang.h
@@ -61,11 +61,7 @@ inline SEXP Rcpp_list5(SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4) {
     return x0;
 }
 
-
-
-// `Rf_lang6()` is available on R 3.3, but `Rf_list6()` is not
-inline SEXP Rcpp_list6( SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4, SEXP x5 )
-{
+inline SEXP Rcpp_list6(SEXP x0, SEXP x1, SEXP x2, SEXP x3, SEXP x4, SEXP x5) {
     PROTECT(x0);
     x0 = Rf_cons(x0, Rcpp_list5(x1, x2, x3, x4, x5));
     UNPROTECT(1);


### PR DESCRIPTION
The comment was added in commit cfdb196267a8b04b2bda897c1bb7f2496bf3edcd to explain why Rcpp_list6() is special.
However, in a later commit 6eac444d92e26c185a0523d0bb6417862bb4fd30 Rcpp_list{2,3,4,5}() were added with similar definitions.
This means that Rcpp_list6() is no longer special, and the comment is now confusing rather than informative.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
