### PR TITLE
Address #1108: enable finalizeOnExit via RCPP_USE_FINALIZE_ON_EXIT

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-09-29  Iñaki Ucar  <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/XPtr.h: Check for new define
+        `RCPP_USE_FINALIZE_ON_EXIT` to flip the value of XPtr's `finalizeOnExit`
+        parameter from false (default) to true.
+	* inst/tinytest/test_xptr.R: Added test for this functionality.
+
 2021-09-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Added total downloads badge

--- a/inst/include/Rcpp/XPtr.h
+++ b/inst/include/Rcpp/XPtr.h
@@ -2,6 +2,7 @@
 // XPtr.h: Rcpp R/C++ interface class library -- smart external pointers
 //
 // Copyright (C) 2009 - 2020  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2021         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -51,7 +52,11 @@ template <
     typename T,
     template <class> class StoragePolicy = PreserveStorage,
     void Finalizer(T*) = standard_delete_finalizer<T>,
-    bool finalizeOnExit = false
+    #ifdef RCPP_USE_FINALIZE_ON_EXIT
+        bool finalizeOnExit = true
+    #else
+        bool finalizeOnExit = false
+    #endif
 >
 class XPtr :
     public StoragePolicy< XPtr<T,StoragePolicy, Finalizer, finalizeOnExit> >,

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -1,5 +1,6 @@
 
-##  Copyright (C) 2009 - 2019  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2009 - 2020  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2021         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 ##
 ##  This file is part of Rcpp.
 ##
@@ -35,3 +36,31 @@ expect_true(xptr_release(xp), info = "check release of external pointer")
 expect_true(xptr_access_released(xp), info = "check access of released external pointer")
 
 expect_error(xptr_use_released(xp), info = "check exception on use of released external pointer")
+
+# test finalizeOnExit default depending on RCPP_USE_FINALIZE_ON_EXIT
+file_path <- tempfile(fileext=".cpp")
+on.exit(unlink(file_path), add=TRUE)
+R <- shQuote(file.path(R.home(component = "bin"), "R"))
+cmd <- paste0(R, " -s -e 'Rcpp::sourceCpp(\"", file_path, "\"); test()'")
+
+code <- '
+#include <Rcpp.h>
+using namespace Rcpp;
+
+template <typename T>
+void custom_finalizer(T* obj) {
+    Rcout << "custom_finalizer was called" << std::endl;
+    delete obj;
+}
+
+// [[Rcpp::export]]
+void test() {
+    XPtr<int, PreserveStorage, custom_finalizer> x(new int);
+}
+'
+
+writeLines(code, file_path)
+expect_silent(system(cmd), info="check that finalizer is NOT called on exit")
+
+writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
+expect_stdout(system(cmd), info="check that finalizer is called on exit")

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -62,5 +62,7 @@ void test() {
 writeLines(code, file_path)
 expect_silent(system(cmd), info="check that finalizer is NOT called on exit")
 
+if (packageVersion("tinytest") < "1.2.0") exit_file("Skip remainder on older test platform")
+
 writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
 expect_stdout(system(cmd), info="check that finalizer is called on exit")


### PR DESCRIPTION
Building on #656, closes #1108. As discussed, enables switching default behaviour to `finalizeOnExit=true` by defining `RCPP_USE_FINALIZE_ON_EXIT`.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
