### PR TITLE
Silence two tests 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_xptr.R: Condition one test writing to stdout
+	on test verbosity environment variable being set
+
 2023-01-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,6 @@
-2023-01-29  Dirk Eddelbuettel  <edd@debian.org>
+2023-01-29  Iñaki Ucar  <iucar@fedoraproject.org>
 
-	* inst/tinytest/test_xptr.R: Condition one test writing to stdout
-	on test verbosity environment variable being set
+	* inst/tinytest/test_xptr.R: Fix a couple of tests writing to stdout
 
 2023-01-24  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -64,5 +64,7 @@ expect_silent(system(cmd), info="check that finalizer is NOT called on exit")
 
 if (packageVersion("tinytest") < "1.2.0") exit_file("Skip remainder on older test platform")
 
-writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
-expect_stdout(system(cmd), info="check that finalizer is called on exit")
+if (Sys.getenv("RunVerboseRcppTests") == "yes") {
+    writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
+    expect_stdout(system(cmd), info="check that finalizer is called on exit")
+}

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -60,11 +60,9 @@ void test() {
 '
 
 writeLines(code, file_path)
-expect_silent(system(cmd), info="check that finalizer is NOT called on exit")
+expect_equal(system(cmd, intern=TRUE), character(0))
 
 if (packageVersion("tinytest") < "1.2.0") exit_file("Skip remainder on older test platform")
 
-if (Sys.getenv("RunVerboseRcppTests") == "yes") {
-    writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
-    expect_stdout(system(cmd), info="check that finalizer is called on exit")
-}
+writeLines(c("#define RCPP_USE_FINALIZE_ON_EXIT", code), file_path)
+expect_equal(system(cmd, intern=TRUE), "custom_finalizer was called")


### PR DESCRIPTION
This trivial PR makes one test (that otherwise barks on `stdout`) conditional on the env var making some tests quiet.  As we use `system()` the stdout capture of tinytest does not work for us.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
