### PR TITLE
Minor polish on one Rd file and new micro release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-10-27  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* R/tools.R: Correct missing Rd macros (spotted by R-devel CMD check)
 
 2023-10-22 Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-10-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/tools.R: Correct missing Rd macros (spotted by R-devel CMD check)
+
 2023-10-22 Aaron Lun <infinite.monkeys.with.keyboards@gmail.com>
 
 	* inst/include/Rcpp/vector/MatrixColumn.h: Cast integer index

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.11.2
-Date: 2023-08-31
+Version: 1.0.11.3
+Date: 2023-10-27
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/tools.R
+++ b/R/tools.R
@@ -53,7 +53,7 @@ asBuildPath <- function(path) {
 ##' Helper function to report the package version of the R installation.
 ##'
 ##' While \code{packageVersion(Rcpp)} exports the version registers in
-##' {DESCRIPTION}, this version does get incremented more easily
+##' \code{DESCRIPTION}, this version does get incremented more easily
 ##' during development and can therefore be higher than the released
 ##' version.  The actual \code{#define} long used at the C++ level
 ##' corresponds more to an \sQuote{API Version} which is now provided

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.11"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,2)
-#define RCPP_DEV_VERSION_STRING "1.0.11.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,3)
+#define RCPP_DEV_VERSION_STRING "1.0.11.3"
 
 #endif

--- a/man/getRcppVersion.Rd
+++ b/man/getRcppVersion.Rd
@@ -19,7 +19,7 @@ Helper function to report the package version of the R installation.
 }
 \details{
 While \code{packageVersion(Rcpp)} exports the version registers in
-{DESCRIPTION}, this version does get incremented more easily
+\code{DESCRIPTION}, this version does get incremented more easily
 during development and can therefore be higher than the released
 version.  The actual \code{#define} long used at the C++ level
 corresponds more to an \sQuote{API Version} which is now provided


### PR DESCRIPTION
One Rd file is corrected, r-devel now notices a use such as `{DESCRIPTION}` that was meant to be `\code{DESCRIPTION}` which is nice.  Also rolls the micro-release following PR #1281.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
