### PR TITLE
Support C++20 and C++23 (in r-devel)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,8 @@
 	* DESCRIPTION (Version, Date): Roll minor version
 	* inst/include/Rcpp/config.h: Idem
 
-	* R/Attributes.R: Support C++20 and C++23 via plugins
+	* R/Attributes.R: Support C++20, C++23 and C++2b (for experimental /
+	incomplete support) via new plugins
 
 2022-07-27  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-09-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R: Support C++20 and C++23 via plugins
+
 2022-07-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2022-09-20  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h: Idem
+
 	* R/Attributes.R: Support C++20 and C++23 via plugins
 
 2022-07-27  Dirk Eddelbuettel  <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.9.1
-Date: 2022-07-27
+Version: 1.0.9.2
+Date: 2022-09-20
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -551,7 +551,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
         list(env = list(PKG_CXXFLAGS ="-std=c++20"))
 }
 
-# built-in C++23 plugin for C++20
+# built-in C++23 plugin for C++23
 .plugins[["cpp23"]] <- function() {
     if (getRversion() >= "4.3")         # with recent R versions, R can decide
         list(env = list(USE_CXX23 = "yes"))

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -573,6 +573,11 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
     list(env = list(PKG_CXXFLAGS ="-std=c++2a"))
 }
 
+## built-in C++2b plugin for compilers without C++23 support
+.plugins[["cpp2b"]] <- function() {
+    list(env = list(PKG_CXXFLAGS ="-std=c++2b"))
+}
+
 ## built-in OpenMP plugin
 .plugins[["openmp"]] <- function() {
     list(env = list(PKG_CXXFLAGS="-fopenmp",

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -556,7 +556,7 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
     if (getRversion() >= "4.3")         # with recent R versions, R can decide
         list(env = list(USE_CXX23 = "yes"))
     else
-        list(env = list(PKG_CXXFLAGS ="-std=c++20"))
+        list(env = list(PKG_CXXFLAGS ="-std=c++23"))
 }
 
 

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -543,6 +543,23 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
         list(env = list(PKG_CXXFLAGS ="-std=c++17"))
 }
 
+# built-in C++20 plugin for C++20
+.plugins[["cpp20"]] <- function() {
+    if (getRversion() >= "4.2")         # with recent R versions, R can decide
+        list(env = list(USE_CXX20 = "yes"))
+    else
+        list(env = list(PKG_CXXFLAGS ="-std=c++20"))
+}
+
+# built-in C++23 plugin for C++20
+.plugins[["cpp23"]] <- function() {
+    if (getRversion() >= "4.3")         # with recent R versions, R can decide
+        list(env = list(USE_CXX23 = "yes"))
+    else
+        list(env = list(PKG_CXXFLAGS ="-std=c++20"))
+}
+
+
 ## built-in C++1z plugin for C++17 standard under development
 ## note that as of Feb 2017 this is taken to be a moving target
 ## see https://gcc.gnu.org/projects/cxx-status.html

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp release version 1.0.9.1 (2022-07-27)}{
+\section{Changes in Rcpp release version 1.0.9.2 (2022-09-20)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
@@ -12,6 +12,11 @@
       including \code{Rcpp.h}. \code{RCPP_USE_UNWIND_PROTECT} is not checked
       anymore and has no effect. The associated plugin \code{unwindProtect}
       is therefore deprecated and will be removed in a future release.
+    }
+    \item Changes in Rcpp Attributes:
+    \itemize{
+      \item The C++20 and C+=23 standards are now supported via plugins
+      just like the other C++ standards (Dirk in \ghpr{1228})
     }
   }
 }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,8 +15,8 @@
     }
     \item Changes in Rcpp Attributes:
     \itemize{
-      \item The C++20 and C+=23 standards are now supported via plugins
-      just like the other C++ standards (Dirk in \ghpr{1228})
+      \item The C++20, C++2b (experimental) and C++23 standards now have
+      plugin support like the other C++ standards (Dirk in \ghpr{1228})
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.9"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,1)
-#define RCPP_DEV_VERSION_STRING "1.0.9.1"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,2)
+#define RCPP_DEV_VERSION_STRING "1.0.9.2"
 
 #endif


### PR DESCRIPTION
r-devel now support C++23 as a compilation standard (if and when the compiler does) so we added a plugin.  We also added one for C++20 which we had apparently skipped.

Tested both under r-devel (svn r82883) and worked.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
