### PR TITLE
Fix pdf textbox overflow (fixes #1195)

### DIFF
--- a/vignettes/rmd/Rcpp-attributes.Rmd
+++ b/vignettes/rmd/Rcpp-attributes.Rmd
@@ -684,7 +684,8 @@ In this case, a call to `my_package_init()` will be added to the end of the auto
 ```{Rcpp, eval = FALSE}
 void my_package_init(DllInfo *dll);
 RcppExport void R_init_pkgname(DllInfo *dll) {
-    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_registerRoutines(dll, NULL, CallEntries,
+                       NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
     my_package_init(dll);
 }


### PR DESCRIPTION
This fixes #1195 (I think).  I can't readily test it because of some issue with my TeX installation, but it is so simple that I think that it'll work (or if not, it'll point in the right direction for a simple fix).