### PR TITLE
Enable compilation under C++20 with clang++ and its standard library 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-02-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/sugar/functions/sapply.h: Enable compilation
+	under C++20 (using clang++ and its C++ library) via invoke_result
+
 2023-01-29  Iñaki Ucar  <iucar@fedoraproject.org>
 
 	* inst/tinytest/test_xptr.R: Fix a couple of tests writing to stdout

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
+
 // sapply.h: Rcpp R/C++ interface class library -- sapply
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2023 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -33,7 +32,13 @@ template <typename Function, typename SugarExpression>
 struct sapply_application_result_of
 {
 #if defined(RCPP_USING_CXX0X_OR_LATER)
-	typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
+    #if __cplusplus < 201703L
+        // deprecated by C++17, removed by C++2020, see https://en.cppreference.com/w/cpp/types/result_of
+ 	    typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
+    #else
+        // since C++17, see https://en.cppreference.com/w/cpp/types/result_of
+ 	    typedef typename ::std::invoke_result<Function(typename SugarExpression::stored_type)>::type type;
+    #endif
 #else
 	typedef typename ::Rcpp::traits::result_of<Function>::type type;
 #endif

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -37,7 +37,7 @@ struct sapply_application_result_of
  	    typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
     #else
         // since C++17, see https://en.cppreference.com/w/cpp/types/result_of
- 	    typedef typename ::std::invoke_result<Function(typename SugarExpression::stored_type)>::type type;
+        typedef typename ::std::invoke_result<Function, typename SugarExpression::stored_type>::type type;
     #endif
 #else
 	typedef typename ::Rcpp::traits::result_of<Function>::type type;


### PR DESCRIPTION
When using C++20 with `clang++` (version 15) _and_ also adding `-stdlib=libc++` to enable use of its standard library,
the removal of `std::result_of` bites us and compilation fails.  This was deprecated in C++17, and removed in C++20.  Conditional use of the replacement `std::invoke_result` works.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
