### PR TITLE
Set a format string in Rf_error call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-11-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/attributes.cpp (generateCpp): Add a format string for Rf_error
+	call to not run afoul of -Wformat-security
+
 2023-11-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2961,7 +2961,7 @@ namespace attributes {
                      << "    if (rcpp_isError_gen) {" << std::endl
                      << "        SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);" << std::endl
                      << "        UNPROTECT(1);" << std::endl
-                     << "        Rf_error(CHAR(rcpp_msgSEXP_gen));" << std::endl
+                     << "        Rf_error(\"%s\", CHAR(rcpp_msgSEXP_gen));" << std::endl
                      << "    }" << std::endl
                      << "    UNPROTECT(1);" << std::endl
                      << "    return rcpp_result_gen;" << std::endl


### PR DESCRIPTION
### Pull Request Template for Rcpp

As discussed in #1287 we trigger a `-Wformat-security` nag from the glue code in `src/attributes.cpp`.  The fix is pretty simple: add a missing `"%s"` format string.
#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
