### PR TITLE
Adjust to -Wformat under R-devel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2023-11-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
+	* inst/include/Rcpp/iostream/Rstreambuf.h: Cast streamsize to int in
+	two spots
+	* inst/include/Rcpp/print.h (warningcall): Add missing '%s' format
+
 2023-11-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* vignettes/rmd/Rcpp-FAQ.Rmd: Updated and edited

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.11.3
-Date: 2023-10-27
+Version: 1.0.11.4
+Date: 2023-11-24
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.11"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,3)
-#define RCPP_DEV_VERSION_STRING "1.0.11.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,4)
+#define RCPP_DEV_VERSION_STRING "1.0.11.4"
 
 #endif

--- a/inst/include/Rcpp/iostream/Rstreambuf.h
+++ b/inst/include/Rcpp/iostream/Rstreambuf.h
@@ -1,9 +1,8 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
 // Rstreambuf.h: Rcpp R/C++ interface class library -- stream buffer
 //
 // Copyright (C) 2011 - 2020  Dirk Eddelbuettel, Romain Francois and Jelmer Ypma
-// Copyright (C) 2021         Dirk Eddelbuettel, Romain Francois, Jelmer Ypma and Iñaki Ucar
+// Copyright (C) 2021 - 2023  Dirk Eddelbuettel, Romain Francois, Jelmer Ypma and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -50,11 +49,11 @@ namespace Rcpp {
     };
 							// #nocov start
     template <> inline std::streamsize Rstreambuf<true>::xsputn(const char *s, std::streamsize num) {
-        Rprintf("%.*s", num, s);
+        Rprintf("%.*s", static_cast<int>(num), s);
         return num;
     }
     template <> inline std::streamsize Rstreambuf<false>::xsputn(const char *s, std::streamsize num) {
-        REprintf("%.*s", num, s);
+        REprintf("%.*s", static_cast<int>(num), s);
         return num;
     }
 

--- a/inst/include/Rcpp/print.h
+++ b/inst/include/Rcpp/print.h
@@ -1,6 +1,5 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
 //
-// Copyright (C) 2015 - 2016  Dirk Eddelbuettel
+// Copyright (C) 2015 - 2023  Dirk Eddelbuettel
 //
 // This file is part of Rcpp.
 //
@@ -27,7 +26,7 @@ inline void print(SEXP s) {
 }
 
 inline void warningcall(SEXP call, const std::string & s) {
-    Rf_warningcall(call, s.c_str());
+    Rf_warningcall(call, "%s", s.c_str());
 }
 
 // also note that warning() is defined in file exceptions.h
@@ -35,4 +34,3 @@ inline void warningcall(SEXP call, const std::string & s) {
 }
 
 #endif
-


### PR DESCRIPTION
### Pull Request Template for Rcpp

This PR adjusts two files with changes kindly suggested by @kalibera, and tested under update r-devel. 

When used with `-Wformat`,  the compiler no longer complains about incorrect format strings.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
