### PR TITLE
remove command quoting in sourceCpp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-03-27  Iñaki Ucar  <iucar@fedoraproject.org>
+
+	* R/Attributes.R: Remove command quoting, not needed anymore for system2()
+	* inst/tinytest/test_xptr.R: Update copyright
+
 2023-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1,5 +1,6 @@
 
 # Copyright (C) 2012 - 2022  JJ Allaire, Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2023         JJ Allaire, Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 #
 # This file is part of Rcpp.
 #
@@ -130,7 +131,6 @@ sourceCpp <- function(file = "",
 
         # grab components we need to build command
         r <- file.path(R.home("bin"), "R")
-        if (.Platform$OS.type == "windows") r <- shQuote(r)
         lib  <- context$dynlibFilename
         deps <- context$cppDependencySourcePaths
         src  <- context$cppSourceFilename

--- a/inst/tinytest/test_xptr.R
+++ b/inst/tinytest/test_xptr.R
@@ -1,6 +1,6 @@
 
 ##  Copyright (C) 2009 - 2020  Dirk Eddelbuettel and Romain Francois
-##  Copyright (C) 2021         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+##  Copyright (C) 2021 - 2023  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 ##
 ##  This file is part of Rcpp.
 ##


### PR DESCRIPTION
Of course, `system2()` already quotes its first argument, I missed that in #1259.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
