### PR TITLE
Skip one more test on macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,40 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        include:
+          - {os: macOS-latest}
+          #- {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci-setup@master
+
+      - name: Bootstrap
+        run: ./run.sh bootstrap
+
+      - name: Dependencies
+        run: ./run.sh install_deps
+
+      - name: Test
+        run: ./run.sh run_tests
+
+      #- name: Coverage
+      #  if: ${{ matrix.os == 'ubuntu-latest' }}
+      #  run: ./run.sh coverage

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,6 +1,6 @@
 # Run CI for R using https://eddelbuettel.github.io/r-ci/
 
-name: ci
+name: macos
 
 on:
   push:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-08-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_sugar.R: Skip one more NA related test on arm64
+	and macOS as failure is seen at r-universe on arm64
+
 2024-08-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* Contributing.md: Refreshed content

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 	* inst/tinytest/test_sugar.R: Skip one more NA related test on arm64
 	and macOS as failure is seen at r-universe on arm64
 
+	* .github/workflows/macos.yaml: Add basic r-ci setup but dialed-down
+	to macOS only (as Linux is covered via multiple Docker setups)
+
 2024-08-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* Contributing.md: Refreshed content

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -1567,7 +1567,7 @@ expect_error(strimws(x[1], "invalid"), info = "strimws -- bad `which` argument")
 ## min/max
 #    test.sugar.min.max <- function() {
 ## min(empty) gives NA for integer, Inf for numeric (#844)
-expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
+if (!isArmMacOs) expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
 if (!isArmMacOs) expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
 
 ## max(empty_ gives NA for integer, Inf for numeric (#844)


### PR DESCRIPTION
We are seeing an additional (new) failure on macOS and arm64 at r-universe ([recent build log](https://github.com/r-universe/rcppcore/actions/runs/10464014682/job/28977023009)).  We already skip a number of `NA` related tests on that platform so I added one.  I cannot test this locally -- anybody reading this who has an arm64 mac and the `clang` that @jeroen reports, namely

```
clang --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
