### PR TITLE
Use more accurate qnorm value from R 4.3.0 (Closes #1251)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-07  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_stats.R: Use more accurate value in R 4.3.0
+
 2023-02-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/CITATION: Update to new format preferred by r-devel

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -14,6 +14,16 @@
       \item Compilation under C++ using \pkg{clang++} and its standard
       library is enabled (Dirk in \ghpr{1248}) closing \ghit{1244}).
     }
+    \item Changes in Rcpp Documentation:
+    \itemize{
+      \item The CITATION file format has been updated (Dirk in \ghpr{1250}
+      fixing \ghit{1249}.
+    }
+    \item Changes in Rcpp Deployment:
+    \itemize{
+      \item A test for \code{qnorm} now uses the more accurate value from R
+      4.3.0 (Dirk in \ghpr{1252} fixing \ghit{1251}).
+    }
   }
 }
 

--- a/inst/tinytest/test_stats.R
+++ b/inst/tinytest/test_stats.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2010 - 2019  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2010 - 2023  Dirk Eddelbuettel and Romain Francois
 ##
 ##  This file is part of Rcpp.
 ##
@@ -243,7 +243,11 @@ expect_equal(runit_qnorm_log(c(-Inf, 0, 0.1)),
              list(lower = c(-Inf, Inf, NaN),
                   upper = c(Inf, -Inf, NaN)),
              info = "stats.qnorm" )
-expect_equal(runit_qnorm_log(-1e5)$lower, -447.1974945)
+if (getRversion() >= "4.3.0") {			# newer high-precision code in R 4.3.0
+    expect_equal(runit_qnorm_log(-1e5)$lower, -447.197893678525)
+} else { 								# older pre-R 4.3.0 value
+    expect_equal(runit_qnorm_log(-1e5)$lower, -447.1974945)
+}
 
 #    test.stats.qpois.prob <- function( ) {
 vv <- seq(0, 1, by = 0.1)


### PR DESCRIPTION
R-devel, per the Feb 4 NEWS post, now have a more accurate `qnorm`.  We need to reflect that in a test.

There may a 'timing' issue with the docker container used for r-devel, but if this fails now I will update the container.  The new tests passes locally.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
