### PR TITLE
use read-only variants of {STRING/VECTOR}_PTR

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-07-07  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/internal/SEXP_Iterator.h: Avoid using VECTOR_PTR
+	* inst/include/Rcpp/vector/Subsetter.h: Avoid using STRING_PTR
+	* inst/include/RcppCommon.h: Include compatibility defines
+	* src/barrier.cpp: Avoid using {STRING/VECTOR}_PTR
+	* inst/include/Rcpp/r/compat.h: Include compatibility defines
+
 2024-06-22  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/inst/include/Rcpp/internal/SEXP_Iterator.h
+++ b/inst/include/Rcpp/internal/SEXP_Iterator.h
@@ -37,7 +37,7 @@ public:
 
 		SEXP_Iterator( ): ptr(){} ;
 		SEXP_Iterator( const SEXP_Iterator& other) : ptr(other.ptr){} ;
-		SEXP_Iterator( const VECTOR& vec ) : ptr( get_vector_ptr(vec) ){} ;
+		SEXP_Iterator( const VECTOR& vec ) : ptr( RCPP_VECTOR_PTR(vec) ){} ;
 
 		SEXP_Iterator& operator=(const SEXP_Iterator& other){ ptr = other.ptr ; return *this ;}
 

--- a/inst/include/Rcpp/r/compat.h
+++ b/inst/include/Rcpp/r/compat.h
@@ -22,13 +22,15 @@
 #ifndef RCPP_R_COMPAT_H
 #define RCPP_R_COMPAT_H
 
-#if defined(STRING_PTR_RO)
+#include <Rversion.h>
+
+#if R_VERSION >= R_Version(4, 4, 0)
 # define RCPP_STRING_PTR STRING_PTR_RO
 #else
 # define RCPP_STRING_PTR STRING_PTR
 #endif
 
-#if defined(VECTOR_PTR_RO)
+#if R_VERSION >= R_Version(4, 4, 0)
 # define RCPP_VECTOR_PTR VECTOR_PTR_RO
 #else
 # define RCPP_VECTOR_PTR VECTOR_PTR

--- a/inst/include/Rcpp/r/compat.h
+++ b/inst/include/Rcpp/r/compat.h
@@ -24,13 +24,13 @@
 
 #include <Rversion.h>
 
-#if R_VERSION >= R_Version(4, 4, 0)
+#if R_VERSION >= R_Version(4, 4, 2)
 # define RCPP_STRING_PTR STRING_PTR_RO
 #else
 # define RCPP_STRING_PTR STRING_PTR
 #endif
 
-#if R_VERSION >= R_Version(4, 4, 0)
+#if R_VERSION >= R_Version(4, 4, 2)
 # define RCPP_VECTOR_PTR VECTOR_PTR_RO
 #else
 # define RCPP_VECTOR_PTR VECTOR_PTR

--- a/inst/include/Rcpp/r/compat.h
+++ b/inst/include/Rcpp/r/compat.h
@@ -1,0 +1,37 @@
+
+//
+// compat.h: Rcpp R/C++ interface class library -- compatibility defines
+//
+// Copyright (C) 2024         Dirk Eddelbuettel, Kevin Ushey
+//
+// This file is part of Rcpp.
+//
+// Rcpp is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+//
+// Rcpp is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Rcpp.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef RCPP_R_COMPAT_H
+#define RCPP_R_COMPAT_H
+
+#if defined(STRING_PTR_RO)
+# define RCPP_STRING_PTR STRING_PTR_RO
+#else
+# define RCPP_STRING_PTR STRING_PTR
+#endif
+
+#if defined(VECTOR_PTR_RO)
+# define RCPP_VECTOR_PTR VECTOR_PTR_RO
+#else
+# define RCPP_VECTOR_PTR VECTOR_PTR
+#endif
+
+#endif /* RCPP_R_COMPAT_H */

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -174,8 +174,8 @@ private:
         indices.reserve(rhs_n);
         SEXP names = Rf_getAttrib(lhs, R_NamesSymbol);
         if (Rf_isNull(names)) stop("names is null");
-        SEXP* namesPtr = STRING_PTR(names);
-        SEXP* rhsPtr = STRING_PTR(rhs);
+        const SEXP* namesPtr = RCPP_STRING_PTR(names);
+        const SEXP* rhsPtr = RCPP_STRING_PTR(rhs);
         for (R_xlen_t i = 0; i < rhs_n; ++i) {
             SEXP* match = std::find(namesPtr, namesPtr + lhs_n, *(rhsPtr + i));
             if (match == namesPtr + lhs_n)

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -177,7 +177,7 @@ private:
         const SEXP* namesPtr = RCPP_STRING_PTR(names);
         const SEXP* rhsPtr = RCPP_STRING_PTR(rhs);
         for (R_xlen_t i = 0; i < rhs_n; ++i) {
-            SEXP* match = std::find(namesPtr, namesPtr + lhs_n, *(rhsPtr + i));
+            const SEXP* match = std::find(namesPtr, namesPtr + lhs_n, *(rhsPtr + i));
             if (match == namesPtr + lhs_n)
                 stop("not found");
             indices.push_back(match - namesPtr);

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -28,6 +28,7 @@
 // #define RCPP_DEBUG_MODULE_LEVEL 1
 
 #include <Rcpp/r/headers.h>
+#include <Rcpp/r/compat.h>
 
 /**
  * \brief Rcpp API

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -112,7 +112,7 @@ namespace Rcpp {
         case BCODESXP:  	return "BCODESXP";
         case EXTPTRSXP: 	return "EXTPTRSXP";
         case WEAKREFSXP:    return "WEAKREFSXP";
-#if R_Version >= R_Version(4,4,0)					// replaces S4SXP in R 4.4.0
+#if R_VERSION >= R_Version(4,4,0)					// replaces S4SXP in R 4.4.0
         case OBJSXP:    	return Rf_isS4(x) ? "S4SXP" : "OBJSXP"; 	// cf src/main/inspect.c
 #else
         case S4SXP:     	return "S4SXP";

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -22,11 +22,15 @@
 #define COMPILING_RCPP
 
 #define USE_RINTERNALS
-#include <Rinternals.h>
-#include <Rcpp/barrier.h>
-#include "internal.h"
+
 #include <algorithm>
+#include <Rinternals.h>
+
+#include <Rcpp/barrier.h>
 #include <Rcpp/protection/Shield.h>
+#include <Rcpp/r/compat.h>
+
+#include "internal.h"
 
 // [[Rcpp::register]]
 SEXP get_string_elt(SEXP x, R_xlen_t i) {			// #nocov start
@@ -50,7 +54,7 @@ void char_set_string_elt(SEXP x, R_xlen_t i, const char* value) {
 
 // [[Rcpp::register]]
 SEXP* get_string_ptr(SEXP x) {
-    return STRING_PTR(x);
+    return RCPP_STRING_PTR(x);
 }
 
 // [[Rcpp::register]]
@@ -65,7 +69,8 @@ void set_vector_elt(SEXP x, R_xlen_t i, SEXP value) {
 
 // [[Rcpp::register]]
 SEXP* get_vector_ptr(SEXP x) {
-    return VECTOR_PTR(x);							// #nocov end
+    // TODO: should we deprecate this?
+    return const_cast<SEXP*>(RCPP_VECTOR_PTR(x));							// #nocov end
 }
 
 // [[Rcpp::register]]

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -54,7 +54,8 @@ void char_set_string_elt(SEXP x, R_xlen_t i, const char* value) {
 
 // [[Rcpp::register]]
 SEXP* get_string_ptr(SEXP x) {
-    return RCPP_STRING_PTR(x);
+    // TODO: should we deprecate this?
+    return const_cast<SEXP*>(RCPP_STRING_PTR(x));
 }
 
 // [[Rcpp::register]]


### PR DESCRIPTION
### Pull Request Template for Rcpp

Closes https://github.com/RcppCore/Rcpp/issues/1316. I tried to do this in a way that lets us use the read-only variants with newer versions of R, and fall back to the non-API variants for older versions of R.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
