### PR TITLE
force 'finalize' method to be materialized on Modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2022-09-23  Kevin Ushey  <kevinushey@gmail.com>
 
-    * R/Module.R: Force 'finalize' method to be materialized
+	* R/Module.R: Force 'finalize' method to be materialized
 
 2022-09-20  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-09-23  Kevin Ushey  <kevinushey@gmail.com>
+
+    * R/Module.R: Force 'finalize' method to be materialized
+
 2022-09-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/R/Module.R
+++ b/R/Module.R
@@ -131,6 +131,8 @@ new_dummyObject <- function(...)                                # #nocov
 
 # class method for $initialize
 cpp_object_initializer <- function(.self, .refClassDef, ..., .object_pointer){
+    # force finalize method to be materialized
+    invisible(.self$finalize)
     selfEnv <- as.environment(.self)
     ## generate the C++-side object and store its pointer, etc.
     ## access the private fields in the fieldPrototypes env.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,9 @@
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
+      \item The 'finalize' method for Rcpp Modules is now eagerly materialized,
+      fixing an issue where errors can occur when Module finalizers are run.
+      (Kevin in \ghpr{1231})
       \item Unwind protection is enabled by default (Iñaki in \ghpr{1225}).
       It can be disabled by defining \code{RCPP_NO_UNWIND_PROTECT} before
       including \code{Rcpp.h}. \code{RCPP_USE_UNWIND_PROTECT} is not checked


### PR DESCRIPTION
Closes https://github.com/RcppCore/Rcpp/issues/1230.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferebly, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
