### PR TITLE
require R 4.5.0 (closes #1341)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-10-31  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/r/compat.h: Require R (>= 4.5.0) for new APIs
+
 2024-10-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.4

--- a/inst/include/Rcpp/r/compat.h
+++ b/inst/include/Rcpp/r/compat.h
@@ -24,13 +24,13 @@
 
 #include <Rversion.h>
 
-#if R_VERSION >= R_Version(4, 4, 2)
+#if R_VERSION >= R_Version(4, 5, 0)
 # define RCPP_STRING_PTR STRING_PTR_RO
 #else
 # define RCPP_STRING_PTR STRING_PTR
 #endif
 
-#if R_VERSION >= R_Version(4, 4, 2)
+#if R_VERSION >= R_Version(4, 5, 0)
 # define RCPP_VECTOR_PTR VECTOR_PTR_RO
 #else
 # define RCPP_VECTOR_PTR VECTOR_PTR


### PR DESCRIPTION
Closes https://github.com/RcppCore/Rcpp/issues/1341.