### PR TITLE
Add R 4.0.* to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,9 @@ jobs:
           - name: release
             cntr: rcpp/ci
             r: R
+          - name: r-4.0
+            cntr: rcpp/ci-4.0
+            r: R
           - name: r-3.6
             cntr: rcpp/ci-3.6
             r: R

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ local/
 ## docker helpers
 docker/*sh
 docker/*/*.sh
+
+## Emacs
+*~

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-09-06  Dirk Eddelbuettel  <edd@debian.org>
+
+	* docker/ci-4.0/Dockerfile: Using R 4.0.5 to build ci-4.0
+	* .github/workflows/ci.yaml (jobs): Also run against R 4.0.*
+
 2021-09-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/examples/Misc/piSugar.cpp (piSugar): Remove spurious call to

--- a/docker/ci-4.0/Dockerfile
+++ b/docker/ci-4.0/Dockerfile
@@ -1,0 +1,17 @@
+## Emacs, make this -*- mode: sh; -*-
+
+FROM r-base:4.0.5
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
+      maintainer="Dirk Eddelbuettel <edd@debian.org>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && install.r inline pkgKitten rbenchmark tinytest
+
+ENV _R_CHECK_FORCE_SUGGESTS_ FALSE
+ENV _R_CHECK_TESTS_NLINES_ 0
+ENV RunAllRcppTests yes
+
+CMD ["bash"]


### PR DESCRIPTION
This extends the set of Dockerfiles to include R 4.0.5.  The complementary part is that I also updated where/how the containers are being built because the end-of-life of free build support by Docker threw a spanner in the ring.  

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
