### PR TITLE
fix: Macro problems in consuming libraries because C <inttypes.h> was used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-03-31 Alex Petty <pettyalex@gmail.com>
+
+        * inst/include/Rcpp/hash/hash.h: Replace <inttypes.h> with <cinttypes>
+        fixing a bug when consuming applications use <cinttypes>
+
 2022-03-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/hash/hash.h
+++ b/inst/include/Rcpp/hash/hash.h
@@ -22,7 +22,7 @@
 #ifndef RCPP__HASH__HASH_H
 #define RCPP__HASH__HASH_H
 
-#include <inttypes.h>			// needed with g++-4.7 to declare intptr_t
+#include <cinttypes>			// needed with g++-4.7 to declare intptr_t
 
 #include <Rcpp/hash/IndexHash.h>
 #include <Rcpp/hash/SelfHash.h>


### PR DESCRIPTION
Change to C++ standard <cinttypes> instead of C library <inttypes.h> to fix macros in consuming applications.

An issue with longer discussion is here: https://github.com/RcppCore/Rcpp/issues/1210

There is a bug in Rcpp when consuming applications are wanting to use the macros defined in <inttypes.h> or `<cinttypes>` when on a platform with C99 <inttypes.h>, which requires __STDC_FORMAT_MACROS to be defined in order to set up its formatting macros. More detail is provided in the issue. 

I will update the checklist as I do the steps

#### Checklist

- [x] Code compiles correctly
- [ ] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
