### PR TITLE
Adjust two sets of tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-03-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_stats.R: Revisit change from PR #1252; we now
+	use a slightly smaller tolerance to accomodate old and new value
+
 2023-03-25  Iñaki Ucar  <iucar@fedoraproject.org>
 
 	* R/Attributes.R: Switch to system2 to be able to capture stderr on error

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 	* inst/tinytest/test_stats.R: Revisit change from PR #1252; we now
 	use a slightly smaller tolerance to accomodate old and new value
 
+	* inst/tinytest/test_sugar.R: Protect a small number of tests on NA
+	propagation from running on arm64/Darwin which requires special care
+
 2023-03-25  Iñaki Ucar  <iucar@fedoraproject.org>
 
 	* R/Attributes.R: Switch to system2 to be able to capture stderr on error

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* inst/tinytest/test_stats.R: Revisit change from PR #1252; we now
 	use a slightly smaller tolerance to accomodate old and new value
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.10.3
-Date: 2023-03-19
+Version: 1.0.10.4
+Date: 2023-03-26
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.10"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,3)
-#define RCPP_DEV_VERSION_STRING "1.0.10.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,4)
+#define RCPP_DEV_VERSION_STRING "1.0.10.4"
 
 #endif

--- a/inst/tinytest/test_stats.R
+++ b/inst/tinytest/test_stats.R
@@ -243,11 +243,9 @@ expect_equal(runit_qnorm_log(c(-Inf, 0, 0.1)),
              list(lower = c(-Inf, Inf, NaN),
                   upper = c(Inf, -Inf, NaN)),
              info = "stats.qnorm" )
-if (getRversion() >= "4.3.0") {			# newer high-precision code in R 4.3.0
-    expect_equal(runit_qnorm_log(-1e5)$lower, -447.197893678525)
-} else { 								# older pre-R 4.3.0 value
-    expect_equal(runit_qnorm_log(-1e5)$lower, -447.1974945)
-}
+## newer high-precision code in R 4.3.0 has slightly different value
+## of -447.197893678525 so lowering tolerance a little
+expect_equal(runit_qnorm_log(-1e5)$lower, -447.1974945, tolerance=1e-6)
 
 #    test.stats.qpois.prob <- function( ) {
 vv <- seq(0, 1, by = 0.1)

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2010 - 2019  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2010 - 2023  Dirk Eddelbuettel and Romain Francois
 ##
 ##  This file is part of Rcpp.
 ##
@@ -20,6 +20,10 @@ if (Sys.getenv("RunAllRcppTests") != "yes") exit_file("Set 'RunAllRcppTests' to 
 
 Rcpp::sourceCpp("cpp/sugar.cpp")
 
+## There are some (documented, see https://blog.r-project.org/2020/11/02/will-r-work-on-apple-silicon/index.html)
+## issues with NA propagation on arm64 / macOS. We not (yet ?) do anything special so we just skip some tests
+isArmMacOs <- Sys.info()[["sysname"]] == "Darwin" && Sys.info()[["machine"]] == "arm64"
+
 ## Needed for a change in R 3.6.0 reducing a bias in very large samples
 suppressWarnings(RNGversion("3.5.0"))
 
@@ -31,8 +35,8 @@ expect_equal( runit_abs(x,y) , list( abs(x), abs(y) ) )
 #    test.sugar.all.one.less <- function( ){
 expect_true( runit_all_one_less( 1 ) )
 expect_true( ! runit_all_one_less( 1:10 ) )
-expect_true( is.na( runit_all_one_less( NA ) ) )
-expect_true( is.na( runit_all_one_less( c( NA, 1)  ) ) )
+if (!isArmMacOs) expect_true( is.na( runit_all_one_less( NA ) ) )
+if (!isArmMacOs) expect_true( is.na( runit_all_one_less( c( NA, 1)  ) ) )
 expect_true( ! runit_all_one_less( c( 6, NA)  ) )
 
 
@@ -41,14 +45,14 @@ expect_true( ! runit_all_one_greater( 1 ) )
 expect_true( ! runit_all_one_greater( 1:10 ) )
 expect_true( runit_all_one_greater( 6:10 ) )
 expect_true( ! runit_all_one_greater( c(NA, 1) ) )
-expect_true( is.na( runit_all_one_greater( c(NA, 6) ) ) )
+if (!isArmMacOs) expect_true( is.na( runit_all_one_greater( c(NA, 6) ) ) )
 
 
 #    test.sugar.all.one.less.or.equal <- function( ){
 expect_true( runit_all_one_less_or_equal( 1 ) )
 expect_true( ! runit_all_one_less_or_equal( 1:10 ) )
-expect_true( is.na( runit_all_one_less_or_equal( NA ) ) )
-expect_true( is.na( runit_all_one_less_or_equal( c( NA, 1)  ) ) )
+if (!isArmMacOs) expect_true( is.na( runit_all_one_less_or_equal( NA ) ) )
+if (!isArmMacOs) expect_true( is.na( runit_all_one_less_or_equal( c( NA, 1)  ) ) )
 expect_true( ! runit_all_one_less_or_equal( c( 6, NA)  ) )
 expect_true( runit_all_one_less_or_equal( 5 ) )
 
@@ -61,7 +65,7 @@ expect_true( ! fx( 1:10 ) )
 expect_true( fx( 6:10 ) )
 expect_true( fx( 5 ) )
 expect_true( ! fx( c(NA, 1) ) )
-expect_true( is.na( fx( c(NA, 6) ) ) )
+if (!isArmMacOs) expect_true( is.na( fx( c(NA, 6) ) ) )
 
 
 #    test.sugar.all.one.equal <- function( ){
@@ -69,7 +73,7 @@ fx <- runit_all_one_equal
 expect_true( ! fx( 1 ) )
 expect_true( ! fx( 1:2 ) )
 expect_true( fx( rep(5,4) ) )
-expect_true( is.na( fx( c(5,NA) ) ) )
+if (!isArmMacOs) expect_true( is.na( fx( c(5,NA) ) ) )
 expect_true(! fx( c(NA, 1) ) )
 
 
@@ -78,7 +82,7 @@ fx <- runit_all_not_equal_one
 expect_true( fx( 1 ) )
 expect_true( fx( 1:2 ) )
 expect_true( ! fx( 5 ) )
-expect_true( is.na( fx( c(NA, 1) ) ) )
+if (!isArmMacOs) expect_true( is.na( fx( c(NA, 1) ) ) )
 expect_true( ! fx( c(NA, 5) ) )
 
 
@@ -1564,7 +1568,7 @@ expect_error(strimws(x[1], "invalid"), info = "strimws -- bad `which` argument")
 #    test.sugar.min.max <- function() {
 ## min(empty) gives NA for integer, Inf for numeric (#844)
 expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
-expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
+if (!isArmMacOs) expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
 
 ## max(empty_ gives NA for integer, Inf for numeric (#844)
 expect_true(is.na(intmax(integer(0))),     "max(integer(0))")


### PR DESCRIPTION
The qnorm() test adjustment (for a more precise value in R 4.3.0) may have been too ambitious, this PR simplifies using a lower tolerance.

Arm64/Darwin has issues with NA propagation so we condition a handful of tests in the sugar test file.

This was tested on the macbuilder box against R 4.3.0 too.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
