### PR TITLE
Use fast_eval when constructing Date (resolves #1208)

### DIFF
--- a/inst/include/Rcpp/api/meat/Date.h
+++ b/inst/include/Rcpp/api/meat/Date.h
@@ -30,7 +30,9 @@ namespace Rcpp{
     inline Date::Date(const std::string &s, const std::string &fmt) {
         Function strptime("strptime");	// we cheat and call strptime() from R
         Function asDate("as.Date");	// and we need to convert to Date
-        m_d = Rcpp::as<int>(asDate(strptime(s, fmt, "UTC")));
+        Language strptime_call(strptime, s, fmt, "UTC");
+        Language asDate_call(asDate, strptime_call.fast_eval());
+        m_d = Rcpp::as<int>(asDate_call.fast_eval());
         update_tm();
     }
 


### PR DESCRIPTION
The Date constructor for strings uses R functions, which causes Rcpp to
insert a very costly tryCatch around any Rcpp code which uses it.
Using fast_eval prevents this issue. Handling of invalid input is
unchanged.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [ ] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
