### PR TITLE
Additional file path normalization to protect a windows path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-10-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R (sourceCpp): Protect path to binary from spaces
+
 2022-10-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2022-10-12  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* R/Attributes.R (sourceCpp): Protect path to binary from spaces
 
 2022-10-06  Dirk Eddelbuettel  <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.9.4
-Date: 2022-10-06
+Version: 1.0.9.5
+Date: 2022-10-12
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -129,7 +129,8 @@ sourceCpp <- function(file = "",
         }                                                       # #nocov end
 
         # grab components we need to build command
-        r <- normalizePath(file.path(R.home("bin"), "R"), winslash = "/", mustWork = FALSE)
+        r <- file.path(R.home("bin"), "R")
+        if (.Platform$OS.type == "windows") r <- shQuote(r)
         lib  <- context$dynlibFilename
         deps <- context$cppDependencySourcePaths
         src  <- context$cppSourceFilename

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -129,7 +129,7 @@ sourceCpp <- function(file = "",
         }                                                       # #nocov end
 
         # grab components we need to build command
-        r <- paste(R.home("bin"), "R", sep = .Platform$file.sep)
+        r <- normalizePath(file.path(R.home("bin"), "R"), winslash = "/", mustWork = FALSE)
         lib  <- context$dynlibFilename
         deps <- context$cppDependencySourcePaths
         src  <- context$cppSourceFilename

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.9"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,4)
-#define RCPP_DEV_VERSION_STRING "1.0.9.4"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,9,5)
+#define RCPP_DEV_VERSION_STRING "1.0.9.5"
 
 #endif


### PR DESCRIPTION
#### Motivation

Issue #1234 demonstrated that we had a left-over non-normalized path, this PR addresses this.  

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
