### PR TITLE
Update format string in test package by updating generated RcppExports file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-11-28  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/testRcppInterfaceExporter/R/RcppExports.R: Regenerated
+	* inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp: Idem
+
 2023-11-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.11.5
-Date: 2023-11-26
+Version: 1.0.11.6
+Date: 2023-11-28
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.11"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,5)
-#define RCPP_DEV_VERSION_STRING "1.0.11.5"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,11,6)
+#define RCPP_DEV_VERSION_STRING "1.0.11.6"
 
 #endif

--- a/inst/tinytest/testRcppInterfaceExporter/R/RcppExports.R
+++ b/inst/tinytest/testRcppInterfaceExporter/R/RcppExports.R
@@ -8,5 +8,5 @@ test_cpp_interface <- function(x, fast = FALSE) {
 
 # Register entry points for exported C++ functions
 methods::setLoadAction(function(ns) {
-    .Call('_testRcppInterfaceExporter_RcppExport_registerCCallable', PACKAGE = 'testRcppInterfaceExporter')
+    .Call(`_testRcppInterfaceExporter_RcppExport_registerCCallable`)
 })

--- a/inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp
+++ b/inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp
@@ -8,6 +8,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // test_cpp_interface
 SEXP test_cpp_interface(SEXP x, bool fast);
 static SEXP _testRcppInterfaceExporter_test_cpp_interface_try(SEXP xSEXP, SEXP fastSEXP) {
@@ -38,7 +43,7 @@ RcppExport SEXP _testRcppInterfaceExporter_test_cpp_interface(SEXP xSEXP, SEXP f
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error(CHAR(rcpp_msgSEXP_gen));
+        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;


### PR DESCRIPTION
@kalibera found another format string in need of an update, this time in an embedded source package used by `tinytest`, and very kindly emailed a diff. 

The fix was actually even more trivial thanks to #1288 as it needed simply an call of `compileAttributes()` with the update source package from #1288.  This also updates two other minor aspects in the generated code we had addressed since the test example was first created.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
