### PR TITLE
Simplified container use thanks to hint by @enchufa2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         run: ${{matrix.r }} CMD build --no-build-vignettes --no-manual .
 
       - name: Check
-        run: ${{ matrix.r }} CMD check --no-vignettes --no-manual Rcpp_*.tar.gz
+        run: CI=true ${{ matrix.r }} CMD check --no-vignettes --no-manual Rcpp_*.tar.gz
 
   #covr:
   #  runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 # Run CI for R using https://eddelbuettel.github.io/r-ci/
+# This file is a slight variant by running a matrix of containers
 
 name: ci
 
@@ -12,7 +13,12 @@ env:
 
 jobs:
   ci:
+
     runs-on: ubuntu-latest
+
+    container:
+      image: ${{ matrix.cntr }}
+
     strategy:
       matrix:
         include:
@@ -44,17 +50,14 @@ jobs:
       #    chmod 0755 run.sh
       #    ./run.sh bootstrap
 
-      - name: Container
-        run: docker pull ${{ matrix.cntr }}
-
       - name: SessionInfo
-        run: docker run --rm -i -v ${PWD}:/mnt -w /mnt ${{ matrix.cntr }} ${{ matrix.r }} -q -e 'sessionInfo()'
+        run: ${{ matrix.r }} -q -e 'sessionInfo()'
 
       - name: Build
-        run: docker run --rm -i -v ${PWD}:/mnt -w /mnt ${{ matrix.cntr }} ${{matrix.r }} CMD build --no-build-vignettes --no-manual .
+        run: ${{matrix.r }} CMD build --no-build-vignettes --no-manual .
 
       - name: Check
-        run: docker run --rm -i -v ${PWD}:/mnt -w /mnt -e CI=true ${{ matrix.cntr }} ${{ matrix.r }} CMD check --no-vignettes --no-manual Rcpp_*.tar.gz
+        run: ${{ matrix.r }} CMD check --no-vignettes --no-manual Rcpp_*.tar.gz
 
   #covr:
   #  runs-on: ubuntu-latest

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-04-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .github/workflows/ci.yaml: Simplified container use
+
 2023-03-27  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/stale.yaml: Roll to v8


### PR DESCRIPTION

This PR simplifies the Dockerfile for the Linux grid a little as we can indeed remove a layer of docker invocation as all jobs are already in the specified container.  Thanks to @Enchufa2 for the suggestion.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
