### PR TITLE
Release 1.0.11

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2023-07-03  Dirk Eddelbuettel  <edd@debian.org>
+
+        * DESCRIPTION (Date, Version): Release 1.0.11
+
+        * inst/include/Rcpp/config.h: Idem
+        * inst/NEWS.Rd: Idem
+        * vignettes/rmd/Rcpp.bib: Idem
+        * inst/bib/Rcpp.bib: Idem
+	* vignettes/pdf/*: Rebuilt
+
 2023-07-02  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Update usage numbers in Examples section
@@ -94,6 +104,13 @@
 2023-01-24  Lukasz Laniewski-Wollk  <llaniewski@meil.pw.edu.pl>
 
 	* R/RcppLdpath.R: CxxFlags() now quotes only non-standard paths on linux
+
+2023-01-22  Dirk Eddelbuettel  <edd@debian.org>
+
+        * DESCRIPTION (Date, Version): Release 1.0.10
+
+        * inst/include/Rcpp/config.h: Idem
+        * inst/NEWS.Rd: Idem
 
 2023-01-08  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.10.5
-Date: 2023-06-12
+Version: 1.0.11
+Date: 2023-07-03
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/RcppCore/Rcpp/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/RcppCore/Rcpp/issues/#1}{##1}}
 
-\section{Changes in Rcpp rc version 1.0.10.3 for 1.0.11 (2023-07-xx)}{
+\section{Changes in Rcpp rc version 1.0.11 (2023-07-03)}{
   \itemize{
     \item Changes in Rcpp API:
     \itemize{
@@ -12,19 +12,26 @@
       \item Two unit tests no longer accidentally bark on stdout (Dirk and
       Iñaki in \ghpr{1245}).
       \item Compilation under C++ using \pkg{clang++} and its standard
-      library is enabled (Dirk in \ghpr{1248}) closing \ghit{1244}).
+      library is enabled (Dirk in \ghpr{1248} closing \ghit{1244}).
       \item Use backticks in a generated \code{.Call()} statement in
       `RcppExports.R` (Dirk \ghpr{1256} closing \ghit{1255}).
+      \item Switch to \code{system2()} to capture standard error messages in
+      error cases (Iñaki in \ghpr{1259} and \ghpr{1261} fixing \ghit{1257}).
     }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The CITATION file format has been updated (Dirk in \ghpr{1250}
-      fixing \ghit{1249}.
+      fixing \ghit{1249}).
     }
     \item Changes in Rcpp Deployment:
     \itemize{
       \item A test for \code{qnorm} now uses the more accurate value from R
-      4.3.0 (Dirk in \ghpr{1252} fixing \ghit{1251}).
+      4.3.0 (Dirk in \ghpr{1252} and \ghpr{1260} fixing \ghit{1251}).
+      \item Skip tests with path issues on Windows (Iñaki in \ghpr{1258}).
+      \item Container deployment in continuous integrations was
+      improved. (Iñaki and Dirk in \ghpr{1264}, Dirk in \ghpr{1269}).
+      \item Several files receives minor edits to please \code{R CMD check}
+      from r-devel (Dirk in \ghpr{1267}).
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -26,11 +26,11 @@
 #define RcppDevVersion(maj, min, rev, dev)  (((maj)*1000000) + ((min)*10000) + ((rev)*100) + (dev))
 
 // the currently released version
-#define RCPP_VERSION            Rcpp_Version(1,0,10)
-#define RCPP_VERSION_STRING     "1.0.10"
+#define RCPP_VERSION            Rcpp_Version(1,0,11)
+#define RCPP_VERSION_STRING     "1.0.11"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,10,5)
-#define RCPP_DEV_VERSION_STRING "1.0.10.5"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,0)
+#define RCPP_DEV_VERSION_STRING "1.0.11.0"
 
 #endif


### PR DESCRIPTION
### Pull Request Template for Rcpp

Planning to submit this to CRAN shortly to engage in usual email exchange given the grand-fathered NOTE on `.Call(symbol)` and the likely issues stemming from the numerous reverse-depends.  As before will update the PR with
progress and leave open til we get the anticipated acceptance at CRAN.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Prefereably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
