### PR TITLE
Add a missing -f to one rm, add 4.2 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
           - name: release
             cntr: rcpp/ci
             r: R
+          - name: r-4.2
+            cntr: rcpp/ci-4.2
+            r: R
           - name: r-4.1
             cntr: rcpp/ci-4.1
             r: R

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-07-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* docker/ci-dev/Dockerfile: Make 'rm' more robust as 'rm -f'
+	* docker/ci-4.2/Dockerfile: Add new container for R 4.2.3
+	* .github/workflows/ci.yaml (jobs): Add entry for R 4.2.3
+
 2023-06-12  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/docker/ci-4.2/Dockerfile
+++ b/docker/ci-4.2/Dockerfile
@@ -1,15 +1,14 @@
 ## Emacs, make this -*- mode: sh; -*-
 
-FROM rocker/drd
+FROM r-base:4.2.3
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
       maintainer="Dirk Eddelbuettel <edd@debian.org>"
 
-RUN rm -f /etc/apt/sources.list.d/experimental.list \
-        && apt update -y \
-        && apt install -y --no-install-recommends git \
-        && RDscript -e 'install.packages(c("codetools", "inline", "pkgKitten", "rbenchmark", "tinytest"))'
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && install.r inline pkgKitten rbenchmark tinytest
 
 ENV _R_CHECK_FORCE_SUGGESTS_ FALSE
 ENV _R_CHECK_TESTS_NLINES_ 0


### PR DESCRIPTION
### Pull Request Template for Rcpp

Monthly CI updating the Docker containers broke last evening for the `ci-dev` one: removing the (Debian) "experimental" repo info file broke because ... just after the Debian release update there is none.  So I added a `-f` to the `rm` to make it more robust.  And while add it added a 4.2 entry to the CI matrix.

So in sum a very mechanical PR.  I still have revisiting the CI setup on a TODO list but didn't get to it yet.  Likely some time after the 1.0.11 release.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
