### PR TITLE
switch to system2 to be able to capture stderr on error (closes #1257)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-03-25  Iñaki Ucar  <iucar@fedoraproject.org>
+
+	* R/Attributes.R: Switch to system2 to be able to capture stderr on error
+
 2023-03-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci-dev/Dockerfile: During Debian freeze experimental repo is

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -137,7 +137,7 @@ sourceCpp <- function(file = "",
 
         # prepare the command (output if we are in showOutput mode)
         args <- c(
-            r, "CMD", "SHLIB",
+            "CMD", "SHLIB",
             if (windowsDebugDLL) "-d",
             if (rebuild) "--preclean",
             if (dryRun) "--dry-run",
@@ -147,13 +147,13 @@ sourceCpp <- function(file = "",
             shQuote(src)
         )
 
-        cmd <- paste(args, collapse = " ")
         if (showOutput)
-            cat(cmd, "\n")										# #nocov
+            cat(paste(c(r, args), collapse = " "), "\n")		# #nocov
 
         # execute the build -- suppressWarnings b/c when showOutput = FALSE
         # we are going to explicitly check for an error and print the output
-        result <- suppressWarnings(system(cmd, intern = !showOutput))
+        so <- if (showOutput) "" else TRUE
+        result <- suppressWarnings(system2(r, args, stdout = so, stderr = so))
 
         # check build results
         if(!showOutput) {


### PR DESCRIPTION
Minimal changes, fixes #1257. According to [rcheology](https://github.com/hughjonesd/rcheology), `system2` has been around since 2.12.0, and allows us to capture both stdout and stderr when `showOutput=FALSE`. A collateral advantage is that now, when an error happens, the output is in the correct order (previously, the error appeared _first_, then the compilation command).

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
