### PR TITLE
Use snprintf instead of sprintf (even in trivial case)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 	* inst/tinytest/cpp/coerce.cpp: add coerce unit tests
 	* inst/tinytest/test_coerce.R: idem
 
+2022-10-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/internal/r_coerce.h (coerce_to_string<RAWSXP >):
+	Replace last remaining sprintf with snprintf
+
 2022-10-12  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/include/Rcpp/internal/r_coerce.h
+++ b/inst/include/Rcpp/internal/r_coerce.h
@@ -246,14 +246,14 @@ inline const char* coerce_to_string<REALSXP>(double x){
 template <>
 inline const char* coerce_to_string<INTSXP >(int from) {
 	static char buffer[NB] ;
-    snprintf( buffer, NB, "%*d", integer_width(from), from );
+    snprintf(buffer, NB, "%*d", integer_width(from), from);
     return buffer ;
 }
 template <>
 inline const char* coerce_to_string<RAWSXP >(Rbyte from){
 	static char buff[3];
-    ::sprintf(buff, "%02x", from);
-    return buff ;
+    snprintf(buff, 3, "%02x", from);
+    return buff;
 }
 template <>
 inline const char* coerce_to_string<LGLSXP >(int from){


### PR DESCRIPTION
This commit replace the sole use `sprintf` with `snprintf`.  A full run of reverse depends checks revealed no 'change to worse'.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
