### PR TITLE
Update code generation with one more backtick (instead of apostrophe) pair

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-03-19  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/attributes.cpp (RExportsGenerator::writeEnd): Replace a pair of
+	apostrophes with backticks in generated .Call() statemente
+
 2023-02-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_stats.R: Use more accurate value in R 4.3.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-03-19  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* src/attributes.cpp (RExportsGenerator::writeEnd): Replace a pair of
 	apostrophes with backticks in generated .Call() statemente
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.10.2
-Date: 2023-02-02
+Version: 1.0.10.3
+Date: 2023-03-19
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,6 +13,8 @@
       Iñaki in \ghpr{1245}).
       \item Compilation under C++ using \pkg{clang++} and its standard
       library is enabled (Dirk in \ghpr{1248}) closing \ghit{1244}).
+      \item Use backticks in a generated \code{.Call()} statement in
+      `RcppExports.R` (Dirk \ghpr{1256} closing \ghit{1255}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp rc version 1.0.10.2 for 1.0.11 (2023-07-xx)}{
+\section{Changes in Rcpp rc version 1.0.10.3 for 1.0.11 (2023-07-xx)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.10"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,2)
-#define RCPP_DEV_VERSION_STRING "1.0.10.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,3)
+#define RCPP_DEV_VERSION_STRING "1.0.10.3"
 
 #endif

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2541,9 +2541,11 @@ namespace attributes {
             ostr() << "methods::setLoadAction(function(ns) {" << std::endl;
             ostr() << "    .Call("
                    << (registration_ ? "`" : "'")
-                   <<  registerCCallableExportedName()
-                   << (registration_ ? "`" : "'")
-                   << ", PACKAGE = '" << package() << "')"
+                   << registerCCallableExportedName()
+                   << (registration_ ? "`" : "'");
+            if (!registration_)
+                ostr() << ", PACKAGE = '" << package() << "'";
+            ostr() << ")"
                    << std::endl << "})" << std::endl;		// #nocov end
         }
     }

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2539,8 +2539,8 @@ namespace attributes {
             ostr() << "# Register entry points for exported C++ functions"
                    << std::endl;
             ostr() << "methods::setLoadAction(function(ns) {" << std::endl;
-            ostr() << "    .Call('" << registerCCallableExportedName()
-                   << "', PACKAGE = '" << package() << "')"
+            ostr() << "    .Call(`" << registerCCallableExportedName()
+                   << "`, PACKAGE = '" << package() << "')"
                    << std::endl << "})" << std::endl;		// #nocov end
         }
     }

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2539,8 +2539,11 @@ namespace attributes {
             ostr() << "# Register entry points for exported C++ functions"
                    << std::endl;
             ostr() << "methods::setLoadAction(function(ns) {" << std::endl;
-            ostr() << "    .Call(`" << registerCCallableExportedName()
-                   << "`, PACKAGE = '" << package() << "')"
+            ostr() << "    .Call("
+                   << (registration_ ? "`" : "'")
+                   <<  registerCCallableExportedName()
+                   << (registration_ ? "`" : "'")
+                   << ", PACKAGE = '" << package() << "')"
                    << std::endl << "})" << std::endl;		// #nocov end
         }
     }


### PR DESCRIPTION
As discussed in #1255, we have (at least) one remaining case of using apostrophes instead of backticks in the generated file `R/RcppExports.R` created by `compileAttributes()`.  

The narrow fix is simple, the wider issue may be to determine if there are other parts that need updating.  We can keep the PR open for a bit to discuss.

#### Checklist

- [X] Code compiles correctly
- [X] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [X] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
