### PR TITLE
skip tests with path issues on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-03-24  Iñaki Ucar  <iucar@fedoraproject.org>
+
+	* inst/tinytest/test_xptr.R: Skip some tests on Windows
+
 2023-03-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -19,6 +19,9 @@
 
 if (Sys.getenv("RunAllRcppTests") != "yes") exit_file("Set 'RunAllRcppTests' to 'yes' to run.")
 
+## used below
+.onWindows <- .Platform$OS.type == "windows"
+
 Rcpp::sourceCpp("cpp/XPtr.cpp")
 
 #    test.XPtr <- function(){
@@ -36,6 +39,8 @@ expect_true(xptr_release(xp), info = "check release of external pointer")
 expect_true(xptr_access_released(xp), info = "check access of released external pointer")
 
 expect_error(xptr_use_released(xp), info = "check exception on use of released external pointer")
+
+if (.onWindows) exit_file("Skipping remainder of file on Windows")
 
 # test finalizeOnExit default depending on RCPP_USE_FINALIZE_ON_EXIT
 file_path <- tempfile(fileext=".cpp")


### PR DESCRIPTION
The fix in https://github.com/RcppCore/Rcpp/commit/54ee8fdd91d954ce9458442f3afeeaac3522b337 uncovered an issue with those two tests on Windows. Life is too short to debug path issues for tests on Windows, so this fix just skips them there.

Successful rhub tests here (there's one ERROR, but it's about vignette rebuilding, something about `texi2pdf` not being found): https://builder.r-hub.io/status/Rcpp_1.0.10.3.tar.gz-94d653c1f4064cf29639fc441187ce3d

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
