### PR TITLE
Allow 'five element version' numbers during development

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-05-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/cpp/rcppversion.cpp (checkVersion): Allow for more
+	than four components of a development version number
+	* inst/tinytest/test_packageversion.R: Idem
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Clarify in comment
+
 2021-05-13  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Version, Date): Roll minor version

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -19,12 +19,12 @@
       \item The \code{uint32_t} type is used throughout instead of
       \code{unsigned int} (Dirk in \ghpr{1153} fixing \ghit{1152}).
       \item The \code{cfloat} header for floating point limits is now
-      included {\Dirk in \ghpr{1162} fixing \ghit{1161}).
+      included (Dirk in \ghpr{1162} fixing \ghit{1161}).
     }
     \item Changes in Rcpp Attributes:
     \itemize{
       \item Packages with dots in their name can now have per-package
-      include files (Dirk in \ghpr{1132} fixes \ghit{1129}).
+      include files (Dirk in \ghpr{1132} fixing \ghit{1129}).
       \item New argument \code{echo} to quieten optional evaluation in
       \code{sourceCpp} (Dirk in \ghpr{1138} fixing \ghit{1126}).
     }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -29,7 +29,7 @@
 #define RCPP_VERSION            Rcpp_Version(1,0,6)
 #define RCPP_VERSION_STRING     "1.0.6"
 
-// the current source snapshot
+// the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
 #define RCPP_DEV_VERSION        RcppDevVersion(1,0,6,7)
 #define RCPP_DEV_VERSION_STRING "1.0.6.7"
 

--- a/inst/tinytest/cpp/rcppversion.cpp
+++ b/inst/tinytest/cpp/rcppversion.cpp
@@ -10,7 +10,8 @@ Rcpp::List checkVersion(Rcpp::IntegerVector v) {
 
     // ensure that length is four, after possibly appending 0
     if (v.size() == 3) v.push_back(0);
-    if (v.size() != 4) Rcpp::stop("Expect vector with four elements.");
+    if (v.size() == 4) v.push_back(0);
+    if (v.size() > 5) Rcpp::stop("Expect vector with up to five elements.");
 
     return Rcpp::List::create(Rcpp::Named("def_ver")     = RCPP_VERSION,
                               Rcpp::Named("def_str")     = RCPP_VERSION_STRING,

--- a/inst/tinytest/test_packageversion.R
+++ b/inst/tinytest/test_packageversion.R
@@ -29,7 +29,6 @@ v <- as.integer(unlist(strsplit(pvstr, "\\.")))
 ## construct a release string from the first three elements, ie "1.0.3" from 1.0.3.1
 relstr <- as.character(as.package_version(paste(v[1:3], collapse=".")))
 
-
 ## call C++ function returning list of six values, three each for 'release' and 'dev' version
 res <- checkVersion(v)
 
@@ -41,9 +40,11 @@ expect_equal(res$cur_ver, res$def_ver, info="current computed version equal defi
 expect_equal(relstr, res$def_str, info="current computed version equal defined dev string")
 
 ## additional checks if we are a dev version
-if (length(v) == 4) {
+if (length(v) >= 4) {
     expect_equal(res$cur_dev_ver, res$def_dev_ver, info="current computed dev version greater equal defined dev version")
+}
 
+if (length(v) <= 4) {
     ## basic check: is #defined string version equal to computed string
     expect_equal(pvstr, res$def_dev_str, info="current computed version equal defined dev string")
 }


### PR DESCRIPTION
We have used a scheme of three-element releases (such as the current 1.0.6) along with four-element development releases (currently 1.0.6.7 as the newest in the drat repo).  While testing STRICT_R_HEADERS I wanted to differentiate with/without the define tarballs ... and could not as our testing code is a little too rigid.

This PR addresses this.  No other changes, no actual functionality changes.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Prefereably, new tests were added which fail without the change (tests were updated)
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
