### PR TITLE
Support OBJSXP coming in R 4.4.0 (closes #1283)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-12-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/api.cpp (type2name): Refine OBJSXP return
+
 2023-12-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/api.cpp (type2name): Recognise OBJSXP added in R 4.4.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-12-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/api.cpp (type2name): Recognise OBJSXP added in R 4.4.0
+
 2023-11-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/testRcppInterfaceExporter/R/RcppExports.R: Regenerated

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -3,7 +3,7 @@
 // api.cpp: Rcpp R/C++ interface class library -- Rcpp api
 //
 // Copyright (C) 2012 - 2020  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2021         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2021 - 2023  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -89,30 +89,33 @@ namespace Rcpp {
     // [[Rcpp::register]]
     const char * type2name(SEXP x) {                            // #nocov start
         switch (TYPEOF(x)) {
-        case NILSXP:    return "NILSXP";
-        case SYMSXP:    return "SYMSXP";
-        case RAWSXP:    return "RAWSXP";
-        case LISTSXP:   return "LISTSXP";
-        case CLOSXP:    return "CLOSXP";
-        case ENVSXP:    return "ENVSXP";
-        case PROMSXP:   return "PROMSXP";
-        case LANGSXP:   return "LANGSXP";
+        case NILSXP:    	return "NILSXP";
+        case SYMSXP:    	return "SYMSXP";
+        case RAWSXP:    	return "RAWSXP";
+        case LISTSXP:   	return "LISTSXP";
+        case CLOSXP:    	return "CLOSXP";
+        case ENVSXP:    	return "ENVSXP";
+        case PROMSXP:   	return "PROMSXP";
+        case LANGSXP:   	return "LANGSXP";
         case SPECIALSXP:    return "SPECIALSXP";
         case BUILTINSXP:    return "BUILTINSXP";
-        case CHARSXP:   return "CHARSXP";
-        case LGLSXP:    return "LGLSXP";
-        case INTSXP:    return "INTSXP";
-        case REALSXP:   return "REALSXP";
-        case CPLXSXP:   return "CPLXSXP";
-        case STRSXP:    return "STRSXP";
-        case DOTSXP:    return "DOTSXP";
-        case ANYSXP:    return "ANYSXP";
-        case VECSXP:    return "VECSXP";
-        case EXPRSXP:   return "EXPRSXP";
-        case BCODESXP:  return "BCODESXP";
-        case EXTPTRSXP: return "EXTPTRSXP";
+        case CHARSXP:   	return "CHARSXP";
+        case LGLSXP:    	return "LGLSXP";
+        case INTSXP:    	return "INTSXP";
+        case REALSXP:   	return "REALSXP";
+        case CPLXSXP:   	return "CPLXSXP";
+        case STRSXP:    	return "STRSXP";
+        case DOTSXP:    	return "DOTSXP";
+        case ANYSXP:    	return "ANYSXP";
+        case VECSXP:    	return "VECSXP";
+        case EXPRSXP:   	return "EXPRSXP";
+        case BCODESXP:  	return "BCODESXP";
+        case EXTPTRSXP: 	return "EXTPTRSXP";
         case WEAKREFSXP:    return "WEAKREFSXP";
-        case S4SXP:     return "S4SXP";
+#if R_Version >= R_Version(4,4,0)
+        case OBJSXP:    	return "OBJSXP"; 					// replaces S4SXP in R 4.4.0
+#endif
+        case S4SXP:     	return "S4SXP";
         default:
         return "<unknown>";
         }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -112,10 +112,11 @@ namespace Rcpp {
         case BCODESXP:  	return "BCODESXP";
         case EXTPTRSXP: 	return "EXTPTRSXP";
         case WEAKREFSXP:    return "WEAKREFSXP";
-#if R_Version >= R_Version(4,4,0)
-        case OBJSXP:    	return "OBJSXP"; 					// replaces S4SXP in R 4.4.0
-#endif
+#if R_Version >= R_Version(4,4,0)					// replaces S4SXP in R 4.4.0
+        case OBJSXP:    	return Rf_isS4(x) ? "S4SXP" : "OBJSXP"; 	// cf src/main/inspect.c
+#else
         case S4SXP:     	return "S4SXP";
+#endif
         default:
         return "<unknown>";
         }


### PR DESCRIPTION
This addressed #1283 and the addition of `OBJSXP` as a new value / replacement for `S4SXP` to better support S7 changes. I ran a full reverse-depends check but given that the change is conditional on R 4.4.0 or later nothing much came up.

It is something we probably want to get into 1.0.12 for the next cycle. and I don't think it will do anything wrong but reviews would be much appreciated as I may still have forgotten something.

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
