### PR TITLE
Fix compilation on DragonFlyBSD

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-10-26  Gábor Csárdi  <csardi.gabor@gmail.com>
+
+	* inst/include/Rcpp/exceptions_impl.h: check for DragonFlyBSD to fix compilation
+
 2024-10-07  Iñaki Ucar  <iucar@fedoraproject.org>
 
 	* inst/include/Rcpp/platform/compiler.h: Uncomment HAS_VARIADIC_TEMPLATES

--- a/inst/include/Rcpp/exceptions_impl.h
+++ b/inst/include/Rcpp/exceptions_impl.h
@@ -23,15 +23,16 @@
 
 // disable demangler on platforms where we have no support
 #ifndef RCPP_DEMANGLER_ENABLED
-# if defined(_WIN32)     || \
-    defined(__FreeBSD__) || \
-    defined(__NetBSD__)  || \
-    defined(__OpenBSD__) || \
-    defined(__CYGWIN__)  || \
-    defined(__sun)       || \
-    defined(_AIX)        || \
-    defined(__MUSL__)    || \
-    defined(__HAIKU__)   || \
+# if defined(_WIN32)       || \
+    defined(__FreeBSD__)   || \
+    defined(__NetBSD__)    || \
+    defined(__OpenBSD__)   || \
+    defined(__DragonFly__) || \
+    defined(__CYGWIN__)    || \
+    defined(__sun)         || \
+    defined(_AIX)          || \
+    defined(__MUSL__)      || \
+    defined(__HAIKU__)     || \
     defined(__ANDROID__)
 #  define RCPP_DEMANGLER_ENABLED 0
 # elif defined(__GNUC__)  || defined(__clang__)


### PR DESCRIPTION

Fixed compilation on DragonFlyBSD.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
