### PR TITLE
Additional switch to size_t (or R_xlen_t) to avoid conversion warnings from clang++-17 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-06-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/internal/Proxy_Iterator.h (Proxy_Iterator):
+	Switch to R_xlen_t ('clang++-17 -Wconversion -Wno-sign-conversion')
+
 2024-05-28  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,15 @@
+2024-06-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/internal/export.h: More R_xlen_t switching
+	* inst/include/Rcpp/vector/SubMatrix.h: Idem
+	* inst/include/Rcpp/vector/Vector.h: Idem
+
 2024-06-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/internal/Proxy_Iterator.h (Proxy_Iterator):
 	Switch to R_xlen_t ('clang++-17 -Wconversion -Wno-sign-conversion')
+	* inst/include/Rcpp/DataFrame.h: Idem
+	* inst/include/Rcpp/Vector.h: Idem
 
 2024-05-28  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -137,7 +137,7 @@ namespace Rcpp{
         }
 
         void set_type_after_push(){
-            int max_rows = 0;
+            R_xlen_t max_rows = 0;
             bool invalid_column_size = false;
             List::iterator it;
             // Get the maximum number of rows

--- a/inst/include/Rcpp/Vector.h
+++ b/inst/include/Rcpp/Vector.h
@@ -1,5 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
+
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois

--- a/inst/include/Rcpp/internal/Proxy_Iterator.h
+++ b/inst/include/Rcpp/internal/Proxy_Iterator.h
@@ -1,6 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
+
 // Proxy_Iterator.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
@@ -31,7 +29,7 @@ class Proxy_Iterator {
 public:
 		typedef PROXY& reference ;
 		typedef PROXY* pointer ;
-		typedef int difference_type ;
+		typedef R_xlen_t difference_type ;
 		typedef PROXY value_type;
 		typedef std::random_access_iterator_tag iterator_category ;
 
@@ -122,4 +120,3 @@ private:
 }
 
 #endif
-

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -1,6 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-/* :tabSize=4:indentSize=4:noTabs=false:folding=explicit:collapseFolds=1: */
-//
+
 // export.h: Rcpp R/C++ interface class library --
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
@@ -111,7 +109,8 @@ namespace Rcpp{
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
 			R_xlen_t size = ::Rf_xlength(y)  ;
 			for( R_xlen_t i=0; i<size; i++){
-				res[i] =  start[i] ;
+                T ii{i};
+				res[ii] =  start[i] ;
 			}
 		}
 

--- a/inst/include/Rcpp/internal/export.h
+++ b/inst/include/Rcpp/internal/export.h
@@ -109,8 +109,7 @@ namespace Rcpp{
 			STORAGE* start = ::Rcpp::internal::r_vector_start<RTYPE>(y) ;
 			R_xlen_t size = ::Rf_xlength(y)  ;
 			for( R_xlen_t i=0; i<size; i++){
-                T ii{i};
-				res[ii] =  start[i] ;
+				res[i] =  start[i] ;
 			}
 		}
 

--- a/inst/include/Rcpp/vector/SubMatrix.h
+++ b/inst/include/Rcpp/vector/SubMatrix.h
@@ -1,5 +1,4 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
+
 // SubMatrix.h: Rcpp R/C++ interface class library -- sub matrices
 //
 // Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
@@ -40,8 +39,8 @@ public:
     {}
 
     inline R_xlen_t size() const { return ((R_xlen_t)ncol()) * nrow() ; }
-    inline int ncol() const { return nc ; }
-    inline int nrow() const { return nr ; }
+    inline R_xlen_t ncol() const { return nc ; }
+    inline R_xlen_t nrow() const { return nr ; }
 
     inline Proxy operator()(int i, int j) const {
         return iter[ i + j*m_nr ] ;
@@ -52,16 +51,16 @@ public:
 private:
     MATRIX& m ;
     vec_iterator iter ;
-    int m_nr, nc, nr ;
+    R_xlen_t m_nr, nc, nr ;
 } ;
 
 template <int RTYPE, template <class> class StoragePolicy >
-Matrix<RTYPE,StoragePolicy>::Matrix( const SubMatrix<RTYPE>& sub ) : VECTOR( Rf_allocMatrix( RTYPE, sub.nrow(), sub.ncol() )), nrows(sub.nrow()) {
-    int nc = sub.ncol() ;
+Matrix<RTYPE,StoragePolicy>::Matrix( const SubMatrix<RTYPE>& sub ) : VECTOR( Rf_allocMatrix( RTYPE, (int)sub.nrow(), (int)sub.ncol() )), nrows((int)sub.nrow()) {
+    R_xlen_t nc = sub.ncol() ;
     iterator start = VECTOR::begin() ;
 	iterator rhs_it ;
-	for( int j=0; j<nc; j++){
-	    rhs_it = sub.column_iterator(j) ;
+	for( R_xlen_t j=0; j<nc; j++){
+	    rhs_it = sub.column_iterator((int)j) ;
 	    for( int i=0; i<nrows; i++, ++start){
 	        *start = rhs_it[i] ;
 	    }

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -593,7 +593,7 @@ public:
         return false ;
     }
 
-    int findName(const std::string& name) const {
+    R_xlen_t findName(const std::string& name) const {
         SEXP names = RCPP_GET_NAMES(Storage::get__());
         if (Rf_isNull(names)) stop("'names' attribute is null");
         R_xlen_t n = Rf_xlength(names);


### PR DESCRIPTION
This is a continuation of PR #1307 with a few changes -- with many remaining to be done.  As we wrote in #1307:
> Issue https://github.com/RcppCore/Rcpp/issues/1299 alerts to issues from the (very much opt-in, not (yet ?) compulsory) conversion warnings clang++17 can do. As I noticed a few from one of our own tests a first attempt squashed those.
> 
> This likely does not 'close' the issue so not adding the tag, but should do no harm.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
