### PR TITLE
Condition undoing of Rmath prefixes on R < 4.5.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-12-22  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/sugar/undoRmath.h: Condition undefining of
+	non-prefixed Rmath functions in R < 4.5.0; redefine R_Version macro
+
 2024-11-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.6

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.13.6
-Date: 2024-11-25
+Version: 1.0.13.6.1
+Date: 2024-12-21
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -17,6 +17,8 @@
       \ghpr{1338})
       \item Use read-only \code{VECTOR_PTR} and \code{STRING_PTR} only with
       with R 4.5.0 or later (Kevin in \ghpr{1342} fixing \ghit{1341})
+      \item As R 4.5.0 or later prefix math functions, make undefine in Rcpp
+      Sugar version dependent (Dirk in \ghpr{1352} fixing \ghit{1351})
     }
     \item Changes in Rcpp Attributes:
     \itemize{

--- a/inst/include/Rcpp/sugar/undoRmath.h
+++ b/inst/include/Rcpp/sugar/undoRmath.h
@@ -1,8 +1,6 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // undoRmath.h: Rcpp R/C++ interface class library -- undo the macros set by Rmath.h
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -22,7 +20,17 @@
 #ifndef RCPP_SUGAR_UNDORMATH_H
 #define RCPP_SUGAR_UNDORMATH_H
 
-// undo some of the mess of Rmath
+// Reverse-depends checks found rare cases where R_Version would not evaluate
+// So here we, if needed, we first undefine ...
+#ifdef R_Version
+#undef R_Version
+#endif
+// ... and then repeat the definition from Rversion.h
+#define R_Version(v,p,s) (((v) * 65536) + ((p) * 256) + (s))
+
+// Undo some of the definitions in Rmath -- but only prior to R 4.5.0
+#if R_VERSION < R_Version(4,5,0)
+
 #undef sign
 #undef trunc
 #undef rround
@@ -163,5 +171,6 @@
 #undef tetragamma
 #undef trigamma
 
+#endif
 
 #endif


### PR DESCRIPTION
### Pull Request Template for Rcpp

As discussed in #1351 recent changes in R-devel change the Rmath interface creating some issue.  This PR aims to accommodate but since filing the issue CRAN has (per another email) found more issues to this may evolve.  Leaving this as draft for now.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
