### PR TITLE
Quoting only non-standard paths on linux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-01-24  Lukasz Laniewski-Wollk  <llaniewski@meil.pw.edu.pl>
+
+	* R/RcppLdpath.R: CxxFlags() now quotes only non-standard paths on linux
+
 2023-01-08  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/String.h: Address clang++-14 conversion warning

--- a/R/RcppLdpath.R
+++ b/R/RcppLdpath.R
@@ -21,16 +21,11 @@ Rcpp.system.file <- function(...){
 }
 
 ## quote path if non-standard characters are used
-Rcpp.quoteNonStandard <- function(path, quoteAll = .Platform$OS.type!="unix") {
-    quoted <- shQuote(path)
-    if (quoteAll) {
-        quoted
-    } else {
-        # Select paths in which all characters do not need quoting
-        sel <- grepl("^[[:alnum:]/._~+@%-]*$", path)
-        # Quote remaining paths
-        ifelse(sel, path, quoted)
-    }
+Rcpp.quoteNonStandard <- function(path) {
+    ## On unix, check if path has only characters that do not need quoting
+    noquote <- .Platform$OS.type == "unix" && grepl("^[[:alnum:]/._~+@%-]*$", path)
+    ## If no quoting needed return unchanged else quote input
+    if (noquote) path else shQuote(path)
 }
 
 ## Use R's internal knowledge of path settings to find the lib/ directory

--- a/R/RcppLdpath.R
+++ b/R/RcppLdpath.R
@@ -20,6 +20,19 @@ Rcpp.system.file <- function(...){
     tools::file_path_as_absolute( base::system.file( ..., package = "Rcpp" ) )
 }
 
+## quote path if non-standard characters are used
+Rcpp.quoteNonStandard <- function(path, quoteAll = .Platform$OS.type!="unix") {
+    quoted <- shQuote(path)
+    if (quoteAll) {
+        quoted
+    } else {
+        # Select paths in which all characters do not need quoting
+        sel <- grepl("^[[:alnum:]/._~+@%-]*$", path)
+        # Quote remaining paths
+        ifelse(sel, path, quoted)
+    }
+}
+
 ## Use R's internal knowledge of path settings to find the lib/ directory
 ## plus optinally an arch-specific directory on system building multi-arch
 RcppLdPath <- function() {
@@ -51,7 +64,7 @@ RcppCxxFlags <- function(cxx0x=FALSE) {
     if (.Platform$OS.type=="windows") {
         path <- asBuildPath(path)				# #nocov
     }
-    paste0('-I"', path, '"')
+    paste0('-I', Rcpp.quoteNonStandard(path))
 }
 
 ## Shorter names, and call cat() directly

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,16 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
+\section{Changes in Rcpp hotfix release version 1.0.11 (2023-07-xx)}{
+  \itemize{
+    \item Changes in Rcpp API:
+    \itemize{
+      \item \code{Rcpp:::CxxFlags()} now quotes only non-standard include path
+       on linux (closing \ghit{1242}).
+    }
+  }
+}
+
 \section{Changes in Rcpp release version 1.0.10 (2023-01-12)}{
   \itemize{
     \item Changes in Rcpp API:


### PR DESCRIPTION
This closes #1242

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
