### PR TITLE
Expand CI matrix to R 4.3.*

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
           - name: release
             cntr: rcpp/ci
             r: R
+          - name: r-4.3
+            cntr: rcpp/ci-4.3
+            r: R
           - name: r-4.2
             cntr: rcpp/ci-4.2
             r: R

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-05-18  Dirk Eddelbuettel  <edd@debian.org>
+
+	* docker/ci-4.3/Dockerfile: Add rcpp/ci-4.3 container for R 4.3.*
+	* .github/workflows/ci.yaml (jobs): Add rcpp/ci-4.3 to matrix
+
 2024-05-16  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Use tinyverse.netlify.app for dependency badge

--- a/cleanup
+++ b/cleanup
@@ -35,5 +35,5 @@ rm -rf	autom4te.cache inst/lib/ inst/doc/man/ inst/doc/html/ inst/doc/latex/ \
 find . -name \*~ -exec rm {} \;
 find . -name \*.flc -exec rm {} \;
 
-(test -d vignettes/    && cd vignettes/     && make clean && cd -) >/dev/null
-(test -d vignettes/rmd && cd vignettes/rmd/ && make clean && cd -) >/dev/null
+(test -d vignettes/    && cd vignettes/     && test -f Makefile && make clean && cd -) >/dev/null
+(test -d vignettes/rmd && cd vignettes/rmd/ && test -f Makefile && make clean && cd -) >/dev/null

--- a/docker/ci-4.3/Dockerfile
+++ b/docker/ci-4.3/Dockerfile
@@ -1,0 +1,17 @@
+## Emacs, make this -*- mode: sh; -*-
+
+FROM r-base:4.3.3
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
+      maintainer="Dirk Eddelbuettel <edd@debian.org>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && install.r inline pkgKitten rbenchmark tinytest
+
+ENV _R_CHECK_FORCE_SUGGESTS_ FALSE
+ENV _R_CHECK_TESTS_NLINES_ 0
+ENV RunAllRcppTests yes
+
+CMD ["bash"]


### PR DESCRIPTION
With R 4.4.0 release and now in container 'ci' we had a gap for R 4.3.* which this PR fills.

Overhauling the CI scripts is still on the docket too ...

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
