### PR TITLE
Additional headers for easy-to-use light(er,est) entry points

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-12-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Rcpp: Added as new entry point
+	* inst/include/Rcpp/Light: Added as lighter-weight entry point
+	* inst/include/Rcpp/Lighter: Idem
+	* inst/include/Rcpp/Lightest: Idem
+
 2021-11-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Remove Travis badge

--- a/inst/include/Rcpp/Light
+++ b/inst/include/Rcpp/Light
@@ -1,4 +1,22 @@
-// New (draft) header with optional components off
+// Rcpp/Light: R/C++ interface class library -- without Rcpp Modules
+//
+// Copyright (C) 2008 - 2021  Dirk Eddelbuettel
+// Copyright (C) 2009 - 2021  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
 // no Modules
 #define RCPP_NO_MODULES

--- a/inst/include/Rcpp/Light
+++ b/inst/include/Rcpp/Light
@@ -1,0 +1,7 @@
+// New (draft) header with optional components off
+
+// no Modules
+#define RCPP_NO_MODULES
+
+// include Rcpp as usual
+#include <Rcpp/Rcpp>

--- a/inst/include/Rcpp/Lighter
+++ b/inst/include/Rcpp/Lighter
@@ -1,0 +1,7 @@
+// New (draft) header with optional components off
+
+// no RTTI (actually implies no Modules) -- solid gain
+#define RCPP_NO_RTTI
+
+// include Rcpp/Light which includes Rcpp
+#include <Rcpp/Light>

--- a/inst/include/Rcpp/Lighter
+++ b/inst/include/Rcpp/Lighter
@@ -1,4 +1,22 @@
-// New (draft) header with optional components off
+// Rcpp/Lighter: R/C++ interface class library -- without Rcpp Modules + RTTI
+//
+// Copyright (C) 2008 - 2021  Dirk Eddelbuettel
+// Copyright (C) 2009 - 2021  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
 // no RTTI (actually implies no Modules) -- solid gain
 #define RCPP_NO_RTTI

--- a/inst/include/Rcpp/Lightest
+++ b/inst/include/Rcpp/Lightest
@@ -1,3 +1,22 @@
+// Rcpp/Lightest: R/C++ interface class library -- without Rcpp Modules, RTTI, Sugar
+//
+// Copyright (C) 2008 - 2021  Dirk Eddelbuettel
+// Copyright (C) 2009 - 2021  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 // New (draft) header with optional components off
 
 // no Sugar (but unclear how much it helps)

--- a/inst/include/Rcpp/Lightest
+++ b/inst/include/Rcpp/Lightest
@@ -1,0 +1,7 @@
+// New (draft) header with optional components off
+
+// no Sugar (but unclear how much it helps)
+#define RCPP_NO_SUGAR
+
+// include Rcpp/Lighter
+#include <Rcpp/Lighter>

--- a/inst/include/Rcpp/Rcpp
+++ b/inst/include/Rcpp/Rcpp
@@ -1,7 +1,21 @@
-// New (draft) catch all header
-
-// With (at least) one (potentially) breaking change
-// (but also note r/headers.h)
-#define STRICT_R_HEADERS
+// Rcpp/Rcpp: R/C++ interface class library
+//
+// Copyright (C) 2008 - 2021  Dirk Eddelbuettel
+// Copyright (C) 2009 - 2021  Dirk Eddelbuettel and Romain Francois
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <Rcpp.h>

--- a/inst/include/Rcpp/Rcpp
+++ b/inst/include/Rcpp/Rcpp
@@ -1,0 +1,7 @@
+// New (draft) catch all header
+
+// With (at least) one (potentially) breaking change
+// (but also note r/headers.h)
+#define STRICT_R_HEADERS
+
+#include <Rcpp.h>


### PR DESCRIPTION
This PR adds three new headers (along with a new alternate Rcpp/Rcpp pulling in Rcpp.h) to offer (hopefully) easier access to (simple) speedups from unused headers / features. 

An older work-in-in-progress branch, renamed featires/new_headers_initial, has the original commits as well as two more files which I do not think add value, hence this new (smaller) branch.

As new entry points, no existing code is changed or affected.

I had been sitting on this for months, undecided, but when I mentioned it recently @kevinushey was in favour so there it for review. 

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
