### PR TITLE
Address a warning from g++-12

### DIFF
--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -1621,7 +1621,7 @@ namespace attributes {
         // Look for the signature termination ({ or ; not inside quotes)
         // on this line and then subsequent lines if necessary
         std::string signature;
-        for (size_t i = lineNumber; i<lines_.size(); i++) {
+        for (size_t i = lineNumber; i < (size_t)lines_.size(); i++) {
             std::string line;
             line = lines_[i];
             bool insideQuotes = false;


### PR DESCRIPTION
This micro PR is a follow-up from #1240 and silences a warning now created by `g++-12`.  The change is included in the reverse-depends check now running.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
