### PR TITLE
support include files for package names with dot (closes #1129)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-01-17  Dirk Eddelbuettel  <edd@debian.org>
+
+        * DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 2021-01-16  Dirk Eddelbuettel  <edd@debian.org>
 
 	* tests/tinytest.R: Test for CODECOV when deciding to run extensive

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@
 	* R/RcppClass.R: Idem
 	* R/RcppLdpath.R: Idem
 
+	* src/attributes.cpp: Support include files with dots in package name
+
 2021-01-14  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Date, Version): Release 1.0.6

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.6
-Date: 2021-01-14
+Version: 1.0.6.1
+Date: 2021-01-17
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.6"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,6,0)
-#define RCPP_DEV_VERSION_STRING "1.0.6.0"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,6,1)
+#define RCPP_DEV_VERSION_STRING "1.0.6.1"
 
 #endif

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -633,6 +633,9 @@ namespace attributes {
         // if it wasn't (throws exception on io error)
         bool commit(const std::string& preamble = std::string());
 
+        // Convert a dot in package name to underscore for use in header file name
+        std::string dotNameHelper(const std::string & name) const;
+
     private:
 
         // Private virtual for doWriteFunctions so the base class
@@ -717,7 +720,7 @@ namespace attributes {
         std::string includeDir_;
     };
 
-    // Class which manages generating PackageName_RcppExports.h header file
+    // Class which manages generating PackageName.h header file
     class CppPackageIncludeGenerator : public ExportsGenerator {
     public:
         CppPackageIncludeGenerator(const std::string& packageDir,
@@ -1894,6 +1897,13 @@ namespace attributes {
         return removeFile(targetFile_);
     }
 
+    // Convert a possible dot in package name to underscore as needed for header file
+    std::string ExportsGenerator::dotNameHelper(const std::string & name) const {
+        std::string newname(name);
+        std::replace(newname.begin(), newname.end(), '.', '_');
+        return newname;
+    }
+
     CppExportsGenerator::CppExportsGenerator(const std::string& packageDir,
                                              const std::string& package,
                                              const std::string& fileSep)
@@ -2128,7 +2138,7 @@ namespace attributes {
                                             const std::string& fileSep)
         : ExportsGenerator(
             packageDir +  fileSep + "inst" +  fileSep + "include" +
-            fileSep + package + kRcppExportsSuffix,
+            fileSep + dotNameHelper(package) + kRcppExportsSuffix,
             package,
             "//")
     {
@@ -2346,7 +2356,7 @@ namespace attributes {
                                             const std::string& fileSep)
         : ExportsGenerator(
             packageDir +  fileSep + "inst" +  fileSep + "include" +
-            fileSep + package + ".h",
+            fileSep + dotNameHelper(package) + ".h",
             package,
             "//")
     {
@@ -2359,7 +2369,6 @@ namespace attributes {
             std::string guard = getHeaderGuard();			// #nocov start
             ostr() << "#ifndef " << guard << std::endl;
             ostr() << "#define " << guard << std::endl << std::endl;
-
             ostr() << "#include \"" << packageCpp() << kRcppExportsSuffix
                    << "\"" << std::endl;
 


### PR DESCRIPTION
#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)

This addresses the issue in #1129 which itself bring back up #500 and related SO question.  The fix is actually pretty simple, was made (and even tested) a few weeks ago.
