### PR TITLE
Update checkout action to v4, roll micro release, re-indent NEWS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
             r: RD
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       #- name: Bootstrap
       #  run: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,19 @@
+2024-10-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.4
+	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
+
+	* .github/workflows/ci.yaml (jobs): Roll checkout action to v4
+
 2024-10-26  Gábor Csárdi  <csardi.gabor@gmail.com>
 
-	* inst/include/Rcpp/exceptions_impl.h: check for DragonFlyBSD to fix compilation
+	* inst/include/Rcpp/exceptions_impl.h: check for DragonFlyBSD to fix
+	compilation
 
 2024-10-07  Iñaki Ucar  <iucar@fedoraproject.org>
 
-	* inst/include/Rcpp/platform/compiler.h: Uncomment HAS_VARIADIC_TEMPLATES
-	macro definition
+	* inst/include/Rcpp/platform/compiler.h: Uncomment
+	HAS_VARIADIC_TEMPLATES macro definition
 	* src/api.cpp: Simplify checks for variadic templates
 	* inst/include/Rcpp/DataFrame.h: Idem
 	* inst/include/Rcpp/DottedPair.h: Idem
@@ -20,7 +28,8 @@
 	* inst/include/Rcpp/traits/named_object.h: Idem
 	* inst/include/Rcpp/vector/Vector.h: Idem
 	* inst/include/Rcpp/Module.h: Idem + add missing is_void method
-	* inst/tinytest/test_module.R: Add test for void functions and methods
+	* inst/tinytest/test_module.R: Add test for void functions and
+	methods
 
 2024-10-04  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.13.3
-Date: 2024-10-04
+Version: 1.0.13.4
+Date: 2024-10-26
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -13,6 +13,8 @@
       \ghpr{1315} fixing \ghit{1312})
       \item An errorneous cast to \code{int} affecting large return object
       has been removed (Dirk in \ghpr{1335} fixing \ghpr{1334})
+      \item Compilation on DragonFlyBSD is now supported (Gábor Csárdi in
+      \ghpr{1338})
     }
     \item Changes in Rcpp Deployment:
     \itemize{

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.13"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,13,3)
-#define RCPP_DEV_VERSION_STRING "1.0.13.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,13,4)
+#define RCPP_DEV_VERSION_STRING "1.0.13.4"
 
 #endif


### PR DESCRIPTION
Very procedural:  GHA nagged about checkout action being too old so rolled to @4, updated micro release version and whitespace indented NEWS.  No code changes.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
