### PR TITLE
Switch to size_t to avoid conversion warnings from clang++-17

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 
 	* README.md: Remove link references to StackOverflow
 	* inst/NEWS.Rd: Idem
+	* inst/include/Rcpp/Module.h (S4_CppOverloadedMethods): Add cast to int
+	to avoid warnings under 'clang++-17 -Wconversion -Wno-sign-conversion'
+	* inst/include/Rcpp/vector/Vector.h (Vector): Idem
+	* inst/include/Rcpp/module/class.h: Switch variable to size_t to avoid
+	to avoid warnings under 'clang++-17 -Wconversion -Wno-sign-conversion'
+	* inst/tinytest/testRcppClass/src/init.c: Add void to signature
 
 2024-05-26  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -1,5 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // Module.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois
@@ -105,13 +104,13 @@ namespace Rcpp {
     class CppFunctionN : public CppFunction {
         public:
             CppFunctionN(RESULT_TYPE (*fun)(T...), const char* docstring = 0) : CppFunction(docstring), ptr_fun(fun) {}
-            
+
             SEXP operator()(SEXP* args) {
                 BEGIN_RCPP
                 return call<decltype(ptr_fun), RESULT_TYPE, T...>(ptr_fun, args);
                 END_RCPP
             }
-            
+
             inline int nargs() { return sizeof...(T); }
             inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE, T...>(s, name); }
             inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
@@ -119,7 +118,7 @@ namespace Rcpp {
         private:
             RESULT_TYPE (*ptr_fun)(T...);
     };
-    
+
     template <typename RESULT_TYPE, typename... T>
     class CppFunction_WithFormalsN : public CppFunctionN<RESULT_TYPE, T...> {
         public:
@@ -351,7 +350,7 @@ namespace Rcpp{
         typedef std::vector<signed_method_class*> vec_signed_method ;
 
         S4_CppOverloadedMethods( vec_signed_method* m, const XP_Class& class_xp, const char* name, std::string& buffer ) : Reference( "C++OverloadedMethods" ){
-            int n = m->size() ;
+            int n = static_cast<int>(m->size()) ;
             Rcpp::LogicalVector voidness(n), constness(n) ;
             Rcpp::CharacterVector docstrings(n), signatures(n) ;
             Rcpp::IntegerVector nargs(n) ;
@@ -405,10 +404,10 @@ namespace Rcpp{
     private:
         Method met;
     };
-    
+
     template <typename Class, typename RESULT_TYPE, typename... T>
     using CppMethodN = CppMethodImplN<false, Class, RESULT_TYPE, T...>;
-    
+
     template <typename Class, typename RESULT_TYPE, typename... T>
     using const_CppMethodN = CppMethodImplN<true, Class, RESULT_TYPE, T...>;
 
@@ -435,10 +434,10 @@ namespace Rcpp{
     private:
         Method met;
     };
-    
+
     template <typename Class, typename RESULT_TYPE, typename... T>
     using Pointer_CppMethodN = Pointer_CppMethodImplN<false, Class, RESULT_TYPE, T...>;
-    
+
     template <typename Class, typename RESULT_TYPE, typename... T>
     using Const_Pointer_CppMethodN = Pointer_CppMethodImplN<true, Class, RESULT_TYPE, T...>;
 #else
@@ -661,4 +660,3 @@ static VARIABLE_IS_NOT_USED SEXP moduleSym = NULL;
     Rcpp_fast_eval( __load_module_call__, R_GlobalEnv );
 
 #endif
-

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -1,5 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // class.h: Rcpp R/C++ interface class library -- Rcpp modules
 //
 // Copyright (C) 2012 - 2013 Dirk Eddelbuettel and Romain Francois
@@ -136,8 +135,8 @@
         SEXP newInstance( SEXP* args, int nargs ){
             BEGIN_RCPP
                 signed_constructor_class* p ;
-            int n = constructors.size() ;
-            for( int i=0; i<n; i++ ){
+            size_t n = constructors.size() ;
+            for( size_t i=0; i<n; i++ ){
                 p = constructors[i];
                 bool ok = (p->valid)(args, nargs) ;
                 if( ok ){
@@ -148,7 +147,7 @@
 
             signed_factory_class* pfact ;
             n = factories.size() ;
-            for( int i=0; i<n; i++){
+            for( size_t i=0; i<n; i++){
               pfact = factories[i] ;
               bool ok = (pfact->valid)(args, nargs) ;
               if( ok ){
@@ -162,15 +161,15 @@
                 }
 
         bool has_default_constructor(){
-            int n = constructors.size() ;
+            size_t n = constructors.size() ;
             signed_constructor_class* p ;
-            for( int i=0; i<n; i++ ){
+            for( size_t i=0; i<n; i++ ){
                 p = constructors[i];
                 if( p->nargs() == 0 ) return true ;
             }
             n = factories.size() ;
             signed_factory_class* pfact ;
-            for( int i=0; i<n; i++ ){
+            for( size_t i=0; i<n; i++ ){
                 pfact = factories[i];
                 if( pfact->nargs() == 0 ) return true ;
             }
@@ -182,10 +181,10 @@
 
                 vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( R_ExternalPtrAddr( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
-            int n = mets->size() ;
+            size_t n = mets->size() ;
             method_class* m = 0 ;
             bool ok = false ;
-            for( int i=0; i<n; i++, ++it ){
+            for( size_t i=0; i<n; i++, ++it ){
                 if( ( (*it)->valid )( args, nargs) ){
                     m = (*it)->method ;
                     ok = true ;
@@ -209,10 +208,10 @@
 
                 vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( R_ExternalPtrAddr( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
-            int n = mets->size() ;
+            size_t n = mets->size() ;
             method_class* m = 0 ;
             bool ok = false ;
-            for( int i=0; i<n; i++, ++it ){
+            for( size_t i=0; i<n; i++, ++it ){
                 if( ( (*it)->valid )( args, nargs) ){
                     m = (*it)->method ;
                     ok = true ;
@@ -231,10 +230,10 @@
 
                 vec_signed_method* mets = reinterpret_cast< vec_signed_method* >( R_ExternalPtrAddr( method_xp ) ) ;
             typename vec_signed_method::iterator it = mets->begin() ;
-            int n = mets->size() ;
+            size_t n = mets->size() ;
             method_class* m = 0 ;
             bool ok = false ;
-            for( int i=0; i<n; i++, ++it ){
+            for( size_t i=0; i<n; i++, ++it ){
                 if( ( (*it)->valid )( args, nargs) ){
                     m = (*it)->method ;
                     ok = true ;
@@ -326,19 +325,19 @@
         }
 
         Rcpp::CharacterVector method_names(){
-            int n = 0 ;
-            int s = vec_methods.size() ;
+            size_t n = 0 ;
+            size_t s = vec_methods.size() ;
             typename map_vec_signed_method::iterator it = vec_methods.begin( ) ;
-            for( int i=0; i<s; i++, ++it){
+            for( size_t i=0; i<s; i++, ++it){
                 n += (it->second)->size() ;
             }
             Rcpp::CharacterVector out(n) ;
             it = vec_methods.begin() ;
-            int k = 0 ;
-            for( int i=0; i<s; i++, ++it){
+            size_t k = 0 ;
+            for( size_t i=0; i<s; i++, ++it){
                 n = (it->second)->size() ;
                 std::string name = it->first ;
-                for( int j=0; j<n; j++, k++){
+                for( size_t j=0; j<n; j++, k++){
                     out[k] = name ;
                 }
             }
@@ -346,21 +345,21 @@
         }
 
         Rcpp::IntegerVector methods_arity(){
-            int n = 0 ;
-            int s = vec_methods.size() ;
+            size_t n = 0 ;
+            size_t s = vec_methods.size() ;
             typename map_vec_signed_method::iterator it = vec_methods.begin( ) ;
-            for( int i=0; i<s; i++, ++it){
+            for( size_t i=0; i<s; i++, ++it){
                 n += (it->second)->size() ;
             }
             Rcpp::CharacterVector mnames(n) ;
             Rcpp::IntegerVector res(n) ;
             it = vec_methods.begin() ;
-            int k = 0 ;
-            for( int i=0; i<s; i++, ++it){
+            size_t k = 0 ;
+            for( size_t i=0; i<s; i++, ++it){
                 n = (it->second)->size() ;
                 std::string name = it->first ;
                 typename vec_signed_method::iterator m_it = (it->second)->begin() ;
-                for( int j=0; j<n; j++, k++, ++m_it){
+                for( size_t j=0; j<n; j++, k++, ++m_it){
                     mnames[k] = name ;
                     res[k] = (*m_it)->nargs() ;
                 }
@@ -370,21 +369,21 @@
         }
 
         Rcpp::LogicalVector methods_voidness(){
-            int n = 0 ;
-            int s = vec_methods.size() ;
+            size_t n = 0 ;
+            size_t s = vec_methods.size() ;
             typename map_vec_signed_method::iterator it = vec_methods.begin( ) ;
-            for( int i=0; i<s; i++, ++it){
+            for( size_t i=0; i<s; i++, ++it){
                 n += (it->second)->size() ;
             }
             Rcpp::CharacterVector mnames(n) ;
             Rcpp::LogicalVector res(n) ;
             it = vec_methods.begin() ;
-            int k = 0 ;
-            for( int i=0; i<s; i++, ++it){
+            size_t k = 0 ;
+            for( size_t i=0; i<s; i++, ++it){
                 n = (it->second)->size() ;
                 std::string name = it->first ;
                 typename vec_signed_method::iterator m_it = (it->second)->begin() ;
-                for( int j=0; j<n; j++, k++, ++m_it){
+                for( size_t j=0; j<n; j++, k++, ++m_it){
                     mnames[k] = name ;
                     res[k] = (*m_it)->is_void() ;
                 }
@@ -395,21 +394,21 @@
 
 
         Rcpp::CharacterVector property_names(){
-            int n = properties.size() ;
+            size_t n = properties.size() ;
             Rcpp::CharacterVector out(n) ;
             typename PROPERTY_MAP::iterator it = properties.begin( ) ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 out[i] = it->first ;
             }
             return out ;
         }
 
         Rcpp::List property_classes(){
-            int n = properties.size() ;
+            size_t n = properties.size() ;
             Rcpp::CharacterVector pnames(n) ;
             Rcpp::List out(n) ;
             typename PROPERTY_MAP::iterator it = properties.begin( ) ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 pnames[i] = it->first ;
                 out[i] = it->second->get_class() ;
             }
@@ -418,12 +417,12 @@
         }
 
         Rcpp::CharacterVector complete(){
-            int n = vec_methods.size() - specials ;
-            int ntotal = n + properties.size() ;
+            size_t n = vec_methods.size() - specials ;
+            size_t ntotal = n + properties.size() ;
             Rcpp::CharacterVector out(ntotal) ;
             typename map_vec_signed_method::iterator it = vec_methods.begin( ) ;
             std::string buffer ;
-            int i=0 ;
+            size_t i=0 ;
             for( ; i<n; ++it){
                 buffer = it->first ;
                 if( buffer[0] == '[' ) continue ;
@@ -459,11 +458,11 @@
 
 
         Rcpp::List fields( const XP_Class& class_xp ){
-            int n = properties.size() ;
+            size_t n = properties.size() ;
             Rcpp::CharacterVector pnames(n) ;
             Rcpp::List out(n) ;
             typename PROPERTY_MAP::iterator it = properties.begin( ) ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 pnames[i] = it->first ;
                 out[i] = S4_field<Class>( it->second, class_xp ) ;
             }
@@ -476,12 +475,12 @@
             #if RCPP_DEBUG_LEVEL > 0
                 Rf_PrintValue( class_xp ) ;
             #endif
-            int n = vec_methods.size() ;
+            size_t n = vec_methods.size() ;
             Rcpp::CharacterVector mnames(n) ;
             Rcpp::List res(n) ;
             typename map_vec_signed_method::iterator it = vec_methods.begin( ) ;
             vec_signed_method* v;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 mnames[i] = it->first ;
                 v = it->second ;
                 res[i] = S4_CppOverloadedMethods<Class>( v , class_xp, it->first.c_str(), buffer ) ;
@@ -491,10 +490,10 @@
         }
 
         Rcpp::List getConstructors( const XP_Class& class_xp, std::string& buffer){
-            int n = constructors.size() ;
+            size_t n = constructors.size() ;
             Rcpp::List out(n) ;
             typename vec_signed_constructor::iterator it = constructors.begin( ) ;
-            for( int i=0; i<n; i++, ++it){
+            for( size_t i=0; i<n; i++, ++it){
                 out[i] = S4_CppConstructor<Class>( *it , class_xp, name, buffer ) ;
             }
             return out ;

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -331,7 +331,7 @@ public:
     }
 
     inline iterator begin() { return cache.get() ; }
-    inline iterator end() { return cache.get() + size() ; }
+    inline iterator end() { return cache.get() + static_cast<int>(size()) ; }
     inline const_iterator begin() const{ return cache.get_const() ; }
     inline const_iterator end() const{ return cache.get_const() + size() ; }
     inline const_iterator cbegin() const{ return cache.get_const() ; }

--- a/inst/tinytest/testRcppClass/src/init.c
+++ b/inst/tinytest/testRcppClass/src/init.c
@@ -3,15 +3,15 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* FIXME: 
+/* FIXME:
    Check these declarations against the C/Fortran source code.
 */
 
 /* .Call calls */
-extern SEXP rcpp_hello_world_cpp();
-extern SEXP _rcpp_module_boot_NumEx();
-extern SEXP _rcpp_module_boot_RcppClassModule();
-extern SEXP _rcpp_module_boot_stdVector();
+extern SEXP rcpp_hello_world_cpp(void);
+extern SEXP _rcpp_module_boot_NumEx(void);
+extern SEXP _rcpp_module_boot_RcppClassModule(void);
+extern SEXP _rcpp_module_boot_stdVector(void);
 
 static const R_CallMethodDef CallEntries[] = {
     {"rcpp_hello_world_cpp", (DL_FUNC) &rcpp_hello_world_cpp, 0},


### PR DESCRIPTION
Issue #1299 alerts to issues from the (very much opt-in, not (yet ?) compulsory) conversion warnings `clang++17` can do. As I noticed a few from one of our own tests a first attempt squashed those.

This likely does not 'close' the issue so not adding the tag, but should do no harm.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
