### PR TITLE
add cfloat header (fixes #1161)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,11 @@
+2021-05-09  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/RcppCommon.h: Add cfloat header
+
 2021-04-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/hash/IndexHash.h: Silence one comparison, update
-	use of unsigned it to uint32_t throughout
+	use of unsigned int to uint32_t throughout
 
 2021-03-22  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,11 +11,15 @@
       which are now O(1) (Dirk and Iñaki in \ghpr{1133} and \ghpr{1135}
       fixing \ghit{382} and \ghit{1081}).
       \item A spuriously assigned variable was removed (Dirk in
-      \ghpr{1138} fixing \ghit{1137})
+      \ghpr{1138} fixing \ghit{1137}).
       \item Global \code{Rcout} and \code{Rcerr} objects are supported
       via a compiler directive (Iñaki in \ghpr{1139} fixing \ghit{928})
       \item Add support for \code{Rcpp::message} (Dirk in \ghpr{1146}
-      fixing \ghit{1145})
+      fixing \ghit{1145}).
+      \item The \code{uint32_t} type is used throughout instead of
+      \code{unsigned int} (Dirk in \ghpr{1153} fixing \ghit{1152}).
+      \item The \code{cfloat} header for floating point limits is now
+      included {\Dirk in \ghpr{1162} fixing \ghit{1161}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -63,6 +63,7 @@ namespace Rcpp {
 #include <numeric>
 #include <algorithm>
 #include <complex>
+#include <cfloat>
 #include <limits>
 #include <typeinfo>
 #include <Rcpp/sprintf.h>


### PR DESCRIPTION
As seen in #1158 and described in #1161, we are apparently missing `cloat` (or `float.h`) for numeric limits.  This small commit addresses this.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
