### PR TITLE
Add missing includes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,5 +7,5 @@ Please explain the changes you want to apply to Rcpp, preferably in an issue tic
 
 - [ ] Code compiles correctly
 - [ ] `R CMD check` still passes all tests
-- [ ] Prefereably, new tests were added which fail without the change
+- [ ] Preferably, new tests were added which fail without the change
 - [ ] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-08-03  Michael Chirico  <chiricom@google.com>
+
+        * src/attributes.cpp: Directly `#include <ostream>` for `std::endl`
+        * src/date.cpp: Directly `#include <R_ext/Booelan.h>` for `TRUE` and `FALSE`
+
 2023-07-03  Dirk Eddelbuettel  <edd@debian.org>
 
         * DESCRIPTION (Date, Version): Release 1.0.11

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -31,6 +31,7 @@
 #include <map>
 #include <set>
 #include <algorithm>
+#include <ostream> // for std::endl
 #include <fstream>
 #include <sstream>
 

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -25,6 +25,7 @@
 
 #define COMPILING_RCPP
 
+#include <R_ext/Boolean.h> // for TRUE,FALSE
 #include <Rcpp.h>
 #include <time.h>		// for gmtime
 #include <Rcpp/exceptions.h>


### PR DESCRIPTION
Minor cleanup, no ticket.

Feel free to suggest another ordering of `#include`s, picked somewhat haphazardly