### PR TITLE
update old examples with respect to RNGScope (closes #1172)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-09-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/examples/Misc/piSugar.cpp (piSugar): Remove spurious call to
+	RNGScope we do not need with Rcpp Attributes
+	* inst/examples/RcppGibbs/RcppGibbs.R (Rgibbs): Comment on two uses
+	of RNGScope as historical in pre-Attributes code
+	* inst/examples/RcppGibbs/timeRNGs.R: Idem for one more
+
 2021-08-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/bib/Rcpp.bib: Use https for CRAN URLs

--- a/inst/examples/Misc/piSugar.cpp
+++ b/inst/examples/Misc/piSugar.cpp
@@ -5,9 +5,8 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 double piSugar(const int N) {
-  RNGScope scope;		// ensure RNG gets set/reset
-  NumericVector x = runif(N);
-  NumericVector y = runif(N);
-  NumericVector d = sqrt(x*x + y*y);
-  return 4.0 * sum(d < 1.0) / N;
+    NumericVector x = runif(N);
+    NumericVector y = runif(N);
+    NumericVector d = sqrt(x*x + y*y);
+    return 4.0 * sum(d < 1.0) / N;
 }

--- a/inst/examples/RcppGibbs/RcppGibbs.R
+++ b/inst/examples/RcppGibbs/RcppGibbs.R
@@ -100,7 +100,7 @@ gibbscode <- '
   int i,j;
   NumericMatrix mat(N, 2);
 
-  RNGScope scope;         // Initialize Random number generator
+  RNGScope scope;         // Initialize Random number generator. Not needed when Attributes used.
 
   // The rest of the code follows the R version
   double x=0, y=0;
@@ -174,10 +174,10 @@ NumericMatrix RcppGibbs(int N, int thn){
 
     // Setup storage matrix
     NumericMatrix mat(N, 2);
-    
+
     // The rest of the code follows the R version
     double x = 0, y = 0;
-    
+
     for (int i = 0; i < N; i++) {
         for (int j = 0; j < thn; j++) {
             x = R::rgamma(3.0,1.0/(y*y+4));
@@ -186,14 +186,14 @@ NumericMatrix RcppGibbs(int N, int thn){
         mat(i,0) = x;
         mat(i,1) = y;
     }
-    
+
     return mat;             // Return to R
 }')
 
 
 ## Use of the sourceCpp() is preferred for users who wish to source external
 ## files or specify their headers and Rcpp attributes within their code.
-## Code here is able to easily be extracted and placed into its own C++ file. 
+## Code here is able to easily be extracted and placed into its own C++ file.
 
 ## Compile and Load
 sourceCpp(code="
@@ -219,7 +219,7 @@ NumericMatrix GSLGibbs(int N, int thin){
         mat(i,1) = y;
     }
     gsl_rng_free(r);
-    
+
     return mat;           // Return to R
 }")
 
@@ -289,5 +289,3 @@ print(res)
 
 
 ## And we are done
-
-

--- a/inst/examples/RcppGibbs/timeRNGs.R
+++ b/inst/examples/RcppGibbs/timeRNGs.R
@@ -3,6 +3,105 @@ suppressMessages(library(Rcpp))
 suppressMessages(library(inline))
 suppressMessages(library(rbenchmark))
 
+## NOTE: Within this section, the new way to compile Rcpp code inline has been
+## written. Please use the code next as a template for your own project, and
+## no NOT use the old code below
+
+cppFunction('
+NumericVector rcppGamma(NumericVector x){
+    int n   = x.size();
+
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = R::rgamma(3.0, 1.0/(y*y+4));
+    }
+
+    // Return to R
+    return x;
+}')
+
+## This approach is a bit sloppy. Generally, you will want to use
+## sourceCpp() if there are additional includes that are required.
+cppFunction('
+NumericVector gslGamma(NumericVector x){
+    int n   = x.size();
+
+    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = gsl_ran_gamma(r,3.0,1.0/(y*y+4));
+    }
+    gsl_rng_free(r);
+
+    // Return to R
+    return x;
+}', includes = '#include <gsl/gsl_rng.h>
+                #include <gsl/gsl_randist.h>',
+    depends = "RcppGSL")
+
+
+cppFunction('
+NumericVector rcppNormal(NumericVector x){
+    int n   = x.size();
+
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = R::rnorm(1.0/(y+1),1.0/sqrt(2*y+2));
+    }
+
+    // Return to R
+    return x;
+}')
+
+
+## Here we demonstrate the use of sourceCpp() to show the continuity
+## of the code artifact.
+
+sourceCpp(code = '
+#include <RcppGSL.h>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
+
+using namespace Rcpp;
+
+// [[Rcpp::depends("RcppGSL")]]
+
+// [[Rcpp::export]]
+NumericVector gslNormal(NumericVector x){
+    int n   = x.size();
+
+    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
+    const double y = 1.234;
+    for (int i=0; i<n; i++) {
+        x[i] = 1.0/(y+1)+gsl_ran_gaussian(r,1.0/sqrt(2*y+2));
+    }
+    gsl_rng_free(r);
+
+    // Return to R
+    return x;
+}')
+
+x <- rep(NA, 1e6)
+res <- benchmark(rcppGamma(x),
+                 gslGamma(x),
+                 rcppNormal(x),
+                 gslNormal(x),
+                 columns=c("test", "replications", "elapsed", "relative", "user.self", "sys.self"),
+                 order="relative",
+                 replications=20)
+print(res)
+
+
+
+
+
+##
+##
+##  Old code below. Do not use in new projects, it is here solely for comparison
+##
+##
+
+
 ## NOTE: This is the old way to compile Rcpp code inline.
 ## The code here has left as a historical artifact and tribute to the old way.
 ## Please use the code under the "new" inline compilation section.
@@ -11,8 +110,7 @@ rcppGamma_old <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
   NumericVector x(xs);
   int n   = x.size();
 
-  // Initialize Random number generator
-  RNGScope scope;
+  RNGScope scope;         // Initialize Random number generator. Not needed when Attributes used.
 
   const double y = 1.234;
   for (int i=0; i<n; i++) {
@@ -47,8 +145,7 @@ rcppNormal_old <- cxxfunction(signature(xs="numeric"), plugin="Rcpp", body='
   NumericVector x(xs);
   int n   = x.size();
 
-  // Initialize Random number generator
-  RNGScope scope;
+  RNGScope scope;         // Initialize Random number generator. Not needed when Attributes used.
 
   const double y = 1.234;
   for (int i=0; i<n; i++) {
@@ -77,93 +174,3 @@ gslNormal_old <- cxxfunction(signature(xs="numeric"), plugin="RcppGSL",
   // Return to R
   return x;
 ')
-
-
-## NOTE: Within this section, the new way to compile Rcpp code inline has been
-## written. Please use the code next as a template for your own project.
-
-cppFunction('
-NumericVector rcppGamma(NumericVector x){
-    int n   = x.size();
-    
-    const double y = 1.234;
-    for (int i=0; i<n; i++) {
-        x[i] = R::rgamma(3.0, 1.0/(y*y+4));
-    }
-    
-    // Return to R
-    return x;
-}')
-
-## This approach is a bit sloppy. Generally, you will want to use 
-## sourceCpp() if there are additional includes that are required.
-cppFunction('
-NumericVector gslGamma(NumericVector x){
-    int n   = x.size();
-    
-    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
-    const double y = 1.234;
-    for (int i=0; i<n; i++) {
-        x[i] = gsl_ran_gamma(r,3.0,1.0/(y*y+4));
-    }
-    gsl_rng_free(r);
-    
-    // Return to R
-    return x;
-}', includes = '#include <gsl/gsl_rng.h>
-                #include <gsl/gsl_randist.h>',
-    depends = "RcppGSL")
-
-
-cppFunction('
-NumericVector rcppNormal(NumericVector x){
-    int n   = x.size();
-    
-    const double y = 1.234;
-    for (int i=0; i<n; i++) {
-        x[i] = R::rnorm(1.0/(y+1),1.0/sqrt(2*y+2));
-    }
-    
-    // Return to R
-    return x;
-}')
-
-
-## Here we demonstrate the use of sourceCpp() to show the continuity 
-## of the code artifact.
-
-sourceCpp(code = '
-#include <RcppGSL.h>
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_randist.h>
-
-using namespace Rcpp;
-
-// [[Rcpp::depends("RcppGSL")]]
-
-// [[Rcpp::export]]
-NumericVector gslNormal(NumericVector x){
-    int n   = x.size();
-    
-    gsl_rng *r = gsl_rng_alloc(gsl_rng_mt19937);
-    const double y = 1.234;
-    for (int i=0; i<n; i++) {
-        x[i] = 1.0/(y+1)+gsl_ran_gaussian(r,1.0/sqrt(2*y+2));
-    }
-    gsl_rng_free(r);
-    
-    // Return to R
-    return x;
-}')
-
-x <- rep(NA, 1e6)
-res <- benchmark(rcppGamma(x),
-                 gslGamma(x),
-                 rcppNormal(x),
-                 gslNormal(x),
-                 columns=c("test", "replications", "elapsed", "relative", "user.self", "sys.self"),
-                 order="relative",
-                 replications=20)
-print(res)
-
-

--- a/inst/examples/RcppGibbs/timeRNGs.R
+++ b/inst/examples/RcppGibbs/timeRNGs.R
@@ -5,7 +5,7 @@ suppressMessages(library(rbenchmark))
 
 ## NOTE: Within this section, the new way to compile Rcpp code inline has been
 ## written. Please use the code next as a template for your own project, and
-## no NOT use the old code below
+## do NOT use the old code below
 
 cppFunction('
 NumericVector rcppGamma(NumericVector x){


### PR DESCRIPTION
A fresh entry for the Rcpp Gallery came with explicit uses of RNGScope, something we have not needed 'since forever' so I took a quick look at the examples and a) removed one entry and b) used stronger language on the old inline examples.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
