### PR TITLE
Ad-hoc fix for testthat's C entrypoint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-08-29  Iñaki Ucar  <iucar@fedoraproject.org>
+
+	* R/Attributes.R: Ad-hoc fix for testthat's C entrypoint in RcppExports.cpp
+
 2023-08-03  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1260,6 +1260,10 @@ sourceCppFunction <- function(func, isVoid, dll, symbol) {
             if (!routine %in% routines) {
                 declaration <- grep(sprintf("^extern .* %s\\(.*$", routine), code,
                                     value = TRUE)
+                # FIXME: maybe we should extend this to *any* routine?
+                # or is there any case in which `void *` is not SEXP for a .Call?
+                if (routine == "run_testthat_tests")
+                    declaration <- gsub("void *", "SEXP", declaration, fixed=TRUE)
                 declarations <- c(declarations, sub("^extern", "RcppExport", declaration))
                 call_entries <- c(call_entries, match[[1]])			# #nocov end
             }


### PR DESCRIPTION
Background [here](https://stackoverflow.com/questions/76999403/rcpp-compile-attributes-creates-void-argument). It all comes to [this call](https://github.com/RcppCore/Rcpp/blob/ba19cde26d9fbc490e0dcb9ff7b7d148488b2893/R/Attributes.R#L1245-L1249) that relies on `tools::package_native_routine_registration_skeleton` for the generation of registering code, but such function does not make any effort to detect the types of the extern declarations [here](https://github.com/wch/r-source/blob/2336bb0278ef721b9e22dc12d20770e85c6e48d1/src/library/tools/R/sotools.R#L1216-L1246). It's just `void *` for every argument, which works without LTO, but generates a warning with LTO enabled.

So in this patch we just substitute `void *` with `SEXP` for the particular case of testthat's C entrypoint, to make the life of these users easier. We probably could apply this to every declaration, but this should be further investigated. We can revisit this if new reports come out with other functions.

To test this:

``` r
Rcpp::Rcpp.package.skeleton()
#> Creating directories ...
#> Creating DESCRIPTION ...
#> Creating NAMESPACE ...
#> Creating Read-and-delete-me ...
#> Saving functions and data ...
#> Making help files ...
#> Done.
#> Further steps are described in './anRpackage/Read-and-delete-me'.
#> 
#> Adding Rcpp settings
#>  >> added Imports: Rcpp
#>  >> added LinkingTo: Rcpp
#>  >> added useDynLib directive to NAMESPACE
#>  >> added importFrom(Rcpp, evalCpp) directive to NAMESPACE
#>  >> added example src file using Rcpp attributes
#>  >> added Rd file for rcpp_hello_world
#>  >> compiled Rcpp attributes
setwd("anRpackage/")
testthat::use_catch()
#> > Added C++ unit testing infrastructure.
#> > Please ensure you have 'LinkingTo: testthat' in your DESCRIPTION.
#> > Please ensure you have 'Suggests: xml2' in your DESCRIPTION.
#> > Please ensure you have 'useDynLib(anRpackage, .registration = TRUE)' in your NAMESPACE.
desc <- paste(readLines("DESCRIPTION"), collapse="\n")
cat(paste0(desc, ", testthat\nSuggests: xml2\n"), file="DESCRIPTION")
Rcpp::compileAttributes()
readLines("src/RcppExports.cpp")[24]
#> [1] "RcppExport SEXP run_testthat_tests(SEXP);"
```

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
