### PR TITLE
Small update to tests/tinytest.R

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-11-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* tests/tinytest.R: Minor code edit, removal of two no longer
+	required setters for tinytest
+
 2024-11-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.5

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -21,16 +21,31 @@
     \item Changes in Rcpp Deployment:
     \itemize{
       \item One unit tests for arm64 macOS has been adjusted; a macOS
-      continuous integration runner was added
+      continuous integration runner was added (Dirk in \ghpr{1324})
       \item Authors@R is now used in DESCRIPTION as mandated by CRAN, the
-      \code{Rcpp.package.skeleton()} function also creates it
+      \code{Rcpp.package.skeleton()} function also creates it (Dirk in
+      \ghpr{1325} and \ghpr{1327})
     }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item The Rcpp Modules vignette was extended slightly following
-      \ghit{1322}
+      \ghit{1322} (Dirk)
       \item Pdf vignettes have been regenerated under Ghostscript 10.03.1 to
       avoid a false positive by a Windows virus scanner (Iñaki in \ghpr{1331})
+    }
+  }
+}
+
+\section{Changes in Rcpp 'hot-fix' release version 1.0.13-1 (2024-11-01)}{
+  \itemize{
+    \item Changes in Rcpp API:
+    \itemize{
+      \item Use read-only \code{VECTOR_PTR} and \code{STRING_PTR} only with
+      with R 4.5.0 or later (Kevin in \ghpr{1342} fixing \ghit{1341})
+    }
+    \item Changes in Rcpp Deployment:
+    \itemize{
+      \item Authors@R is now used in DESCRIPTION as mandated by CRAN
     }
   }
 }

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -1,21 +1,15 @@
 
 if (requireNamespace("tinytest", quietly=TRUE)) {
 
-    ## Set a seed to make the test deterministic
-    set.seed(42)
-
-    ## R makes us do this (but tinytest now sets it too)
-    Sys.setenv("R_TESTS"="")
-
     ## Force tests to be executed if in dev release which we define as
     ## having a sub-release, eg 0.9.15.5 is one whereas 0.9.16 is not
-    if (length(strsplit(packageDescription("Rcpp")$Version, "\\.")[[1]]) > 3) {	# dev rel, and
+    if (length(strsplit(format(packageVersion("Rcpp")), "\\.")[[1]]) > 3) {	# dev rel, and
         if (Sys.getenv("RunAllRcppTests") != "no") { 			# if env.var not yet set
-            message("Setting \"RunAllRcppTests\"=\"yes\" for development release\n")
+            message("Setting \"RunAllRcppTests\"=\"yes\" for development release")
             Sys.setenv("RunAllRcppTests"="yes")
         }
         if (Sys.getenv("RunVerboseRcppTests") != "no") { 		# if env.var not yet set
-            message("Setting \"RunVerboseRcppTests\"=\"yes\" for development release\n")
+            message("Setting \"RunVerboseRcppTests\"=\"yes\" for development release")
             Sys.setenv("RunVerboseRcppTests"="yes")
         }
     }


### PR DESCRIPTION
While working on the hot-fix 1.0.13-1 (which is now on CRAN, yay!!), I noticed that `tests/tinytest.R` still had two assignments only very early `tinytest` required, plus a call to `packageDescription("Rcpp")$Version` which can be more compactly written as `packageVersion("Rcpp")` (and is supported by R 3.5.0 which our oldest CI use).   Nothing major, really.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
