### PR TITLE
Three small changes to compile (again) under C++98 (closes #1192)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-01-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/attributes.cpp: Make three small changes to permit compilation
+	under C++98 now (while we consider just turning to C++11 overall)
+
 2022-01-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_packageversion.R: Comparison to 'dev' revision

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2,7 +2,7 @@
 // attributes.cpp: Rcpp R/C++ interface class library -- Rcpp attributes
 //
 // Copyright (C) 2012 - 2020  JJ Allaire, Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2021         JJ Allaire, Dirk Eddelbuettel, Romain Francois, Iñaki Ucar and Travers Ching
+// Copyright (C) 2021 - 2022  JJ Allaire, Dirk Eddelbuettel, Romain Francois, Iñaki Ucar and Travers Ching
 //
 // This file is part of Rcpp.
 //
@@ -400,12 +400,20 @@ namespace attributes {
             Param sigParam = paramNamed(kExportSignature);
             std::string sig = sigParam.value();
             trimWhitespace(&sig);
-            if(sig.empty()) return sig;
-            if(sig.back() == '}')
+            if (sig.empty()) return sig;
+#if __cplusplus < 201103L
+            if (sig[sig.size() - 1] == '}')
+#else
+            if (sig.back() == '}')
+#endif
                 sig = sig.substr(0, sig.size()-1);
             // check sig.empty again since we deleted an element
-            if(sig.empty()) return sig;
-            if(sig.front() == '{')
+            if (sig.empty()) return sig;
+#if __cplusplus < 201103L
+            if (sig[0] == '{')
+#else
+            if (sig.front() == '{')
+#endif
                 sig.erase(0,1);
             return sig;
         }
@@ -2810,7 +2818,7 @@ namespace attributes {
         // as the error message is generally more descriptive
         CharacterVector pargs_cv = formalArgs(eval(parse(_["text"] = args)));
         std::vector<std::string> parsed_args =
-            Rcpp::as<std::vector<std::string>>(pargs_cv);
+            Rcpp::as<std::vector<std::string> >(pargs_cv);
 
         for(size_t i=0; i<required_args.size(); ++i) {
             if(std::find(parsed_args.begin(), parsed_args.end(),


### PR DESCRIPTION
PRs #1184 and #1187 added support for (function) 'signatures' to generate R function interfaces.  The string processing in there (inadvertendly) used C++11 idioms in the three spots.  We all missed this during code review.

This should (in general) be a non-issue as R itself now imposes C++11 (in R 4.0.*) and even C++14 (in R 4.1.*).  Of course this is both dependent on the compiler, and can be overridden.  While it generally works (in all our testing) we saw in #1192 that it can fail. 

So while we "probably" should just move to C++11 (which should not have side effects _from the compilation of the package_ on to other packages), it is easy enough to restore plain old C++98 compilation -- so we may as well (while we discuss / test moving to C++11).  This PR does the (simple) restoration of C++98 buildability.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
