### PR TITLE
Allow using variadic templates instead of pre-generated code where supported

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-05-23 Andrew Johnson <andrew.johnson@arjohnsonau.com>
+        
+        * Added variadic templates to be used instead of the generated code
+        in `Rcpp/generated` and `Rcpp/module` when compiling with C++11 or
+        later.
+
 2024-05-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci-4.3/Dockerfile: Add rcpp/ci-4.3 container for R 4.3.*

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -117,8 +117,14 @@ namespace Rcpp{
         static DataFrame_Impl create(){
             return DataFrame_Impl() ;
         }
-
-        #include <Rcpp/generated/DataFrame_generated.h>
+        #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+            template <typename... T>
+            static DataFrame_Impl create(const T&... args) {
+                return DataFrame_Impl::from_list(Parent::create(args...));
+            }
+        #else
+            #include <Rcpp/generated/DataFrame_generated.h>
+        #endif
 
     private:
         void set__(SEXP x){

--- a/inst/include/Rcpp/DottedPair.h
+++ b/inst/include/Rcpp/DottedPair.h
@@ -35,8 +35,14 @@ public:
 	DottedPair_Impl(SEXP x) {
 	    Storage::set__(x) ;
 	}
-
-	#include <Rcpp/generated/DottedPair__ctors.h>
+  #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+		template <typename... T>
+		DottedPair_Impl(const T&... args) {
+			Storage::set__(pairlist(args...));
+		}
+	#else
+		#include <Rcpp/generated/DottedPair__ctors.h>
+	#endif
 
 	void update(SEXP){}
 

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -82,7 +82,14 @@ namespace Rcpp{
             return Rcpp_fast_eval(call, R_GlobalEnv);
         }
 
-        #include <Rcpp/generated/Function__operator.h>
+        #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+            template <typename... T>
+            SEXP operator()(const T&... args) const {
+            return invoke(pairlist(args...), R_GlobalEnv);
+            }
+        #else
+            #include <Rcpp/generated/Function__operator.h>
+        #endif
 
         /**
          * Returns the environment of this function

--- a/inst/include/Rcpp/InternalFunction.h
+++ b/inst/include/Rcpp/InternalFunction.h
@@ -47,9 +47,14 @@ namespace Rcpp{
                     )
                 );
         }
+        //template <typename RESULT_TYPE, typename... T>
+        //InternalFunction_Impl(RESULT_TYPE (*fun)(T...)) {
+        //    set(XPtr<CppFunctionN<RESULT_TYPE, T...> >(new CppFunctionN<RESULT_TYPE, T...>(fun), true));
+        //}
+#else
 #endif
-
         #include <Rcpp/generated/InternalFunction__ctors.h>
+
         void update(SEXP){}
     private:
 

--- a/inst/include/Rcpp/InternalFunction.h
+++ b/inst/include/Rcpp/InternalFunction.h
@@ -47,13 +47,13 @@ namespace Rcpp{
                     )
                 );
         }
-        //template <typename RESULT_TYPE, typename... T>
-        //InternalFunction_Impl(RESULT_TYPE (*fun)(T...)) {
-        //    set(XPtr<CppFunctionN<RESULT_TYPE, T...> >(new CppFunctionN<RESULT_TYPE, T...>(fun), true));
-        //}
+        template <typename RESULT_TYPE, typename... T>
+        InternalFunction_Impl(RESULT_TYPE (*fun)(T...)) {
+            set(XPtr<CppFunctionN<RESULT_TYPE, T...> >(new CppFunctionN<RESULT_TYPE, T...>(fun), true));
+        }
 #else
-#endif
         #include <Rcpp/generated/InternalFunction__ctors.h>
+#endif
 
         void update(SEXP){}
     private:

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -23,27 +23,22 @@
 #ifndef Rcpp_InternalFunctionWithStdFunction_h
 #define Rcpp_InternalFunctionWithStdFunction_h
 
+#include <Rcpp/traits/index_sequence.h>
 #include <functional>
 
 namespace Rcpp {
 
     namespace InternalFunctionWithStdFunction {
         #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
-            template<int...> struct index_sequence {};
-
-            template<int N, int... Is>
-            struct make_index_sequence : make_index_sequence<N-1, N-1, Is...> {};
-
-            template<int... Is>
-            struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
-
             template <typename RESULT_TYPE, typename... Us, int... Is>
-            RESULT_TYPE call_impl(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args, index_sequence<Is...>) {
+            RESULT_TYPE call_impl(const std::function<RESULT_TYPE(Us...)> &fun,
+                                    SEXP* args, traits::index_sequence<Is...>) {
                 return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
             }
+
             template <typename RESULT_TYPE, typename... Us>
             RESULT_TYPE call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
-                return call_impl(fun, args, make_index_sequence<sizeof...(Us)>{});
+                return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
             }
         #else
         #include <Rcpp/generated/InternalFunctionWithStdFunction_call.h>

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -43,7 +43,7 @@ namespace Rcpp {
 
                 SEXP operator()(SEXP* args) {
                     BEGIN_RCPP
-                    return call<RESULT_TYPE, Args...>(fun, args);
+                    return call<decltype(fun), RESULT_TYPE, Args...>(fun, args);
                     END_RCPP
                 }
 

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -23,24 +23,15 @@
 #ifndef Rcpp_InternalFunctionWithStdFunction_h
 #define Rcpp_InternalFunctionWithStdFunction_h
 
-#include <Rcpp/traits/index_sequence.h>
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+#include <Rcpp/internal/call.h>
+#endif
 #include <functional>
 
 namespace Rcpp {
 
     namespace InternalFunctionWithStdFunction {
-        #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
-            template <typename RESULT_TYPE, typename... Us, int... Is>
-            RESULT_TYPE call_impl(const std::function<RESULT_TYPE(Us...)> &fun,
-                                    SEXP* args, traits::index_sequence<Is...>) {
-                return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
-            }
-
-            template <typename RESULT_TYPE, typename... Us>
-            RESULT_TYPE call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
-                return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
-            }
-        #else
+        #if !defined(HAS_VARIADIC_TEMPLATES) && !defined(RCPP_USING_CXX11)
         #include <Rcpp/generated/InternalFunctionWithStdFunction_call.h>
         #endif
 
@@ -52,8 +43,7 @@ namespace Rcpp {
 
                 SEXP operator()(SEXP* args) {
                     BEGIN_RCPP
-                    auto result = call<RESULT_TYPE, Args...>(fun, args);
-                    return Rcpp::module_wrap<RESULT_TYPE>(result);
+                    return Rcpp::module_wrap<RESULT_TYPE>(call<RESULT_TYPE, Args...>(fun, args));
                     END_RCPP
                 }
 

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -43,29 +43,12 @@ namespace Rcpp {
 
                 SEXP operator()(SEXP* args) {
                     BEGIN_RCPP
-                    auto result = call<RESULT_TYPE, Args...>(fun, args);
-                    return Rcpp::module_wrap<RESULT_TYPE>(result);
+                    return call<RESULT_TYPE, Args...>(fun, args);
                     END_RCPP
                 }
 
             private:
                 const std::function<RESULT_TYPE(Args...)> fun;
-        };
-
-        template <typename... Args>
-        class CppFunctionBaseFromStdFunction<void, Args...> : public CppFunctionBase {
-             public:
-                 CppFunctionBaseFromStdFunction(const std::function<void(Args...)> &fun) : fun(fun) {}
-                 virtual ~CppFunctionBaseFromStdFunction() {}
-
-                 SEXP operator()(SEXP* args) {
-                     BEGIN_RCPP
-                     call<void, Args...>(fun, args);
-                     END_RCPP
-                 }
-
-            private:
-                 const std::function<void(Args...)> fun;
         };
 
     } // namespace InternalFunctionWithStdFunction

--- a/inst/include/Rcpp/InternalFunctionWithStdFunction.h
+++ b/inst/include/Rcpp/InternalFunctionWithStdFunction.h
@@ -43,7 +43,8 @@ namespace Rcpp {
 
                 SEXP operator()(SEXP* args) {
                     BEGIN_RCPP
-                    return Rcpp::module_wrap<RESULT_TYPE>(call<RESULT_TYPE, Args...>(fun, args));
+                    auto result = call<RESULT_TYPE, Args...>(fun, args);
+                    return Rcpp::module_wrap<RESULT_TYPE>(result);
                     END_RCPP
                 }
 

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -102,7 +102,19 @@ namespace Rcpp{
          * 0.0 is wrapped as a numeric vector using wrap( const& double )
          * ...
          */
-        #include <Rcpp/generated/Language__ctors.h>
+        #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+            template <typename... T>
+            Language_Impl( const std::string& symbol, const T&... t) {
+                Storage::set__( pairlist(Rf_install( symbol.c_str() ), t...) );
+            }
+
+            template <typename... T>
+            Language_Impl( const Function& function, const T&... t) {
+                Storage::set__( pairlist( function, t...) );
+            }
+        #else
+            #include <Rcpp/generated/Language__ctors.h>
+        #endif
 
         /**
          * sets the symbol of the call

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -104,13 +104,13 @@ namespace Rcpp{
          */
         #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
             template <typename... T>
-            Language_Impl( const std::string& symbol, const T&... t) {
-                Storage::set__( pairlist(Rf_install( symbol.c_str() ), t...) );
+            Language_Impl(const std::string& symbol, const T&... t) {
+                Storage::set__(pairlist(Rf_install(symbol.c_str()), t...) );
             }
 
             template <typename... T>
-            Language_Impl( const Function& function, const T&... t) {
-                Storage::set__( pairlist( function, t...) );
+            Language_Impl(const Function& function, const T&... t) {
+                Storage::set__(pairlist(function, t...));
             }
         #else
             #include <Rcpp/generated/Language__ctors.h>

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -455,7 +455,6 @@ bool yes_arity( SEXP* /* args */ , int nargs){
         RESULT_TYPE operator_impl(Class* object, SEXP* args, traits::index_sequence<Is...>) {
             return (object->*met)((typename traits::input_parameter<T>::type(args[Is]))...);
         }
-
     };
 
     template <typename Class, typename... T> class CppMethodN<Class, void, T...> : public CppMethod<Class> {
@@ -524,10 +523,102 @@ bool yes_arity( SEXP* /* args */ , int nargs){
             (object->*met)((typename traits::input_parameter<T>::type(args[Is]))...);
         }
     };
+
+    template <typename Class, typename RESULT_TYPE, typename... T> class Pointer_CppMethodN : public CppMethod<Class> {
+    public:
+        typedef RESULT_TYPE (*Method)(Class*, T...);
+        typedef CppMethod<Class> method_class;
+        typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+
+        Pointer_CppMethodN(Method m) : method_class(), met(m) {}
+        SEXP operator()(Class* object, SEXP* args) {
+            return Rcpp::module_wrap<CLEANED_RESULT_TYPE>(operator_impl(object, args, traits::make_index_sequence<sizeof...(T)>()));
+        }
+        inline int nargs() { return sizeof...(T); }
+        inline bool is_void() { return false; }
+        inline bool is_const() { return false; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,T...>(s, name); }
+    private:
+        Method met;
+
+        template <int... Is>
+        RESULT_TYPE operator_impl(Class* object, SEXP* args, traits::index_sequence<Is...>) {
+            return met(object, (typename traits::input_parameter<T>::type(args[Is]))...);
+        }
+    };
+
+    template <typename Class, typename... T> class Pointer_CppMethodN<Class, void, T...> : public CppMethod<Class> {
+    public:
+        typedef void (*Method)(Class*, T...);
+        typedef CppMethod<Class> method_class;
+
+        Pointer_CppMethodN(Method m) : method_class(), met(m) {}
+        SEXP operator()(Class* object, SEXP* args) {
+            operator_impl(object, args, traits::make_index_sequence<sizeof...(T)>());
+            return R_NilValue;
+        }
+        inline int nargs() { return sizeof...(T); }
+        inline bool is_void() { return true; }
+        inline bool is_const() { return false; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,T...>(s, name); }
+    private:
+        Method met;
+
+        template <int... Is>
+        void operator_impl(Class* object, SEXP* args, traits::index_sequence<Is...>) {
+            met(object, (typename traits::input_parameter<T>::type(args[Is]))...);
+        }
+    };
+
+    template <typename Class, typename RESULT_TYPE, typename... T> class Const_Pointer_CppMethodN : public CppMethod<Class> {
+    public:
+        typedef RESULT_TYPE (*Method)(const Class*, T...);
+        typedef CppMethod<Class> method_class;
+        typedef typename Rcpp::traits::remove_const_and_reference<RESULT_TYPE>::type CLEANED_RESULT_TYPE;
+
+        Const_Pointer_CppMethodN(Method m) : method_class(), met(m) {}
+        SEXP operator()(Class* object, SEXP* args) {
+            return Rcpp::module_wrap<CLEANED_RESULT_TYPE>(operator_impl(object, args, traits::make_index_sequence<sizeof...(T)>()));
+        }
+        inline int nargs() { return sizeof...(T); }
+        inline bool is_void() { return false; }
+        inline bool is_const() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE,T...>(s, name); }
+    private:
+        Method met;
+
+        template <int... Is>
+        RESULT_TYPE operator_impl(Class* object, SEXP* args, traits::index_sequence<Is...>) {
+            return met(object, (typename traits::input_parameter<T>::type(args[Is]))...);
+        }
+    };
+
+    template <typename Class, typename... T> class Const_Pointer_CppMethodN<Class, void, T...> : public CppMethod<Class> {
+    public:
+        typedef void (*Method)(const Class*, T...);
+        typedef CppMethod<Class> method_class;
+
+        Const_Pointer_CppMethodN(Method m) : method_class(), met(m) {}
+        SEXP operator()(Class* object, SEXP* args) {
+            operator_impl(object, args, traits::make_index_sequence<sizeof...(T)>());
+            return R_NilValue;
+        }
+        inline int nargs() { return sizeof...(T); }
+        inline bool is_void() { return true; }
+        inline bool is_const() { return true; }
+        inline void signature(std::string& s, const char* name) { Rcpp::signature<void_type,T...>(s, name); }
+    private:
+        Method met;
+
+        template <int... Is>
+        void operator_impl(Class* object, SEXP* args, traits::index_sequence<Is...>) {
+            met(object, (typename traits::input_parameter<T>::type(args[Is]))...);
+        }
+    };
 #else
     #include <Rcpp/module/Module_generated_CppMethod.h>
+    #include <Rcpp/module/Module_generated_Pointer_CppMethod.h>
 #endif
-#include <Rcpp/module/Module_generated_Pointer_CppMethod.h>
 
     template <typename Class>
     class CppProperty {

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -235,7 +235,7 @@ namespace Rcpp{
             ctor_signature<T...>(s, class_name) ;
         }
     private:
-        template<std::size_t... I>
+        template<int... I>
         Class* get_new( SEXP* args, traits::index_sequence<I...> ){
             return ptr_fun( bare_as<T>(args[I])... ) ;
         }

--- a/inst/include/Rcpp/Pairlist.h
+++ b/inst/include/Rcpp/Pairlist.h
@@ -42,9 +42,14 @@ namespace Rcpp{
         Pairlist_Impl(SEXP x){
             Storage::set__(r_cast<LISTSXP>(x)) ;
         }
-
-        #include <Rcpp/generated/Pairlist__ctors.h>
-
+        #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+            template <typename... T>
+            Pairlist_Impl(const T&... args ){
+                Storage::set__(pairlist(args... )) ;
+            }
+        #else
+            #include <Rcpp/generated/Pairlist__ctors.h>
+        #endif
         void update(SEXP x){
             SET_TYPEOF( x, LISTSXP ) ;
         }

--- a/inst/include/Rcpp/grow.h
+++ b/inst/include/Rcpp/grow.h
@@ -70,7 +70,19 @@ namespace Rcpp {
         return grow(Rf_mkString(head), y);
     }
 
-    #include <Rcpp/generated/grow__pairlist.h>
+    template <typename T1>
+    SEXP pairlist(const T1& t1) {
+        return grow( t1, R_NilValue ) ;
+    }
+
+    #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+        template <typename T, typename... TArgs>
+        SEXP pairlist(const T& t1, const TArgs&... args) {
+            return grow(t1, pairlist(args...));
+        }
+    #else
+        #include <Rcpp/generated/grow__pairlist.h>
+    #endif
 
 } // namespace Rcpp
 

--- a/inst/include/Rcpp/grow.h
+++ b/inst/include/Rcpp/grow.h
@@ -70,12 +70,11 @@ namespace Rcpp {
         return grow(Rf_mkString(head), y);
     }
 
-    template <typename T1>
-    SEXP pairlist(const T1& t1) {
-        return grow( t1, R_NilValue ) ;
-    }
-
     #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+        template <typename T1>
+        SEXP pairlist(const T1& t1) {
+            return grow( t1, R_NilValue ) ;
+        }
         template <typename T, typename... TArgs>
         SEXP pairlist(const T& t1, const TArgs&... args) {
             return grow(t1, pairlist(args...));

--- a/inst/include/Rcpp/internal/call.h
+++ b/inst/include/Rcpp/internal/call.h
@@ -1,0 +1,65 @@
+#ifndef RCPP_INTERNAL_CALL_H
+#define RCPP_INTERNAL_CALL_H
+
+#include <Rcpp/traits/index_sequence.h>
+#include <functional>
+
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+
+// Currently not declared in the Rcpp::internal namespace for compatibility
+// with the generated call operators in InternalFunctionWithStdFunction_call.h
+// but this should be changed in the future
+namespace Rcpp {
+
+template <typename RESULT_TYPE, typename... Us, int... Is>
+RESULT_TYPE call_impl(const std::function<RESULT_TYPE(Us...)> &fun,
+                        SEXP* args, traits::index_sequence<Is...>) {
+    return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+}
+
+template <typename RESULT_TYPE, typename... Us, int... Is>
+RESULT_TYPE call_impl(RESULT_TYPE (*fun)(Us...),
+                        SEXP* args, traits::index_sequence<Is...>) {
+    return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+}
+
+
+template <typename RESULT_TYPE, typename... Us>
+RESULT_TYPE call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
+    return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+}
+
+template <typename RESULT_TYPE, typename... Us>
+RESULT_TYPE call(RESULT_TYPE (*fun)(Us...), SEXP* args) {
+    return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+}
+
+
+template <typename... Us, int... Is>
+void call_impl(const std::function<void(Us...)> &fun,
+                        SEXP* args, traits::index_sequence<Is...>) {
+    fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+}
+
+template <typename... Us, int... Is>
+void call_impl(void (*fun)(Us...),
+                        SEXP* args, traits::index_sequence<Is...>) {
+    fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+}
+
+
+template <typename... Us>
+void call(const std::function<void(Us...)> &fun, SEXP* args) {
+    call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+}
+
+template <typename... Us>
+void call(void (*fun)(Us...), SEXP* args) {
+    call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+}
+
+} // namespace Rcpp
+
+#endif
+
+#endif

--- a/inst/include/Rcpp/internal/call.h
+++ b/inst/include/Rcpp/internal/call.h
@@ -6,56 +6,57 @@
 
 #if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
 
-// Currently not declared in the Rcpp::internal namespace for compatibility
-// with the generated call operators in InternalFunctionWithStdFunction_call.h
-// but this should be changed in the future
 namespace Rcpp {
+namespace internal {
+// Utility struct so that we can pass a pack of types between functions
+template <typename... T> struct type_pack {};
 
-template <typename RESULT_TYPE, typename... Us, int... Is>
-RESULT_TYPE call_impl(const std::function<RESULT_TYPE(Us...)> &fun,
-                        SEXP* args, traits::index_sequence<Is...>) {
-    return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+
+/**
+ * Implementation function for calling a function with an array of SEXP arguments,
+ * where each argument is converted to the appropriate type before being passed
+ * to the function. A compile-time sequence (`Is...`) is used to index the SEXP array.
+ * 
+ * The intended types of the result and arguments are passed using the `type_pack`
+ * struct, which allows the template to be used for both function pointers and
+ * `std::function` objects.
+ * 
+ * This specialisation is for functions that return a value, whereas the below
+ * is for void-returning functions.
+ * 
+ * The "* = nullptr" default argument allows both templates to be well-defined
+ * regardless of which one is used.
+ */
+template <typename F, typename RESULT_TYPE, typename... Us, int... Is,
+            typename std::enable_if<!std::is_same<RESULT_TYPE, void>::value>::type* = nullptr>
+SEXP call_impl(F fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
+                traits::index_sequence<Is...>) {
+    RESULT_TYPE res = fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+    return Rcpp::module_wrap<RESULT_TYPE>(res);
 }
 
-template <typename RESULT_TYPE, typename... Us, int... Is>
-RESULT_TYPE call_impl(RESULT_TYPE (*fun)(Us...),
-                        SEXP* args, traits::index_sequence<Is...>) {
-    return fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+template <typename F, typename RESULT_TYPE, typename... Us, int... Is,
+            typename std::enable_if<std::is_same<RESULT_TYPE, void>::value>::type* = nullptr>
+SEXP call_impl(F fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
+                traits::index_sequence<Is...>) {
+    fun((typename traits::input_parameter<Us>::type(args[Is]))...);
+    return R_NilValue;
 }
+} // namespace internal
 
 
 template <typename RESULT_TYPE, typename... Us>
-RESULT_TYPE call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
-    return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+SEXP call(RESULT_TYPE (*fun)(Us...), SEXP* args) {
+    return internal::call_impl(fun, args,
+                                internal::type_pack<RESULT_TYPE, Us...>{},
+                                traits::make_index_sequence<sizeof...(Us)>{});
 }
 
 template <typename RESULT_TYPE, typename... Us>
-RESULT_TYPE call(RESULT_TYPE (*fun)(Us...), SEXP* args) {
-    return call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
-}
-
-
-template <typename... Us, int... Is>
-void call_impl(const std::function<void(Us...)> &fun,
-                        SEXP* args, traits::index_sequence<Is...>) {
-    fun((typename traits::input_parameter<Us>::type(args[Is]))...);
-}
-
-template <typename... Us, int... Is>
-void call_impl(void (*fun)(Us...),
-                        SEXP* args, traits::index_sequence<Is...>) {
-    fun((typename traits::input_parameter<Us>::type(args[Is]))...);
-}
-
-
-template <typename... Us>
-void call(const std::function<void(Us...)> &fun, SEXP* args) {
-    call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
-}
-
-template <typename... Us>
-void call(void (*fun)(Us...), SEXP* args) {
-    call_impl(fun, args, traits::make_index_sequence<sizeof...(Us)>{});
+SEXP call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
+    return internal::call_impl(fun, args,
+                                internal::type_pack<RESULT_TYPE, Us...>{},
+                                traits::make_index_sequence<sizeof...(Us)>{});
 }
 
 } // namespace Rcpp

--- a/inst/include/Rcpp/internal/call.h
+++ b/inst/include/Rcpp/internal/call.h
@@ -13,14 +13,6 @@ template <typename... T> struct type_pack {};
 
 
 /**
- * Implementation function for calling a function with an array of SEXP arguments,
- * where each argument is converted to the appropriate type before being passed
- * to the function. A compile-time sequence (`Is...`) is used to index the SEXP array.
- * 
- * The intended types of the result and arguments are passed using the `type_pack`
- * struct, which allows the template to be used for both function pointers and
- * `std::function` objects.
- * 
  * This specialisation is for functions that return a value, whereas the below
  * is for void-returning functions.
  * 
@@ -28,37 +20,37 @@ template <typename... T> struct type_pack {};
  * regardless of which one is used.
  */
 template <typename F, typename RESULT_TYPE, typename... Us, int... Is,
-            typename std::enable_if<!std::is_same<RESULT_TYPE, void>::value>::type* = nullptr>
-SEXP call_impl(F fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
+            typename std::enable_if<!std::is_void<RESULT_TYPE>::value>::type* = nullptr>
+SEXP call_impl(const F& fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
                 traits::index_sequence<Is...>) {
     RESULT_TYPE res = fun((typename traits::input_parameter<Us>::type(args[Is]))...);
     return Rcpp::module_wrap<RESULT_TYPE>(res);
 }
 
 template <typename F, typename RESULT_TYPE, typename... Us, int... Is,
-            typename std::enable_if<std::is_same<RESULT_TYPE, void>::value>::type* = nullptr>
-SEXP call_impl(F fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
+            typename std::enable_if<std::is_void<RESULT_TYPE>::value>::type* = nullptr>
+SEXP call_impl(const F& fun, SEXP* args, type_pack<RESULT_TYPE, Us...>,
                 traits::index_sequence<Is...>) {
     fun((typename traits::input_parameter<Us>::type(args[Is]))...);
     return R_NilValue;
 }
 } // namespace internal
 
-
-template <typename RESULT_TYPE, typename... Us>
-SEXP call(RESULT_TYPE (*fun)(Us...), SEXP* args) {
+/**
+ * Helper for calling a function with an array of SEXP arguments,
+ * where each argument is converted to the appropriate type before being passed
+ * to the function. A compile-time sequence is used to index the SEXP array.
+ * 
+ * The function only needs the intended types of the result and arguments,
+ *  which allows the template to be used for function pointers, lambdas, and
+ * `std::function` objects.
+ */
+template <typename F, typename RESULT_TYPE, typename... Us>
+SEXP call(const F& fun, SEXP* args) {
     return internal::call_impl(fun, args,
                                 internal::type_pack<RESULT_TYPE, Us...>{},
                                 traits::make_index_sequence<sizeof...(Us)>{});
 }
-
-template <typename RESULT_TYPE, typename... Us>
-SEXP call(const std::function<RESULT_TYPE(Us...)> &fun, SEXP* args) {
-    return internal::call_impl(fun, args,
-                                internal::type_pack<RESULT_TYPE, Us...>{},
-                                traits::make_index_sequence<sizeof...(Us)>{});
-}
-
 } // namespace Rcpp
 
 #endif

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -111,8 +111,21 @@
             return constructor( docstring, valid ) ;
         }
 
-#include <Rcpp/module/Module_generated_class_constructor.h>
-#include <Rcpp/module/Module_generated_class_factory.h>
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+    template <typename... T>
+    self& constructor( const char* docstring = 0, ValidConstructor valid = &yes_arity<sizeof...(T)> ){
+        AddConstructor( new Constructor<Class,T...> , valid, docstring ) ;
+        return *this ;
+    }
+    template <typename... T>
+    self& factory( Class* (*fun)(T...), const char* docstring = 0, ValidConstructor valid = &yes_arity<sizeof...(T)> ){
+        AddFactory( new Factory<Class,T...>(fun) , valid, docstring ) ;
+        return *this ;
+    }
+#else
+    #include <Rcpp/module/Module_generated_class_constructor.h>
+    #include <Rcpp/module/Module_generated_class_factory.h>
+#endif
 
     public:
 

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -266,7 +266,34 @@
             return *this ;
         }
 
-#include <Rcpp/module/Module_generated_method.h>
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+    template <typename RESULT_TYPE, typename... T>
+    self& method(const char* name_, RESULT_TYPE (Class::*fun)(T...),
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
+    template <typename RESULT_TYPE, typename... T>
+    self& method(const char* name_, RESULT_TYPE (Class::*fun)(T...) const,
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new const_CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
+    template <typename RESULT_TYPE, typename... T>
+    self& nonconst_method(const char* name_, RESULT_TYPE (Class::*fun)(T...),
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
+    template <typename RESULT_TYPE, typename... T>
+    self& const_method(const char* name_, RESULT_TYPE (Class::*fun)(T...) const,
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new const_CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
+#else
+    #include <Rcpp/module/Module_generated_method.h>
+#endif
 #include <Rcpp/module/Module_generated_Pointer_method.h>
 
         bool has_method( const std::string& m){

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -291,10 +291,22 @@
         AddMethod( name_, new const_CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
         return *this;
     }
+    template <typename RESULT_TYPE, typename... T>
+    self& method(const char* name_, RESULT_TYPE (*fun)(Class*, T...),
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new Pointer_CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
+    template <typename RESULT_TYPE, typename... T>
+    self& const_method(const char* name_, RESULT_TYPE (*fun)(const Class*, T...),
+                const char* docstring = 0, ValidMethod valid = &yes_arity<sizeof...(T)>) {
+        AddMethod( name_, new Const_Pointer_CppMethodN<Class,RESULT_TYPE,T...>(fun), valid, docstring);
+        return *this;
+    }
 #else
     #include <Rcpp/module/Module_generated_method.h>
+    #include <Rcpp/module/Module_generated_Pointer_method.h>
 #endif
-#include <Rcpp/module/Module_generated_Pointer_method.h>
 
         bool has_method( const std::string& m){
             return vec_methods.find(m) != vec_methods.end() ;

--- a/inst/include/Rcpp/traits/index_sequence.h
+++ b/inst/include/Rcpp/traits/index_sequence.h
@@ -6,15 +6,19 @@
 
 namespace Rcpp {
 namespace traits {
+  /**
+   * C++11 implementations for index_sequence and make_index_sequence.
+   * To avoid name conflicts or ambiguity when compiling with C++14 or later,
+   * they should always be prefaced with `Rcpp::traits::` when used.
+  */
+  template <int...>
+  struct index_sequence {};
 
-template<int...> struct index_sequence {};
+  template <int N, int... Is>
+  struct make_index_sequence : make_index_sequence<N-1, N-1, Is...> {};
 
-template<int N, int... Is>
-struct make_index_sequence : make_index_sequence<N-1, N-1, Is...> {};
-
-template<int... Is>
-struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
-
+  template <int... Is>
+  struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
 }
 }
 

--- a/inst/include/Rcpp/traits/index_sequence.h
+++ b/inst/include/Rcpp/traits/index_sequence.h
@@ -1,0 +1,23 @@
+#ifndef RCPP_TRAITS_INDEX_SEQUENCE_H
+#define RCPP_TRAITS_INDEX_SEQUENCE_H
+
+
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+
+namespace Rcpp {
+namespace traits {
+
+template<int...> struct index_sequence {};
+
+template<int N, int... Is>
+struct make_index_sequence : make_index_sequence<N-1, N-1, Is...> {};
+
+template<int... Is>
+struct make_index_sequence<0, Is...> : index_sequence<Is...> {};
+
+}
+}
+
+#endif
+
+#endif

--- a/inst/include/Rcpp/traits/named_object.h
+++ b/inst/include/Rcpp/traits/named_object.h
@@ -66,16 +66,17 @@ template <typename T> struct is_named< named_object<T> > : public true_type {};
 template <> struct is_named< Rcpp::Argument > : public true_type {};
 
 
-template <typename... T> struct is_any_named : public false_type {};
-template <typename T> struct is_any_named<T> : public is_named<T>::type {};
+#if defined(HAS_VARIADIC_TEMPLATES) || defined(RCPP_USING_CXX11)
+    template <typename... T> struct is_any_named : public false_type {};
+    template <typename T> struct is_any_named<T> : public is_named<T>::type {};
 
-template <typename T, typename... TArgs>
-struct is_any_named<T, TArgs...>
-    : public std::conditional<
-                is_any_named<T>::value,
-                std::true_type,
-                is_any_named<TArgs...>>::type {};
-
+    template <typename T, typename... TArgs>
+    struct is_any_named<T, TArgs...>
+        : public std::conditional<
+                    is_any_named<T>::value,
+                    std::true_type,
+                    is_any_named<TArgs...>>::type {};
+#endif
 
 } // namespace traits
 } // namespace Rcpp

--- a/inst/include/Rcpp/traits/named_object.h
+++ b/inst/include/Rcpp/traits/named_object.h
@@ -22,6 +22,8 @@
 #ifndef Rcpp__traits__named_object__h
 #define Rcpp__traits__named_object__h
 
+#include <type_traits>
+
 namespace Rcpp{
 class Argument ;
 
@@ -62,6 +64,18 @@ private:
 template <typename T> struct is_named : public false_type{};
 template <typename T> struct is_named< named_object<T> > : public true_type {};
 template <> struct is_named< Rcpp::Argument > : public true_type {};
+
+
+template <typename... T> struct is_any_named : public false_type {};
+template <typename T> struct is_any_named<T> : public is_named<T>::type {};
+
+template <typename T, typename... TArgs>
+struct is_any_named<T, TArgs...>
+    : public std::conditional<
+                is_any_named<T>::value,
+                std::true_type,
+                is_any_named<TArgs...>>::type {};
+
 
 } // namespace traits
 } // namespace Rcpp

--- a/inst/tinytest/cpp/InternalFunction.cpp
+++ b/inst/tinytest/cpp/InternalFunction.cpp
@@ -27,6 +27,15 @@ int add(int a, int b) {
 	return a + b;
 }
 
+void dummy(int a, int b) {
+	Rcpp::Rcout << "dummy called" << std::endl;
+}
+
+// [[Rcpp::export]]
+Rcpp::InternalFunction getDummy() {
+	return Rcpp::InternalFunction( &dummy );
+}
+
 
 // [[Rcpp::export]]
 Rcpp::InternalFunction getAdd() {


### PR DESCRIPTION
Opening this as a draft/PoC PR for feedback on the general idea/approach before I make more changes.

For users/systems with c++11 compilers, replacing the generated code in Rcpp with variadic templates could reduce the unnecessary compilation of unused overloads/operators and also remove the limitations on the number of parameters that can be used.

Naturally it would greatly reduce the code in the headers if the generated code were replaced with variadic templates entirely, but I can understand the goal of pre-c++11 compatibility so have made the template use conditional.

Let me know if this would be a useful change in general, or if I should approach things differently, and I'll work on the rest.

Thanks!

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
