### PR TITLE
attempt to fix 2019-February/010296.html

### DIFF
--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -168,7 +168,7 @@ namespace attributes {
     // Type info
     class Type {
     public:
-        Type() {}
+        Type(): isConst_(false), isReference_(false) {}
         Type(const std::string& name, bool isConst, bool isReference)
             : name_(name), isConst_(isConst), isReference_(isReference)
         {


### PR DESCRIPTION
PR as requested in https://github.com/RcppCore/Rcpp/issues/1112. 

The following passes with one warning: 

```bash
R CMD build --no-build-vignettes Rcpp
R CMD check --as-cran Rcpp_1.0.5.2.tar.gz
```

I used `--no-build-vignettes` as I got an error otherwise. This resulted in some warnings.

I figure the changes are minor and thus I have not added anything to the ChangeLog file.
