### PR TITLE
Support zero row data frame push back/front (closes #1232)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2022-10-06  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_dataframe.R (test.DataFrame.PushZeroLength): Add
+	new test
+	* inst/tinytest/cpp/DataFrame.cpp (DataFrame_PushOnEmpty): C++
+	support for new test
+
 2022-10-04  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/DataFrame.h (set_type_after_push): Allow zero-row

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-10-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/DataFrame.h (set_type_after_push): Allow zero-row
+	data.frame objects to be grown by push_{back,front}()
+
 2022-09-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2022-10-06  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* inst/tinytest/test_dataframe.R (test.DataFrame.PushZeroLength): Add
 	new test
 	* inst/tinytest/cpp/DataFrame.cpp (DataFrame_PushOnEmpty): C++

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.9.3
-Date: 2022-09-25
+Version: 1.0.9.3.1
+Date: 2022-10-04
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.9.3.1
-Date: 2022-10-04
+Version: 1.0.9.4
+Date: 2022-10-06
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -140,10 +140,12 @@ namespace Rcpp{
                     max_rows = Rf_xlength(*it);
                 }
             }
-            for (it = Parent::begin(); it != Parent::end(); ++it) {
-                if (Rf_xlength(*it) == 0 || ( Rf_xlength(*it) > 1 && max_rows % Rf_xlength(*it) != 0 )) {
-                    // We have a column that is not an integer fraction of the largest
-                    invalid_column_size = true;
+            if (max_rows > 0) {
+                for (it = Parent::begin(); it != Parent::end(); ++it) {
+                    if (Rf_xlength(*it) == 0 || ( Rf_xlength(*it) > 1 && max_rows % Rf_xlength(*it) != 0 )) {
+                        // We have a column that is not an integer fraction of the largest
+                        invalid_column_size = true;
+                    }
                 }
             }
             if (invalid_column_size) {

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.9"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,3)
-#define RCPP_DEV_VERSION_STRING "1.0.9.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,4)
+#define RCPP_DEV_VERSION_STRING "1.0.9.4"
 
 #endif

--- a/inst/tinytest/cpp/DataFrame.cpp
+++ b/inst/tinytest/cpp/DataFrame.cpp
@@ -192,3 +192,17 @@ DataFrame DataFrame_PushZeroLength(){
   df1.push_back(v);
   return df1;
 }
+
+// issue #1232
+// [[Rcpp::export]]
+Rcpp::DataFrame DataFrame_PushOnEmpty() {
+    int n = 0;
+    Rcpp::IntegerVector foo(n);
+    Rcpp::CharacterVector bar(n);
+    Rcpp::CharacterVector baz(n);
+
+    Rcpp::List ll = Rcpp::List::create(Rcpp::Named("foo") = foo,
+                                       Rcpp::Named("bar") = bar);
+    ll.push_back(baz, "baz");
+    return Rcpp::DataFrame(ll);
+}

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -113,3 +113,7 @@ expect_equal( DataFrame_PushReplicateLength(), df )
 
 #    test.DataFrame.PushZeroLength <- function(){
 expect_warning( DataFrame_PushZeroLength())
+
+## issue #1232: push on empty data.frame
+df <- DataFrame_PushOnEmpty()
+expect_equal(ncol(df), 3L)


### PR DESCRIPTION
#### Rationale

This PR addresses the issue identified in #1232 where one cannot push (back or front) into zero-row data.frame objects.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
