### PR TITLE
add small unit test for coerce

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-10-27  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/tinytest/cpp/coerce.cpp: add coerce unit tests
+	* inst/tinytest/test_coerce.R: idem
+
 2022-10-12  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/tinytest/cpp/coerce.cpp
+++ b/inst/tinytest/cpp/coerce.cpp
@@ -1,0 +1,28 @@
+// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
+//
+// coerce.cpp: Rcpp R/C++ interface class library -- coerce unit tests
+//
+// Copyright (C) 2022  Dirk Eddelbuettel and Kevin Ushey
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <Rcpp.h>
+using namespace Rcpp ;
+
+// [[Rcpp::export]]
+std::string coerce_raw_to_string(Rbyte x) {
+    return internal::coerce_to_string<RAWSXP>(x);
+}

--- a/inst/tinytest/test_coerce.R
+++ b/inst/tinytest/test_coerce.R
@@ -1,0 +1,23 @@
+
+##  Copyright (C) 2022  Dirk Eddelbuettel and Kevin Ushey
+##
+##  This file is part of Rcpp.
+##
+##  Rcpp is free software: you can redistribute it and/or modify it
+##  under the terms of the GNU General Public License as published by
+##  the Free Software Foundation, either version 2 of the License, or
+##  (at your option) any later version.
+##
+##  Rcpp is distributed in the hope that it will be useful, but
+##  WITHOUT ANY WARRANTY; without even the implied warranty of
+##  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+##  GNU General Public License for more details.
+##
+##  You should have received a copy of the GNU General Public License
+##  along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+if (Sys.getenv("RunAllRcppTests") != "yes") exit_file("Set 'RunAllRcppTests' to 'yes' to run.")
+
+Rcpp::sourceCpp("cpp/coerce.cpp")
+
+expect_equal(coerce_raw_to_string(0xaa), "aa")


### PR DESCRIPTION
### Pull Request Template for Rcpp

Related to https://github.com/RcppCore/Rcpp/pull/1236; this PR adds a unit test for the Rbyte -> const char* coercion routine used in Rcpp.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
