### PR TITLE
Fewer references to StackOverflow

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-05-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* README.md: Remove link references to StackOverflow
+	* inst/NEWS.Rd: Idem
+
 2024-05-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.12.2
+Version: 1.0.12.2.1
 Date: 2024-05-26
 Author: Dirk Eddelbuettel, Romain Francois, JJ Allaire, Kevin Ushey, Qiang Kou,
  Nathan Russell, Inaki Ucar, Douglas Bates and John Chambers

--- a/README.md
+++ b/README.md
@@ -172,13 +172,6 @@ mailing list hosted at R-forge.  Note that in order to keep spam down, you must
 be a subscriber in order to post.  One can also consult the list archives to see
 if your question has been asked before.
 
-Another option is to use
-[StackOverflow and its 'rcpp' tag](https://stackoverflow.com/questions/tagged/rcpp).
-Search functionality (use `rcpp` in squared brackets as in
-[[rcpp] my question terms](https://stackoverflow.com/search?q=[rcpp]%20my%20question%20terms)
-to tag the query) is very valuable as many questions have indeed been asked, and
-answered, before.
-
 The [issue tickets at the GitHub repo](https://github.com/RcppCore/Rcpp/issues)
 are the primary bug reporting interface.  As with the other web resources,
 previous issues can be searched as well.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1810,8 +1810,7 @@
     }
     \item Changes in Rcpp sugar:
     \itemize{
-      \item New function \code{na_omit} based on the StackOverflow thread
-      \url{http://stackoverflow.com/questions/15953768/}
+      \item New function \code{na_omit} based on a StackOverflow thread
       \item New function \code{is_finite} and \code{is_infinite} that
       reproduces the behavior of R's \code{is.finite} and
       \code{is.infinite} functions


### PR DESCRIPTION
Running `R CMD check` a few times yesterday tickled warning from the URL checker for links to StackOverflow.  Given the overall disenchantment with that site, I opted to just remove actual link references as well as paragraph closer to an endoresement.

Yesterday it also whined about packages.debian.org but that was clearly a temporary hickup with that server and is fine now.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
