### PR TITLE
Update URLs, set Encoding, roll versions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-06-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* README.md: Two URL updates for appease R CMD check
+
+	* DESCRIPTION (Encoding): Somewhat belated addition
+
 2023-04-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Use app.codecov.io as base for codecov link

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-06-12  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* README.md: Two URL updates for appease R CMD check
 
 	* DESCRIPTION (Encoding): Somewhat belated addition

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.10.4
-Date: 2023-03-26
+Version: 1.0.10.5
+Date: 2023-06-12
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,3 +21,4 @@ License: GPL (>= 2)
 BugReports: https://github.com/RcppCore/Rcpp/issues
 MailingList: rcpp-devel@lists.r-forge.r-project.org
 RoxygenNote: 6.1.1
+Encoding: UTF-8

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ represented as instances of `Rcpp::Environment`, functions are represented as
 `Rcpp::Function`, etc ...  The
 [Rcpp-introduction](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-introduction.pdf)
 vignette (now published as a
-[TAS paper](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.2017.1375990); an
+[TAS paper](https://doi.org/10.1080/00031305.2017.1375990); an
 [earlier introduction](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-jss-2011.pdf)
 was also published as a [JSS paper](https://doi.org/10.18637/jss.v040.i08)
 provides a good entry point to Rcpp as do the [Rcpp
@@ -68,7 +68,7 @@ See the [Rcpp-atttributes](https://cran.r-project.org/package=Rcpp/vignettes/Rcp
 The package ships with ten pdf vignettes, including a [recent introduction to
 Rcpp](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-introduction.pdf) now
 published as a [paper in
-TAS](https://amstat.tandfonline.com/doi/abs/10.1080/00031305.2017.1375990) (and as a
+TAS](https://doi.org/10.1080/00031305.2017.1375990) (and as a
 [preprint in PeerJ](https://peerj.com/preprints/3188/)). Also available is an
 [earlier
 introduction](https://cran.r-project.org/package=Rcpp/vignettes/Rcpp-jss-2011.pdf)

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.10"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,4)
-#define RCPP_DEV_VERSION_STRING "1.0.10.4"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,5)
+#define RCPP_DEV_VERSION_STRING "1.0.10.5"
 
 #endif


### PR DESCRIPTION
#### Motivation

This PR regroups a set of tiny changes prompted by `R(-devel) CMD check` on the current version.  We apparently never set the now-common Encoding, so now we do. The TAS paper seems to have moved at the publisher site so we use the DOI in README.md, and while we were at this we rolled the micro release to .5.

No new code

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
