### PR TITLE
Limit testing scope to stay withing CRAN time buckets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-03-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h: Idem
+
+	* tests/tinytest.R: Disable full tests on four-digits release to not
+	exceed CRAN test time preference
+
 2022-03-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.8.2
-Date: 2022-03-10
+Version: 1.0.8.3
+Date: 2022-03-13
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp hotfix release version 1.0.8.2 (2022-03-10)}{
+\section{Changes in Rcpp hotfix release version 1.0.8.3 (2022-03-13)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
@@ -22,6 +22,8 @@
     \item Changes in Rcpp Deployment:
     \itemize{
       \item Accomodate four digit version numbers in unit test (Dirk)
+      \item Do not run complete test suite to limit test time to CRAN
+      preference (Dirk)
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.8"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,8,2)
-#define RCPP_DEV_VERSION_STRING "1.0.8.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,8,3)
+#define RCPP_DEV_VERSION_STRING "1.0.8.3"
 
 #endif

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -9,7 +9,7 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
 
     ## Force tests to be executed if in dev release which we define as
     ## having a sub-release, eg 0.9.15.5 is one whereas 0.9.16 is not
-    if (length(strsplit(packageDescription("Rcpp")$Version, "\\.")[[1]]) > 3) {	# dev rel, and
+    if (FALSE && length(strsplit(packageDescription("Rcpp")$Version, "\\.")[[1]]) > 3) {	# dev rel, and
         if (Sys.getenv("RunAllRcppTests") != "no") { 			# if env.var not yet set
             message("Setting \"RunAllRcppTests\"=\"yes\" for development release\n")
             Sys.setenv("RunAllRcppTests"="yes")


### PR DESCRIPTION
### Pull Request Template for Rcpp

The hot-fix 1.0.8.2 release did not limit its testing scope as normal releases do and will likely exceed CRAN's time budgets. This PR with a suggested 1.0.8.3 release correct this.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
