### PR TITLE
add template specializations to avoid DATAPTR use

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-06-11  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/internal/r_vector.h: Use template specializations to
+	avoid DATAPTR usage
+
 2024-06-02  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/internal/export.h: More R_xlen_t switching

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
 	* inst/include/Rcpp/internal/r_vector.h: Use template specializations to
 	avoid DATAPTR usage
+	* inst/include/Rcpp/vector/traits.h: Implement bounds checks in
+	r_vector_cache access
 
 2024-06-02  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 	avoid DATAPTR usage
 	* inst/include/Rcpp/vector/traits.h: Implement bounds checks in
 	r_vector_cache access
+	* inst/tinytest/cpp/Vector.cpp: Add unit tests
+	* inst/tinytest/test_vector.R: Add unit tests
+	* tests/tinytest.R: Test in serial by default
 
 2024-06-02  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,7 +15,7 @@
       \item Rcpp now avoids the usage of the (non-API) DATAPTR function when
       accessing the contents of Rcpp Vector objects where possible. (Kevin in
       \ghpr{1310})
-      \item Rcpp now throws an R error on out-of-bounds Vector accesses. (Kevin
+      \item Rcpp now emits an R warning on out-of-bounds Vector accesses. (Kevin
       in \ghpr{1310})
     }
     \item Changes in Rcpp Deployment:

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,9 +9,11 @@
     \itemize{
       \item Set R_NO_REMAP if not already defined (Dirk in \ghpr{1296})
       \item Add variadic templates to be used instead of generated code
-      (Andrew Johnson in \ghpr{1303}
+      (Andrew Johnson in \ghpr{1303})
       \item Count variables were switches to \code{size_t} to avoid warnings
       about conversion-narrowing (Dirk in \ghpr{1307})
+      \item Rcpp now avoids the usage of the (non-API) DATAPTR function when
+      accessing the contents of Rcpp Vector objects where possible.
     }
     \item Changes in Rcpp Deployment:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,7 +13,10 @@
       \item Count variables were switches to \code{size_t} to avoid warnings
       about conversion-narrowing (Dirk in \ghpr{1307})
       \item Rcpp now avoids the usage of the (non-API) DATAPTR function when
-      accessing the contents of Rcpp Vector objects where possible.
+      accessing the contents of Rcpp Vector objects where possible. (Kevin in
+      \ghpr{1310})
+      \item Rcpp now throws an R error on out-of-bounds Vector accesses. (Kevin
+      in \ghpr{1310})
     }
     \item Changes in Rcpp Deployment:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -15,8 +15,8 @@
       \item Rcpp now avoids the usage of the (non-API) DATAPTR function when
       accessing the contents of Rcpp Vector objects where possible. (Kevin in
       \ghpr{1310})
-      \item Rcpp now emits an R warning on out-of-bounds Vector accesses. (Kevin
-      in \ghpr{1310})
+      \item Rcpp now emits an R warning on out-of-bounds Vector accesses. This
+      may become an error in a future Rcpp release. (Kevin in \ghpr{1310})
     }
     \item Changes in Rcpp Deployment:
     \itemize{

--- a/inst/include/Rcpp/internal/r_vector.h
+++ b/inst/include/Rcpp/internal/r_vector.h
@@ -32,6 +32,21 @@ typename Rcpp::traits::storage_type<RTYPE>::type* r_vector_start(SEXP x) {
     return reinterpret_cast<pointer>(dataptr(x));
 }
 
+// add specializations to avoid use of dataptr
+#define RCPP_VECTOR_START_IMPL(__RTYPE__, __ACCESSOR__)                                              \
+    template <>                                                                                      \
+    inline typename Rcpp::traits::storage_type<__RTYPE__>::type* r_vector_start<__RTYPE__>(SEXP x) { \
+        return __ACCESSOR__(x);                                                                      \
+    }
+
+RCPP_VECTOR_START_IMPL(LGLSXP,  LOGICAL);
+RCPP_VECTOR_START_IMPL(INTSXP,  INTEGER);
+RCPP_VECTOR_START_IMPL(RAWSXP,  RAW);
+RCPP_VECTOR_START_IMPL(CPLXSXP, COMPLEX);
+RCPP_VECTOR_START_IMPL(REALSXP, REAL);
+
+#undef RCPP_VECTOR_START_IMPL
+
 /**
  * The value 0 statically casted to the appropriate type for
  * the given SEXP type

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -133,9 +133,9 @@ public:
 
 private:
 
-    #ifndef RCPP_NO_BOUNDS_CHECK
     template <typename IDX>
     void check_indices(IDX* x, R_xlen_t n, R_xlen_t size) {
+#ifndef RCPP_NO_BOUNDS_CHECK
         for (IDX i=0; i < n; ++i) {
             if (x[i] < 0 or x[i] >= size) {
                 if(std::numeric_limits<IDX>::is_integer && size > std::numeric_limits<IDX>::max()) {
@@ -144,11 +144,8 @@ private:
                 stop("index error");
             }
         }
+#endif
     }
-    #else
-    template <typename IDX>
-    void check_indices(IDX* x, IDX n, IDX size) {}
-    #endif
 
     void get_indices( traits::identity< traits::int2type<INTSXP> > t ) {
         indices.reserve(rhs_n);

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -79,8 +79,8 @@ namespace traits{
 		void update( const VECTOR& v ){
 			p = const_cast<VECTOR*>(&v) ;
 		}
-		inline iterator get() const { check_index(0); return iterator( proxy(*p, 0 ) ) ;}
-		inline const_iterator get_const() const { check_index(0); return const_iterator( const_proxy(*p, 0) ) ; }
+		inline iterator get() const { return iterator( proxy(*p, 0 ) ) ;}
+		inline const_iterator get_const() const { return const_iterator( const_proxy(*p, 0) ) ; }
 
 		inline proxy ref() { check_index(0); return proxy(*p,0) ; }
 		inline proxy ref(R_xlen_t i) { check_index(i); return proxy(*p,i);}

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -35,22 +35,59 @@ namespace traits{
 		typedef typename r_vector_const_proxy<RTYPE>::type const_proxy ;
 		typedef typename storage_type<RTYPE>::type storage_type ;
 
-		r_vector_cache() : start(0){} ;
+		r_vector_cache() : start(0), size(0) {} ;
+
 		inline void update( const VECTOR& v ) {
-		    start = ::Rcpp::internal::r_vector_start<RTYPE>(v) ;
+			start = ::Rcpp::internal::r_vector_start<RTYPE>(v) ;
+			size = v.size();
 		}
+
 		inline iterator get() const { return start; }
 		inline const_iterator get_const() const { return start; }
 
-		inline proxy ref() { return *start ;}
-		inline proxy ref(R_xlen_t i) { return start[i] ; }
+		inline proxy ref() {
+#ifndef RCPP_NO_BOUNDS_CHECK
+			check_index(0) ;
+#endif
+			return start[0];
+		}
 
-		inline proxy ref() const { return *start ;}
-		inline proxy ref(R_xlen_t i) const { return start[i] ; }
+		inline proxy ref() const {
+#ifndef RCPP_NO_BOUNDS_CHECK
+			check_index(0) ;
+#endif
+			return start[0] ;
+		}
 
-		private:
-			iterator start ;
+		inline proxy ref(R_xlen_t i) {
+#ifndef RCPP_NO_BOUNDS_CHECK
+			check_index(i) ;
+#endif
+			return start[i] ;
+		}
+
+
+		inline proxy ref(R_xlen_t i) const {
+#ifndef RCPP_NO_BOUNDS_CHECK
+			check_index(i) ;
+#endif
+			return start[i] ;
+		}
+
+	private:
+
+#ifndef RCPP_NO_BOUNDS_CHECK
+		void check_index(R_xlen_t i) const {
+			if (i >= size) {
+				stop("index error");
+			}
+		}
+#endif
+
+		iterator start ;
+		R_xlen_t size ;
 	} ;
+
 	template <int RTYPE, template <class> class StoragePolicy = PreserveStorage>
 	class proxy_cache{
 	public:

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -45,44 +45,21 @@ namespace traits{
 		inline iterator get() const { return start; }
 		inline const_iterator get_const() const { return start; }
 
-		inline proxy ref() {
-#ifndef RCPP_NO_BOUNDS_CHECK
-			check_index(0) ;
-#endif
-			return start[0];
-		}
+		inline proxy ref() { check_index(0); return start[0] ;}
+		inline proxy ref(R_xlen_t i) { check_index(i); return start[i] ; }
 
-		inline proxy ref() const {
-#ifndef RCPP_NO_BOUNDS_CHECK
-			check_index(0) ;
-#endif
-			return start[0] ;
-		}
-
-		inline proxy ref(R_xlen_t i) {
-#ifndef RCPP_NO_BOUNDS_CHECK
-			check_index(i) ;
-#endif
-			return start[i] ;
-		}
-
-
-		inline proxy ref(R_xlen_t i) const {
-#ifndef RCPP_NO_BOUNDS_CHECK
-			check_index(i) ;
-#endif
-			return start[i] ;
-		}
+		inline proxy ref() const { check_index(0); return start[0] ;}
+		inline proxy ref(R_xlen_t i) const { check_index(i); return start[i] ; }
 
 	private:
 
-#ifndef RCPP_NO_BOUNDS_CHECK
 		void check_index(R_xlen_t i) const {
+#ifndef RCPP_NO_BOUNDS_CHECK
 			if (i >= size) {
 				stop("subscript out of bounds (index %s >= vector size %s)", i, size);
 			}
-		}
 #endif
+		}
 
 		iterator start ;
 		R_xlen_t size ;
@@ -102,18 +79,25 @@ namespace traits{
 		void update( const VECTOR& v ){
 			p = const_cast<VECTOR*>(&v) ;
 		}
-		inline iterator get() const { return iterator( proxy(*p, 0 ) ) ;}
-		// inline const_iterator get_const() const { return const_iterator( *p ) ;}
-		inline const_iterator get_const() const { return const_iterator( const_proxy(*p, 0) ) ; }
+		inline iterator get() const { check_index(0); return iterator( proxy(*p, 0 ) ) ;}
+		inline const_iterator get_const() const { check_index(0); return const_iterator( const_proxy(*p, 0) ) ; }
 
-		inline proxy ref() { return proxy(*p,0) ; }
-		inline proxy ref(R_xlen_t i) { return proxy(*p,i);}
+		inline proxy ref() { check_index(0); return proxy(*p,0) ; }
+		inline proxy ref(R_xlen_t i) { check_index(i); return proxy(*p,i);}
 
-		inline const_proxy ref() const { return const_proxy(*p,0) ; }
-		inline const_proxy ref(R_xlen_t i) const { return const_proxy(*p,i);}
+		inline const_proxy ref() const { check_index(0); return const_proxy(*p,0) ; }
+		inline const_proxy ref(R_xlen_t i) const { check_index(i); return const_proxy(*p,i);}
 
 	private:
 		VECTOR* p ;
+
+		void check_index(R_xlen_t i) const {
+#ifndef RCPP_NO_BOUNDS_CHECK
+			if (i >= size) {
+				stop("subscript out of bounds (index %s >= vector size %s)", i, size);
+			}
+#endif
+		}
 	} ;
 
 	// regular types for INTSXP, REALSXP, ...

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -56,7 +56,7 @@ namespace traits{
 		void check_index(R_xlen_t i) const {
 #ifndef RCPP_NO_BOUNDS_CHECK
 			if (i >= size) {
-				stop("subscript out of bounds (index %s >= vector size %s)", i, size);
+				warning("subscript out of bounds (index %s >= vector size %s)", i, size);
 			}
 #endif
 		}
@@ -94,7 +94,7 @@ namespace traits{
 		void check_index(R_xlen_t i) const {
 #ifndef RCPP_NO_BOUNDS_CHECK
 			if (i >= p->size()) {
-				stop("subscript out of bounds (index %s >= vector size %s)", i, p->size());
+				warning("subscript out of bounds (index %s >= vector size %s)", i, p->size());
 			}
 #endif
 		}

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -79,7 +79,7 @@ namespace traits{
 #ifndef RCPP_NO_BOUNDS_CHECK
 		void check_index(R_xlen_t i) const {
 			if (i >= size) {
-				stop("index error");
+				stop("subscript out of bounds (index %s >= vector size %s)", i, size);
 			}
 		}
 #endif

--- a/inst/include/Rcpp/vector/traits.h
+++ b/inst/include/Rcpp/vector/traits.h
@@ -93,8 +93,8 @@ namespace traits{
 
 		void check_index(R_xlen_t i) const {
 #ifndef RCPP_NO_BOUNDS_CHECK
-			if (i >= size) {
-				stop("subscript out of bounds (index %s >= vector size %s)", i, size);
+			if (i >= p->size()) {
+				stop("subscript out of bounds (index %s >= vector size %s)", i, p->size());
 			}
 #endif
 		}

--- a/inst/tinytest/cpp/Vector.cpp
+++ b/inst/tinytest/cpp/Vector.cpp
@@ -888,13 +888,11 @@ bool CharacterVector_test_equality_crosspolicy(CharacterVector x, Vector<STRSXP,
 }
 
 // [[Rcpp::export]]
-double NumericVector_test_out_of_bounds_read() {
-    NumericVector v(3);
-    return v[5];
+double NumericVector_test_out_of_bounds_read(NumericVector v, R_xlen_t i) {
+    return v[i];
 }
 
 // [[Rcpp::export]]
-SEXP CharacterVector_test_out_of_bounds_read() {
-    CharacterVector v(3);
-    return v[5];
+SEXP CharacterVector_test_out_of_bounds_read(CharacterVector v, R_xlen_t i) {
+    return v[i];
 }

--- a/inst/tinytest/cpp/Vector.cpp
+++ b/inst/tinytest/cpp/Vector.cpp
@@ -886,3 +886,15 @@ bool CharacterVector_test_equality_crosspolicy(CharacterVector x, Vector<STRSXP,
 
     return std::equal(x.begin(), x.end(), y.begin());
 }
+
+// [[Rcpp::export]]
+double NumericVector_test_out_of_bounds_read() {
+    NumericVector v(3);
+    return v[5];
+}
+
+// [[Rcpp::export]]
+SEXP CharacterVector_test_out_of_bounds_read() {
+    CharacterVector v(3);
+    return v[5];
+}

--- a/inst/tinytest/test_packageversion.R
+++ b/inst/tinytest/test_packageversion.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2019 - 2022  Dirk Eddelbuettel
+##  Copyright (C) 2019 - 2024  Dirk Eddelbuettel
 ##
 ##  This file is part of Rcpp.
 ##
@@ -30,7 +30,7 @@ v <- as.integer(unlist(strsplit(pvstr, "\\.")))
 relstr <- as.character(as.package_version(paste(v[1:3], collapse=".")))
 
 ## call C++ function returning list of six values, three each for 'release' and 'dev' version
-res <- checkVersion(v)
+res <- checkVersion(v[1:min(4, length(v))])
 
 
 ## basic check: is the #defined version equal to the computed version (issue #1014)

--- a/inst/tinytest/test_rcpp_package_skeleton.R
+++ b/inst/tinytest/test_rcpp_package_skeleton.R
@@ -69,7 +69,7 @@ for (file in grep("RcppExports.R", R_files, invert=TRUE, value=TRUE)) {
     code <- readLines(file)
     fn <- eval(parse(text=paste(code, collapse="\n")))
     fn_name <- gsub(".*/(.*)\\.R$", "\\1", file)
-    checkIdentical(fn, get(fn_name),
+    checkIdentical(fn, base::get(fn_name),
                    sprintf("we parsed the function '%s' correctly", fn_name)
                    )
 }

--- a/inst/tinytest/test_vector.R
+++ b/inst/tinytest/test_vector.R
@@ -695,6 +695,9 @@ expect_equal(data, data2)
 expect_true( !CharacterVector_test_equality("foo", "bar") )
 expect_true( !CharacterVector_test_equality_crosspolicy("foo", "bar") )
 
+# https://github.com/RcppCore/Rcpp/issues/1308
+expect_error(NumericVector_test_out_of_bounds_read(numeric(0), 0))
+expect_error(NumericVector_test_out_of_bounds_read(numeric(1), 1))
+expect_error(CharacterVector_test_out_of_bounds_read(character(0), 0))
+expect_error(CharacterVector_test_out_of_bounds_read(character(1), 1))
 
-expect_error(NumericVector_test_out_of_bounds_read())
-expect_error(CharacterVector_test_out_of_bounds_read())

--- a/inst/tinytest/test_vector.R
+++ b/inst/tinytest/test_vector.R
@@ -694,3 +694,7 @@ expect_equal(data, data2)
 #    test.CharacterVector_test_equality <- function(){
 expect_true( !CharacterVector_test_equality("foo", "bar") )
 expect_true( !CharacterVector_test_equality_crosspolicy("foo", "bar") )
+
+
+expect_error(NumericVector_test_out_of_bounds_read())
+expect_error(CharacterVector_test_out_of_bounds_read())

--- a/inst/tinytest/test_vector.R
+++ b/inst/tinytest/test_vector.R
@@ -696,8 +696,9 @@ expect_true( !CharacterVector_test_equality("foo", "bar") )
 expect_true( !CharacterVector_test_equality_crosspolicy("foo", "bar") )
 
 # https://github.com/RcppCore/Rcpp/issues/1308
-expect_error(NumericVector_test_out_of_bounds_read(numeric(0), 0))
-expect_error(NumericVector_test_out_of_bounds_read(numeric(1), 1))
-expect_error(CharacterVector_test_out_of_bounds_read(character(0), 0))
-expect_error(CharacterVector_test_out_of_bounds_read(character(1), 1))
+# tests disabled since these could trigger UBSAN warnings / crashes
+#expect_warning(NumericVector_test_out_of_bounds_read(numeric(0), 0))
+#expect_warning(NumericVector_test_out_of_bounds_read(numeric(1), 1))
+#expect_warning(CharacterVector_test_out_of_bounds_read(character(0), 0))
+#expect_warning(CharacterVector_test_out_of_bounds_read(character(1), 1))
 

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -43,5 +43,5 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
     ## there are several more granular ways to test files in a tinytest directory,
     ## see its package vignette; tests can also run once the package is installed
     ## using the same command `test_package(pkgName)`, or by director or file
-    tinytest::test_package("Rcpp", ncpu=getOption("Ncpus", 1))
+    tinytest::test_package("Rcpp", ncpu=getOption("Ncpus"))
 }

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -43,5 +43,5 @@ if (requireNamespace("tinytest", quietly=TRUE)) {
     ## there are several more granular ways to test files in a tinytest directory,
     ## see its package vignette; tests can also run once the package is installed
     ## using the same command `test_package(pkgName)`, or by director or file
-    tinytest::test_package("Rcpp", ncpu=getOption("Ncpus"))
+    tinytest::test_package("Rcpp")
 }


### PR DESCRIPTION
Addresses https://github.com/RcppCore/Rcpp/issues/1308, but note that this PR would turn these out-of-bounds accesses into R errors, and so we might expect to see some CRAN failures. If that feels too aggressive, we could make these warnings instead, or control the behavior with an environment variable (read on package load), or something else.

This PR seeks to avoid some of the crashes seen in packages using Rcpp, where out-of-bounds accessed could trigger an ASAN misaligned read (due to special behavior in DATAPTR attempting to catch such usages).

This PR also now adds bounds checking to offset accessing via `operator[]` for the various Vector<RTYPE> classes provided by Rcpp; controlled via the same `RCPP_NO_BOUNDS_CHECK` macro used by the subsetting code.

For example:

`````
#include <Rcpp.h>
using namespace Rcpp;

// [[Rcpp::export]]
double get(NumericVector x, R_xlen_t index) {
    return x[index];
}

/*** R
get(42, 2)
*/
`````

Would now give:

```
> get(42, 2)
Error in eval(ei, envir) : 
  subscript out of bounds (index 2 >= vector size 1)
```

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
