### PR TITLE
Rcpp 1.0.9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2022-07-02  Dirk Eddelbuettel  <edd@debian.org>
 
+        * DESCRIPTION (Date, Version): Release 1.0.9
+
+        * inst/include/Rcpp/config.h: Idem
+        * inst/NEWS.Rd: Idem
+        * vignettes/rmd/Rcpp.bib: Idem
+        * inst/bib/Rcpp.bib: Idem
 	* vignettes/pdf/*: Rebuilt
 
 2022-07-01  Dirk Eddelbuettel  <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.8.5
-Date: 2022-05-26
+Version: 1.0.9
+Date: 2022-07-02
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![BioConductor use](https://jangorecki.gitlab.io/rdeps/Rcpp/BioC_usage.svg?sanitize=true)](https://cran.r-project.org/package=Rcpp)
 [![StackOverflow](https://img.shields.io/badge/stackoverflow-rcpp-orange.svg)](https://stackoverflow.com/questions/tagged/rcpp)
 [![JSS](https://img.shields.io/badge/JSS-10.18637%2Fjss.v040.i08-brightgreen)](https://dx.doi.org/10.18637/jss.v040.i08)
-[![Springer useR!](https://img.shields.io/badge/Springer%20useR!-10.1007%2F978--1--4614--6868--4-brightgreen)](http://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6)
+[![Springer useR!](https://img.shields.io/badge/Springer%20useR!-10.1007%2F978--1--4614--6868--4-brightgreen)](https://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6)
 [![TAS](https://img.shields.io/badge/TAS-10.1080%2F00031305.2017.1375990-brightgreen)](https://dx.doi.org/10.1080/00031305.2017.1375990)
 
 ### Synopsis
@@ -37,7 +37,7 @@ provides a good entry point to Rcpp as do the [Rcpp
 website](https://www.rcpp.org), the [Rcpp
 page](https://dirk.eddelbuettel.com/code/rcpp.html) and the [Rcpp
 Gallery](https://gallery.rcpp.org). Full documentation is provided by the
-[Rcpp book](http://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6).
+[Rcpp book](https://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6).
 
 Other highlights:
 
@@ -65,7 +65,7 @@ See the [Rcpp-atttributes](https://cran.r-project.org/package=Rcpp/vignettes/Rcp
 
 ### Documentation
 
-The package ships with nine pdf vignettes, including a [recent introduction to
+The package ships with ten pdf vignettes, including a [recent introduction to
 Rcpp](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-introduction.pdf) now
 published as a [paper in
 TAS](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.2017.1375990) (and as a
@@ -78,7 +78,7 @@ Among the other vignettes are the [Rcpp
 FAQ](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-FAQ.pdf) and the
 introduction to [Rcpp
 Attributes](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-attributes.pdf).
-Additional documentation is available via the [Rcpp book](http://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6)
+Additional documentation is available via the [Rcpp book](https://www.amazon.com/gp/product/1461468671/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1461468671&linkCode=as2&tag=rcpp-20&linkId=3P5LNUWOAQ2YMEJ6)
 by Eddelbuettel (2013, Springer); see 'citation("Rcpp")' for details.
 
 ### Performance
@@ -109,11 +109,13 @@ been factored out of Rcpp into the package RcppClassic, and it is still
 available for code relying on the older interface. New development should
 always use this Rcpp package instead.
 
-Other usage examples are provided by packages using Rcpp. As of late December 2021,
-there are 2469 [CRAN](https://cran.r-project.org) packages using Rcpp, a further
-242 [BioConductor](https://www.bioconductor.org) packages in its current release
+Other usage examples are provided by packages using Rcpp. As of early July 2022,
+there are 2560 [CRAN](https://cran.r-project.org) packages using Rcpp, a further
+252 [BioConductor](https://www.bioconductor.org) packages in its current release
 as well as an unknown number of GitHub, Bitbucket, R-Forge, ... repositories
-using Rcpp.  All these packages provide usage examples for Rcpp.
+using Rcpp.  All these packages provide usage examples for Rcpp. The package
+is in widespread use and has been downloaded over 61 million times (per the
+partial logs from the cloud mirrors of CRAN).
 
 ### Installation
 
@@ -183,7 +185,7 @@ previous issues can be searched as well.
 ### Authors
 
 Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
-Nathan Russell, Doug Bates, and John Chambers
+Nathan Russell, Iñaki Ucar, Doug Bates, and John Chambers
 
 ### License
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp hotfix release version 1.0.8.4 (2022-03-14)}{
+\section{Changes in Rcpp hotfix release version 1.0.9 (2022-07-02)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
@@ -15,17 +15,23 @@
        CRAN request)
        \item Upon removal from precious list, the tag is set to null
        (Iñaki in \ghpr{1205} fixing \ghit{1203})
+       \item Move constructor and assignment for strings have been added
+       (Dean Scarff in \ghpr{1219}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item Adjust one overflowing column (Bill Denney in \ghpr{1196} fixing
       \ghit{1195})
+      \item Correct a typo in the FAQ (Marco Colombo in \ghpr{1217})
     }
     \item Changes in Rcpp Deployment:
     \itemize{
       \item Accomodate four digit version numbers in unit test (Dirk)
       \item Do not run complete test suite to limit test time to CRAN
-      preference (Dirk)
+      preference (Dirk in \ghpr{1206})
+      \item Small updates to the CI test containers have been made
+      \item Some of changes also applied to an interim release
+      1.0.8.3 made for CRAN on 2022-03-14.
     }
   }
 }

--- a/inst/bib/Rcpp.bib
+++ b/inst/bib/Rcpp.bib
@@ -136,7 +136,7 @@
                   Allaire and Kevin Ushey and Qiang Kou and
                   Nathan Russel and John Chambers and Douglas Bates},
   year =	 2022,
-  note =	 {R package version 1.0.8},
+  note =	 {R package version 1.0.9},
   url =		 CRAN # "package=Rcpp"
 }
 

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -26,11 +26,11 @@
 #define RcppDevVersion(maj, min, rev, dev)  (((maj)*1000000) + ((min)*10000) + ((rev)*100) + (dev))
 
 // the currently released version
-#define RCPP_VERSION            Rcpp_Version(1,0,8)
-#define RCPP_VERSION_STRING     "1.0.8"
+#define RCPP_VERSION            Rcpp_Version(1,0,9)
+#define RCPP_VERSION_STRING     "1.0.9"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,8,5)
-#define RCPP_DEV_VERSION_STRING "1.0.8.5"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,0)
+#define RCPP_DEV_VERSION_STRING "1.0.9.0"
 
 #endif

--- a/vignettes/rmd/Rcpp.bib
+++ b/vignettes/rmd/Rcpp.bib
@@ -136,7 +136,7 @@
                   Allaire and Kevin Ushey and Qiang Kou and
                   Nathan Russel and John Chambers and Douglas Bates},
   year =	 2022,
-  note =	 {R package version 1.0.8},
+  note =	 {R package version 1.0.9},
   url =		 CRAN # "package=Rcpp"
 }
 


### PR DESCRIPTION
Release 1.0.9 

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)

Submitted to and now pending at CRAN and expect email on the grand-fathered NOTE on `.Call(symbol)` as well as possible question from what is a likely false positive or two in the reverse-depends checks against 2500+ package so planning to leave this open this accepted at CRAN.