### PR TITLE
Use new CITATION format preferred by r-devel (Closes #1249)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-06  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/CITATION: Update to new format preferred by r-devel
+
 2023-02-02  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,50 +1,41 @@
-citHeader("To cite Rcpp in publications use:")
+bibentry("Manual",
+         other = unlist(citation(auto = meta), recursive = FALSE))
 
-citEntry(entry = "Article",
+bibentry("Article",
          title        = "{Rcpp}: Seamless {R} and {C++} Integration",
-         author       = personList(as.person("Dirk Eddelbuettel"),
-                                   as.person("Romain Fran\\c{c}ois")),
+         author       = c(person("Dirk", "Eddelbuettel",
+                                 email = "edd@debian.org",
+                                 comment = c(ORCID = "0000-0001-6419-907X")),
+                          person("Romain", "Fran\\c{c}ois")),
          journal      = "Journal of Statistical Software",
          year         = "2011",
          volume       = "40",
          number       = "8",
          pages        = "1--18",
-         doi          = "10.18637/jss.v040.i08",
+         doi          = "10.18637/jss.v040.i08")
 
-         textVersion  = paste("Dirk Eddelbuettel and Romain Francois (2011).",
-                              "Rcpp: Seamless R and C++ Integration.",
-                              "Journal of Statistical Software, 40(8), 1-18, ",
-                              "<doi:10.18637/jss.v040.i08>.")
-)
-
-citEntry(entry = "Book",
+bibentry("Book",
          title        = "Seamless {R} and {C++} Integration with {Rcpp}",
-         author       = personList(as.person("Dirk Eddelbuettel")),
+         author       = person("Dirk", "Eddelbuettel",
+                               email = "edd@debian.org",
+                               comment = c(ORCID = "0000-0001-6419-907X")),
          publisher    = "Springer",
          address      = "New York",
          year         = 2013,
          note         = "ISBN 978-1-4614-6867-7",
-         doi          = "10.1007/978-1-4614-6868-4",
+         doi          = "10.1007/978-1-4614-6868-4")
 
-         textVersion  = paste("Eddelbuettel, Dirk (2013)",
-                              "Seamless R and C++ Integration with Rcpp,",
-                              "Springer, New York, ISBN 978-1-4614-6867-7,",
-                              "<doi:10.1007/978-1-4614-6868-4>.")
-)
-
-citEntry(entry = "Article",
-         title       = "{Extending \textit{R} with \textit{C++}: A Brief Introduction to \textit{Rcpp}}",
-         author      = personList(as.person("Dirk Eddelbuettel"),
-                                  as.person("James Joseph Balamuta")),
+bibentry("Article",
+         title       = "{Extending {R} with {C++}: A Brief Introduction to {Rcpp}}",
+         author       = c(person("Dirk", "Eddelbuettel",
+                                 email = "edd@debian.org",
+                                 comment = c(ORCID = "0000-0001-6419-907X")),
+                          person("James Joseph", "Balamuta",
+                                 email = "balamut2@illinois.edu",
+                                 comment = c(ORCID = "0000-0003-2826-8458"))),
          journal     = "The American Statistician",
          year        = "2018",
          volume      = "72",
          number      = "1",
          pages       = "28-36",
-         doi         = "10.1080/00031305.2017.1375990",
-
-         textVersion = paste("Dirk Eddelbuettel and James Joseph Balamuta (2018).",
-                             "Extending R with C++: A Brief Introduction to Rcpp.",
-                             "The American Statistician. 72(1),",
-                             "<doi:10.1080/00031305.2017.1375990>.")
-)
+         doi         = "10.1080/00031305.2017.1375990")


### PR DESCRIPTION
The CITATION format changed, r-devel now nags. I took a look at one of the packages by Kurt Hornik before I made a first change (to RcppArmadillo); this follows the same patter.

It now looks like this:

```sh
edd@rob:~/git/rcpp(feature/update_citation)$ r -pe'citation(package="Rcpp")'

To cite package ‘Rcpp’ in publications use:

  Eddelbuettel D, Francois R, Allaire J, Ushey K, Kou Q, Russell N, Ucar I, Bates D, Chambers J (2023). _Rcpp: Seamless R and C++ Integration_. https://www.rcpp.org,
  https://dirk.eddelbuettel.com/code/rcpp.html, https://github.com/RcppCore/Rcpp.

  Eddelbuettel D, François R (2011). “Rcpp: Seamless R and C++ Integration.” _Journal of Statistical Software_, *40*(8), 1-18. doi:10.18637/jss.v040.i08
  <https://doi.org/10.18637/jss.v040.i08>.

  Eddelbuettel D (2013). _Seamless R and C++ Integration with Rcpp_. Springer, New York. doi:10.1007/978-1-4614-6868-4 <https://doi.org/10.1007/978-1-4614-6868-4>, ISBN
  978-1-4614-6867-7.

  Eddelbuettel D, Balamuta J (2018). “Extending R with C++: A Brief Introduction to Rcpp.” _The American Statistician_, *72*(1), 28-36. doi:10.1080/00031305.2017.1375990
  <https://doi.org/10.1080/00031305.2017.1375990>.

To see these entries in BibTeX format, use 'print(<citation>, bibtex=TRUE)', 'toBibtex(.)', or set 'options(citation.bibtex.max=999)'.

edd@rob:~/git/rcpp(feature/update_citation)$ 
```

Paging @coatless who is in there (I used your Illinois email and followed your RcppEnmallen DESCRIPTION). I am not quite convinced an email is needed when the ORCiD is there.  Ah well.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
