### PR TITLE
Condition define of no remap

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-02-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/r/headers.h: Set R_NO_REMAP (and MAXELTSIZE)
+	only if not already defined (as will be needed with R 4.4.0)
+
 2024-01-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Update usage numbers

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-02-21  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
 	* inst/include/Rcpp/r/headers.h: Set R_NO_REMAP (and MAXELTSIZE)
 	only if not already defined (as will be needed with R 4.4.0)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.12
-Date: 2024-01-08
+Version: 1.0.12.1
+Date: 2024-02-21
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers
 Maintainer: Dirk Eddelbuettel <edd@debian.org>

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -1,6 +1,6 @@
 
 # Copyright (C) 2012 - 2022  JJ Allaire, Dirk Eddelbuettel and Romain Francois
-# Copyright (C) 2023         JJ Allaire, Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+# Copyright (C) 2023 - 2024  JJ Allaire, Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 #
 # This file is part of Rcpp.
 #

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.12"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,12,0)
-#define RCPP_DEV_VERSION_STRING "1.0.12.0"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,12,1)
+#define RCPP_DEV_VERSION_STRING "1.0.12.1"
 
 #endif

--- a/inst/include/Rcpp/r/headers.h
+++ b/inst/include/Rcpp/r/headers.h
@@ -1,7 +1,7 @@
 // headers.h: Rcpp R/C++ interface class library -- R headers
 //
 // Copyright (C) 2008 - 2009 Dirk Eddelbuettel
-// Copyright (C) 2009 - 2022 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2009 - 2024 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -22,8 +22,12 @@
 #define RCPP__R__HEADERS__H
 
 // include R headers, but set R_NO_REMAP and access everything via Rf_ prefixes
-#define MAXELTSIZE 8192
-#define R_NO_REMAP
+#ifndef MAXELTSIZE
+ #define MAXELTSIZE 8192
+#endif
+#ifndef R_NO_REMAP
+ #define R_NO_REMAP
+#endif
 
 // define strict headers for R to not clash on ERROR, MESSGAGE, etc
 #ifndef RCPP_NO_STRICT_R_HEADERS


### PR DESCRIPTION
R 4.4.0 will likely define `R_NO_REMAP` so we need to protect our (currently unconditional) definition.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
