### PR TITLE
Support Authors@R in Rcpp.package.skeleton()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-08-28  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Rcpp.package.skeleton.R: Create DESCRIPTION with Auhors@R fiel
+	* inst/tinytest/test_rcpp_package_skeleton.R: Adjust tests
+
 2024-08-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_sugar.R: Skip one more NA related test on arm64

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -86,7 +86,7 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
                                                      "Description", "License")),
                    "Imports" = paste(imports, collapse = ", "),
                    "LinkingTo" = "Rcpp",
-                   "Authors@R" = sprintf(r"(person("%s", "%s", role = c("aut", "cre"), email = "%s"))",
+                   "Authors@R" = sprintf("person(\"%s\", \"%s\", role = c(\"aut\", \"cre\"), email = \"%s\")",
                                          paste(splitname[-length(splitname)], collapse=" "),
                                          splitname[length(splitname)],
                                          email))

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -81,18 +81,27 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
     DESCRIPTION <- file.path(root, "DESCRIPTION")
     if (file.exists(DESCRIPTION)) {
         imports <- c(if (isTRUE(module)) "methods", sprintf("Rcpp (>= %s)", getRcppVersion()))
-        x <- cbind(read.dcf(DESCRIPTION),
+        splitname <- strsplit(author, " ")[[1]]
+        x <- cbind(read.dcf(DESCRIPTION,  fields = c("Package", "Type", "Title", "Version", "Date",
+                                                     "Description", "License")),
                    "Imports" = paste(imports, collapse = ", "),
-                   "LinkingTo" = "Rcpp")
-        x[, "Author"] <- author
-        x[, "Maintainer"] <- sprintf("%s <%s>", maintainer, email)
+                   "LinkingTo" = "Rcpp",
+                   "Authors@R" = sprintf(r"(person("%s", "%s", role = c("aut", "cre"), email = "%s"))",
+                                         paste(splitname[-length(splitname)], collapse=" "),
+                                         splitname[length(splitname)],
+                                         email))
+        #x[, "Author"] <- author
+        #x[, "Maintainer"] <- sprintf("%s <%s>", maintainer, email)
         x[, "License"] <- license
-        x[, "Title"] <- "What the Package Does in One 'Title Case' Line"
-        x[, "Description"] <- "One paragraph description of what the package does as one or more full sentences."
+        x[, "Title"] <- "Concise Summary of What the Package Does"
+        x[, "Description"] <- "More about what it does (maybe more than one line)."
         message( " >> added Imports: Rcpp" )
         message( " >> added LinkingTo: Rcpp" )
         write.dcf(x, file = DESCRIPTION)
-
+        write.dcf(x[1, c("Package", "Type", "Title", "Version", "Date",
+                         "Authors@R", "Description", "License", "Imports", "LinkingTo"),
+                    drop = FALSE],
+                  file = DESCRIPTION)
     }
 
     ## add useDynLib and importFrom to NAMESPACE

--- a/inst/tinytest/test_rcpp_package_skeleton.R
+++ b/inst/tinytest/test_rcpp_package_skeleton.R
@@ -45,10 +45,8 @@ checkTrue( "foo" %in% list.files(path), "pkg path generated as named" )
 
 ## check the DESCRIPTION
 DESCRIPTION <- as.list( read.dcf( file.path(pkg_path, "DESCRIPTION") )[1,] )
-checkTrue( DESCRIPTION["Author"] == "Boo-Boo Bear",
-          "wrote the Author field in DESCRIPTION" )
-checkTrue( DESCRIPTION["Maintainer"] == "Yogi Bear <yogibear@yogimail.com>",
-          "wrote the Maintainer field in DESCRIPTION")
+checkTrue( DESCRIPTION["Authors@R"] == 'person("Boo-Boo", "Bear", role = c("aut", "cre"), email = "yogibear@yogimail.com")', "wrote the Authors@R field in DESCRIPTION" )
+checkTrue( DESCRIPTION["Date"] == format(Sys.Date()), "uses current date in DESCRIPTION")
 checkTrue( DESCRIPTION["License"] == "An Opensource License",
           "wrote the License field in DESCRIPTION" )
 checkTrue( DESCRIPTION["LinkingTo"] == "Rcpp",

--- a/inst/tinytest/test_rcpp_package_skeleton.R
+++ b/inst/tinytest/test_rcpp_package_skeleton.R
@@ -45,7 +45,9 @@ checkTrue( "foo" %in% list.files(path), "pkg path generated as named" )
 
 ## check the DESCRIPTION
 DESCRIPTION <- as.list( read.dcf( file.path(pkg_path, "DESCRIPTION") )[1,] )
-checkTrue( DESCRIPTION["Authors@R"] == 'person("Boo-Boo", "Bear", role = c("aut", "cre"), email = "yogibear@yogimail.com")', "wrote the Authors@R field in DESCRIPTION" )
+checkEqual(gsub("\\n", " ", DESCRIPTION["Authors@R"]),  # need to neutralise a line break
+           'person("Boo-Boo", "Bear", role = c("aut", "cre"), email = "yogibear@yogimail.com")',
+           "wrote the Authors@R field in DESCRIPTION" )
 checkTrue( DESCRIPTION["Date"] == format(Sys.Date()), "uses current date in DESCRIPTION")
 checkTrue( DESCRIPTION["License"] == "An Opensource License",
           "wrote the License field in DESCRIPTION" )


### PR DESCRIPTION
This small PR changes the helper function creating an Rcpp package to use an Authors@R entry with c("aut", "cre").  Tests have bee adjusted; we just to test for Author and Maintainer being set so now we check for Authors@R and ... Date.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
