### PR TITLE
Add echo parameter to sourcecpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-01-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/DataFrame.h: Remove unused variable
+
+	* R/Attributes.R (sourceCpp): Support argument echo to be passed to
+	source() to silence optional R evaluation
+
 2021-01-19  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2021-01-21  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION (Version, Date): Roll minor version
+        * inst/include/Rcpp/config.h: Idem
+
 	* inst/include/Rcpp/DataFrame.h: Remove unused variable
 
 	* R/Attributes.R (sourceCpp): Support argument echo to be passed to

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.6.3
-Date: 2021-01-19
+Version: 1.0.6.4
+Date: 2021-01-21
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -28,7 +28,8 @@ sourceCpp <- function(file = "",
                       showOutput = verbose,
                       verbose = getOption("verbose"),
                       dryRun = FALSE,
-                      windowsDebugDLL = FALSE) {
+                      windowsDebugDLL = FALSE,
+                      echo = TRUE) {
 
     # use an architecture/version specific subdirectory of the cacheDir
     # (since cached dynlibs can now perist across sessions we need to be
@@ -214,7 +215,7 @@ sourceCpp <- function(file = "",
     if (embeddedR && (length(context$embeddedR) > 0)) {
         srcConn <- textConnection(context$embeddedR)
         setwd(rWorkingDir) # will be reset by previous on.exit handler
-        source(file = srcConn, local = env, echo = TRUE)
+        source(file = srcConn, local = env, echo = echo)
     }
 
     # cleanup the cache dir if requested
@@ -258,7 +259,8 @@ cppFunction <- function(code,
                         rebuild = FALSE,
                         cacheDir = getOption("rcpp.cache.dir", tempdir()),
                         showOutput = verbose,
-                        verbose = getOption("verbose")) {
+                        verbose = getOption("verbose"),
+                        echo = TRUE) {
 
     # process depends
     if (!is.null(depends) && length(depends) > 0) {             # #nocov start
@@ -315,7 +317,8 @@ cppFunction <- function(code,
                           rebuild = rebuild,
                           cacheDir = cacheDir,
                           showOutput = showOutput,
-                          verbose = verbose)
+                          verbose = verbose,
+                          echo = echo)
 
     # verify that a single function was exported and return it
     if (length(exported$functions) == 0)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -8,13 +8,17 @@
     \item Changes in Rcpp API:
     \itemize{
       \item Refactored \code{Rcpp_PreserveObject} and \code{Rcpp_ReleaseObject}
-      which are now O(1) (Dirk and Iñaki in \ghpr{1133} and \ghor{1135}
+      which are now O(1) (Dirk and Iñaki in \ghpr{1133} and \ghpr{1135}
       fixing \ghit{382} and \ghit{1081}).
+      \item A spuriously assigned variable was removed (Dirk in
+      \ghpr{1138} fixing \ghit{1137})
     }
     \item Changes in Rcpp Attributes:
     \itemize{
       \item Packages with dots in their name can now have per-package
       include files (Dirk in \ghpr{1132} fixes \ghit{1129}).
+      \item New argument \code{echo} to quieten optional evaluation in
+      \code{sourceCpp} (Dirk in \ghpr{1138} fixing \ghit{1126}).
     }
   }
 }

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -2,7 +2,7 @@
 //
 // DataFrame.h: Rcpp R/C++ interface class library -- data frames
 //
-// Copyright (C) 2010 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2021  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -106,7 +106,7 @@ namespace Rcpp{
             Parent::push_front(object, name);
             set_type_after_push();
         }
-                
+
         // Offer multiple variants to accomodate both old interface here and signatures in other classes
         inline int nrows() const { return DataFrame_Impl::nrow(); }
         inline int rows()  const { return DataFrame_Impl::nrow(); }
@@ -133,7 +133,6 @@ namespace Rcpp{
         void set_type_after_push(){
             int max_rows = 0;
             bool invalid_column_size = false;
-            SEXP data = Parent::get__();
             List::iterator it;
             // Get the maximum number of rows
             for (it = Parent::begin(); it != Parent::end(); ++it) {

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.6"
 
 // the current source snapshot
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,6,3)
-#define RCPP_DEV_VERSION_STRING "1.0.6.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,6,4)
+#define RCPP_DEV_VERSION_STRING "1.0.6.4"
 
 #endif

--- a/man/cppFunction.Rd
+++ b/man/cppFunction.Rd
@@ -8,8 +8,8 @@ Dynamically define an R function with C++ source code. Compiles and links a shar
 }
 \usage{
 cppFunction(code, depends = character(), plugins = character(), includes = character(),
-            env = parent.frame(), rebuild = FALSE, cacheDir = getOption("rcpp.cache.dir", 
-            tempdir()), showOutput = verbose, verbose = getOption("verbose"))
+            env = parent.frame(), rebuild = FALSE, cacheDir = getOption("rcpp.cache.dir",
+            tempdir()), showOutput = verbose, verbose = getOption("verbose"), echo = TRUE)
 }
 
 \arguments{
@@ -40,10 +40,13 @@ cppFunction(code, depends = character(), plugins = character(), includes = chara
   \item{verbose}{
     \code{TRUE} to print detailed information about generated code to the console.
 }
+  \item{echo}{
+    \code{TRUE} to silence output from optional R evaluation if set to \code{FALSE}.
+}
 }
 \details{
    Functions defined using \code{cppFunction} must have return types that are compatible with \code{Rcpp::wrap} and parameter types that are compatible with \code{Rcpp::as}.
-        
+
     The shared library will not be rebuilt if the underlying code has not changed since the last compilation.
 }
 \value{
@@ -63,36 +66,36 @@ cppFunction(code, depends = character(), plugins = character(), includes = chara
 
 cppFunction(
     'int fibonacci(const int x) {
-        if (x == 0) return(0); 
+        if (x == 0) return(0);
         if (x == 1) return(1);
         return (fibonacci(x - 1)) + fibonacci(x - 2);
     }')
 
 cppFunction(depends = "RcppArmadillo",
     'List fastLm(NumericVector yr, NumericMatrix Xr) {
-        
+
         int n = Xr.nrow(), k = Xr.ncol();
-        
-        arma::mat X(Xr.begin(), n, k, false); 
+
+        arma::mat X(Xr.begin(), n, k, false);
         arma::colvec y(yr.begin(), yr.size(), false);
-        
+
         arma::colvec coef = arma::solve(X, y);
         arma::colvec resid = y - X*coef;
-        
+
         double sig2 = arma::as_scalar(arma::trans(resid)*resid/(n-k) );
         arma::colvec stderrest = arma::sqrt(
             sig2 * arma::diagvec(arma::inv(arma::trans(X)*X)));
-        
+
         return List::create(Named("coefficients") = coef,
             Named("stderr")       = stderrest
         );
     }')
-    
+
 cppFunction(plugins=c("cpp11"), '
     int useCpp11() {
         auto x = 10;
         return x;
     }')
-    
+
 }
 }

--- a/man/sourceCpp.Rd
+++ b/man/sourceCpp.Rd
@@ -8,17 +8,17 @@ Source C++ Code from a File or String
 and RCPP_MODULE declarations. A shared library is then built and its exported functions and Rcpp modules are made available in the specified environment.
 }
 \usage{
-sourceCpp(file = "", code = NULL, env = globalenv(), embeddedR = TRUE, rebuild = FALSE, 
+sourceCpp(file = "", code = NULL, env = globalenv(), embeddedR = TRUE, rebuild = FALSE,
           cacheDir = getOption("rcpp.cache.dir", tempdir()), cleanupCacheDir = FALSE,
           showOutput = verbose, verbose = getOption("verbose"), dryRun = FALSE,
-          windowsDebugDLL = FALSE)
+          windowsDebugDLL = FALSE, echo = TRUE)
 }
 \arguments{
   \item{file}{
     A character string giving the path name of a file
 }
   \item{code}{
-    A character string with source code. If supplied, the code is taken from this string instead of a file. 
+    A character string with source code. If supplied, the code is taken from this string instead of a file.
 }
   \item{env}{
     Environment where the R functions and modules should be made available.
@@ -48,29 +48,32 @@ actually executing the commands).
   \item{windowsDebugDLL}{
     \code{TRUE} to create a debug DLL on Windows (and ignored on other platforms).
 }
+  \item{echo}{
+    \code{TRUE} to silence output from optional R evaluation if set to \code{FALSE}.
+}
 }
 \details{
     If the \code{code} parameter is provided then the \code{file} parameter is ignored.
 
-    Functions exported using \code{sourceCpp} must meet several conditions, 
-    including being defined in the global namespace and having return types 
-    that are compatible with \code{Rcpp::wrap} and parameter types that are 
-    compatible with \code{Rcpp::as}. 
+    Functions exported using \code{sourceCpp} must meet several conditions,
+    including being defined in the global namespace and having return types
+    that are compatible with \code{Rcpp::wrap} and parameter types that are
+    compatible with \code{Rcpp::as}.
     See the \code{\link[=exportAttribute]{Rcpp::export}} documentation for more details.
-    
-    Content of Rcpp Modules will be automatically loaded into the specified 
-    environment using the \code{\link[=Module]{Module}} and 
-    \code{\link[=populate]{populate}} functions. 
-    
-    If the source file has compilation dependencies on other 
-    packages (e.g. \pkg{Matrix}, \pkg{RcppArmadillo}) then an 
-    \code{\link[=dependsAttribute]{Rcpp::depends}} attribute 
-    should be provided naming these dependencies. 
-    
-	It's possible to embed chunks of R code within a C++ source file by 
-	including the R code within a block comment with the 
+
+    Content of Rcpp Modules will be automatically loaded into the specified
+    environment using the \code{\link[=Module]{Module}} and
+    \code{\link[=populate]{populate}} functions.
+
+    If the source file has compilation dependencies on other
+    packages (e.g. \pkg{Matrix}, \pkg{RcppArmadillo}) then an
+    \code{\link[=dependsAttribute]{Rcpp::depends}} attribute
+    should be provided naming these dependencies.
+
+	It's possible to embed chunks of R code within a C++ source file by
+	including the R code within a block comment with the
 	prefix of \code{/*** R}. For example:
-    
+
 \preformatted{
 /*** R
 
@@ -80,11 +83,11 @@ fibonacci(10)
 */
 }
 
-	Multiple R code chunks can be included in a C++ file. R code is sourced after the C++ compilation is completed so all functions and modules will be available to the R code.   
+	Multiple R code chunks can be included in a C++ file. R code is sourced after the C++ compilation is completed so all functions and modules will be available to the R code.
 }
 
 \value{
-    Returns (invisibly) a list with two elements: 
+    Returns (invisibly) a list with two elements:
     \tabular{ll}{
         \code{functions} \tab Names of exported functions\cr
         \code{modules} \tab Names of Rcpp modules\cr
@@ -95,9 +98,9 @@ fibonacci(10)
 	The \code{sourceCpp} function will not rebuild the shared library if the source file has not changed since the last compilation.
 
     The \code{sourceCpp} function is designed for compiling a standalone source file whose only dependencies are R packages. If you are compiling more than one source file or have external dependencies then you should create an R package rather than using \code{sourceCpp}. Note that the \code{\link[=exportAttribute]{Rcpp::export}} attribute can also be used within packages via the \code{\link{compileAttributes}} function.
-    
+
     If you are sourcing a C++ file from within the \code{src} directory of a package then the package's \code{LinkingTo} dependencies, \code{inst/include}, and \code{src} directories are automatically included in the compilation.
-    
+
     If no \code{Rcpp::export} attributes or \code{RCPP_MODULE} declarations are found within the source file then a warning is printed to the console. You can disable this warning by setting the \code{rcpp.warnNoExports} option to \code{FALSE}.
 
 }


### PR DESCRIPTION
This is a twoofer which cleans up the earlier #1126 with a new parameter `echo` that defaults to `TRUE` (old behaviour) and is passed on to `source()` to make any optional R code submitted to `sourceCpp()` or `cppFunction()` silent.  It also cleans up the simple `DataFrame` warning in #1137.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
