### PR TITLE
Update doi entries per JSS request

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-10-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* README.md: Switch JSS url to doi form per JSS request
+	* man/Rcpp-package.Rd: Idem
+	* man/RcppLdFlags.Rd: Idem
+	* inst/CITATION: Only use doi entries in three citEntry blocks
+
 2021-10-02  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/docker.yaml (jobs): Add container builder action

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ represented as instances of `Rcpp::Environment`, functions are represented as
 vignette (now published as a
 [TAS paper](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.2017.1375990); an
 [earlier introduction](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-jss-2011.pdf)
-was also published as a [JSS paper](https://www.jstatsoft.org/v40/i08/))
+was also published as a [JSS paper](https://doi.org/10.18637/jss.v040.i08)
 provides a good entry point to Rcpp as do the [Rcpp
 website](http://www.rcpp.org), the [Rcpp
 page](https://dirk.eddelbuettel.com/code/rcpp.html) and the [Rcpp
@@ -73,7 +73,7 @@ TAS](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.2017.1375990) (and 
 [preprint in PeerJ](https://peerj.com/preprints/3188/)). Also available is an
 [earlier
 introduction](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-jss-2011.pdf)
-which was published as a [JSS paper](https://www.jstatsoft.org/v40/i08/))
+which was published as a [JSS paper](https://doi.org/10.18637/jss.v040.i08).
 
 Among the other vignettes are the [Rcpp
 FAQ](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-FAQ.pdf) and the

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -9,13 +9,12 @@ citEntry(entry = "Article",
          volume       = "40",
          number       = "8",
          pages        = "1--18",
-         url          = "https://www.jstatsoft.org/v40/i08/",
          doi          = "10.18637/jss.v040.i08",
 
          textVersion  = paste("Dirk Eddelbuettel and Romain Francois (2011).",
                               "Rcpp: Seamless R and C++ Integration.",
-                              "Journal of Statistical Software, 40(8), 1-18.",
-                              "URL https://www.jstatsoft.org/v40/i08/.")
+                              "Journal of Statistical Software, 40(8), 1-18, ",
+                              "<doi:10.18637/jss.v040.i08>.")
 )
 
 citEntry(entry = "Book",
@@ -28,8 +27,9 @@ citEntry(entry = "Book",
          doi          = "10.1007/978-1-4614-6868-4",
 
          textVersion  = paste("Eddelbuettel, Dirk (2013)",
-                              "Seamless R and C++ Integration with Rcpp.",
-                              "Springer, New York. ISBN 978-1-4614-6867-7.")
+                              "Seamless R and C++ Integration with Rcpp,",
+                              "Springer, New York, ISBN 978-1-4614-6867-7,",
+                              "<doi:10.1007/978-1-4614-6868-4>.")
 )
 
 citEntry(entry = "Article",
@@ -41,11 +41,10 @@ citEntry(entry = "Article",
          volume      = "72",
          number      = "1",
          pages       = "28-36",
-         url         = "https://doi.org/10.1080/00031305.2017.1375990",
          doi         = "10.1080/00031305.2017.1375990",
 
          textVersion = paste("Dirk Eddelbuettel and James Joseph Balamuta (2018).",
                              "Extending R with C++: A Brief Introduction to Rcpp.",
-                             "The American Statistician. 72(1).",
-                             "URL https://doi.org/10.1080/00031305.2017.1375990.")
+                             "The American Statistician. 72(1),",
+                             "<doi:10.1080/00031305.2017.1375990>.")
 )

--- a/man/Rcpp-package.Rd
+++ b/man/Rcpp-package.Rd
@@ -20,7 +20,7 @@
 \references{
   Dirk Eddelbuettel and Romain Francois (2011). \pkg{Rcpp}: Seamless R
   and C++ Integration. \emph{Journal of Statistical Software},
-  \bold{40(8)}, 1-18. URL \url{https://www.jstatsoft.org/v40/i08/} and
+  \bold{40(8)}, 1-18, \doi{10.18637/jss.v040.i08}. Also
   available as \code{vignette("Rcpp-introduction")}.
 
   Eddelbuettel, Dirk (2013) Seamless R and C++ Integration with

--- a/man/RcppLdFlags.Rd
+++ b/man/RcppLdFlags.Rd
@@ -20,7 +20,7 @@
 \references{
   Dirk Eddelbuettel and Romain Francois (2011). \pkg{Rcpp}: Seamless R
   and C++ Integration. \emph{Journal of Statistical Software},
-  \bold{40(8)}, 1-18. URL http://www.jstatsoft.org/v40/i08/ and
+  \bold{40(8)}, 1-18, \doi{10.18637/jss.v040.i08}. Also
   available as \code{vignette("Rcpp-introduction")}.
 }
 \author{Dirk Eddelbuettel and Romain Francois}


### PR DESCRIPTION
This small and focussed PR responds to a request from JSS emailed in by @zeileis on behalf of the editors.  It simply updates from using explicit URLs / URLs with www.jstatsoft to using \doi{}, <doi:...>, or doi.org in references.   It addresses the points he highlighted, I will do another separate pass for the bib file.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
