### PR TITLE
Remove cast to R_xlen_t (closes #1334)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-09-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/vector/Vector.h: Remove a cast as R_xlen_t
+	is returned now
+
 2024-09-17  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -1,6 +1,6 @@
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
-// Copyright (C) 2010 - 2023  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -331,7 +331,7 @@ public:
     }
 
     inline iterator begin() { return cache.get() ; }
-    inline iterator end() { return cache.get() + static_cast<int>(size()) ; }
+    inline iterator end() { return cache.get() + size(); }
     inline const_iterator begin() const{ return cache.get_const() ; }
     inline const_iterator end() const{ return cache.get_const() + size() ; }
     inline const_iterator cbegin() const{ return cache.get_const() ; }


### PR DESCRIPTION
This addresses the issue highlighted in #1334 by @zilong-li.  Thanks again for noticing I closed this prematurely---my bad!

A rev.dep. has been started on that old machine so it will be a while until it is done.  So far no issues but many, many more packages to go.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
