### PR TITLE
Adjust datetime format in test to not tickle change in R-devel (closes #1347)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.6
 	* inst/include/Rcpp/config.h (RCPP_DEV_VERSION): Idem
 
+	* inst/tinytest/test_date.R: Minor adjustment to datetime format test
+	following R Dev Day change for R bug 17350 (and issue #1347 here)
+
 2024-11-25  Simon Guest  <simon.guest@tesujimath.org>
 
 	* src/attributes.cpp: fix CPP source having to be writable

--- a/inst/tinytest/test_date.R
+++ b/inst/tinytest/test_date.R
@@ -194,7 +194,7 @@ expect_equal(Datetime_format(d,"%Y-%m-%d %H:%M:%S"),
              format(d, "%Y-%m-%d %H:%M:%OS"),
              info="Datetime.formating.default")
 expect_equal(Datetime_format(d, "%Y/%m/%d %H:%M:%S"),
-             format(d, "%Y/%m/%d %H:%M:%OS"),
+             format(d, "%Y/%m/%d %H:%M:%OS6"),
              info="Datetime.formating.given.format")
 expect_equal(Datetime_ostream(d),
              format(d, "%Y-%m-%d %H:%M:%OS"),


### PR DESCRIPTION
As described in #1347, @hturner and I landed a patch in R itself which now tickles a test difference in CI under the update R-devel.  The fix is simple and changes the format string to one that will be passed through leading again to this test of ours passing as before.  The change here should not get affected if R-devel changes again.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
