### PR TITLE
Avoid copies in String

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,11 @@
+2022-05-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_string.R: Add C++11 conditioning for new unit tests
+
 2022-05-23  Dean Scarff  <dos@scarff.id.au>
 
-	* inst/include/Rcpp/String.h: Make less copies of strings by adding
-	move semantics and preserving the buffer/SEXP representation when
-	copying
+	* inst/include/Rcpp/String.h: Make less copies of strings via move
+	semantics and preserving the buffer/SEXP representation when copying
 	* inst/include/RcppCommon.h: include <utility> for std::move
 	* inst/tinytest/cpp/String.cpp: Add unit tests
 	* inst/tinytest/test_string.R: Add unit tests

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2018-10-25  Dean Scarff  <dos@scarff.id.au>
+2022-05-23  Dean Scarff  <dos@scarff.id.au>
 
 	* inst/include/Rcpp/String.h: Make less copies of strings by adding
 	move semantics and preserving the buffer/SEXP representation when

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2018-10-25  Dean Scarff  <dos@scarff.id.au>
+
+	* inst/include/Rcpp/String.h: Make less copies of strings by adding
+	move semantics and preserving the buffer/SEXP representation when
+	copying
+	* inst/include/RcppCommon.h: include <utility> for std::move
+	* inst/tinytest/cpp/String.cpp: Add unit tests
+	* inst/tinytest/test_string.R: Add unit tests
+
 2022-05-12  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci/Dockerfile: Added xml2, also use more r-cran-* binaries

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -66,6 +66,7 @@ namespace Rcpp {
 #include <cfloat>
 #include <limits>
 #include <typeinfo>
+#include <utility>
 #include <Rcpp/sprintf.h>
 #include <R_ext/Callbacks.h>
 #include <R_ext/Visibility.h>

--- a/inst/tinytest/cpp/String.cpp
+++ b/inst/tinytest/cpp/String.cpp
@@ -54,6 +54,35 @@ String test_ctor(String x) {
 }
 
 // [[Rcpp::export]]
+CharacterVector test_move_ctor() {
+  std::vector<String> v = { "test" };
+  String t = std::move( v[0] );
+  v.push_back( std::move( t ) );
+  return CharacterVector( v.begin(), v.end() );
+}
+
+// [[Rcpp::export]]
+String test_move_std_string_ctor() {
+  std::string s = "test";
+  return String( std::move( s ) );
+}
+
+// [[Rcpp::export]]
+CharacterVector test_move_assignment() {
+  std::vector<String> v = { "test", "abc" };
+  v[1] = std::move( v[0] );
+  return CharacterVector( v.begin(), v.end() );
+}
+
+// [[Rcpp::export]]
+String test_move_std_string_assignment() {
+  String x = "abc";
+  std::string s = "test";
+  x = std::move( s );
+  return x;
+}
+
+// [[Rcpp::export]]
 List test_compare_Strings( String aa, String bb ){
     return List::create(
         _["a  < b" ] = aa < bb,

--- a/inst/tinytest/test_string.R
+++ b/inst/tinytest/test_string.R
@@ -63,6 +63,22 @@ expect_equal( res, target )
 res <- test_ctor("abc")
 expect_identical(res, "abc")
 
+#    test.String.move.ctor <- function() {
+res <- test_move_ctor()
+expect_identical(res, c("", "test"))
+
+#    test.String.move.std.string.ctor <- function() {
+res <- test_move_std_string_ctor()
+expect_identical(res, "test")
+
+#    test.String.move.assignment <- function() {
+res <- test_move_assignment()
+expect_identical(res, c("", "test"))
+
+#    test.String.move.std.string.assignment <- function() {
+res <- test_move_std_string_assignment()
+expect_identical(res, "test")
+
 #    test.push.front <- function() {
 res <- test_push_front("def")
 expect_identical(res, "abcdef")

--- a/inst/tinytest/test_string.R
+++ b/inst/tinytest/test_string.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2012 - 2019  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2012 - 2022  Dirk Eddelbuettel and Romain Francois
 ##
 ##  This file is part of Rcpp.
 ##
@@ -63,21 +63,23 @@ expect_equal( res, target )
 res <- test_ctor("abc")
 expect_identical(res, "abc")
 
-#    test.String.move.ctor <- function() {
-res <- test_move_ctor()
-expect_identical(res, c("", "test"))
+if (Rcpp:::capabilities()[["Full C++11 support"]]) {
+    ##    test.String.move.ctor <- function() {
+    res <- test_move_ctor()
+    expect_identical(res, c("", "test"))
 
-#    test.String.move.std.string.ctor <- function() {
-res <- test_move_std_string_ctor()
-expect_identical(res, "test")
+    ##    test.String.move.std.string.ctor <- function() {
+    res <- test_move_std_string_ctor()
+    expect_identical(res, "test")
 
-#    test.String.move.assignment <- function() {
-res <- test_move_assignment()
-expect_identical(res, c("", "test"))
+    ##    test.String.move.assignment <- function() {
+    res <- test_move_assignment()
+    expect_identical(res, c("", "test"))
 
-#    test.String.move.std.string.assignment <- function() {
-res <- test_move_std_string_assignment()
-expect_identical(res, "test")
+    ##    test.String.move.std.string.assignment <- function() {
+    res <- test_move_std_string_assignment()
+    expect_identical(res, "test")
+}
 
 #    test.push.front <- function() {
 res <- test_push_front("def")


### PR DESCRIPTION
Add move constructor/assignment for String&& and std::string&&, and
attempt to preserve the buffer/SEXP representation when copying in the
existing copy ctor and assignment operators.

Closes #1218.

#### Checklist

- [X] Code compiles correctly
- [X] `R CMD check` still passes all tests
- [X] Prefereably, new tests were added which fail without the change
- [X] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
