### PR TITLE
Protect another R_NO_REMAP with preceding #ifndef

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-01-01  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Benchmark/Timer.h (R_NO_REMAP): Protect include
+	with preceding #ifndef now that R 4.5.0 will set this too
+
 2024-11-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version to 1.0.13.6

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
 Version: 1.0.13.6
-Date: 2024-11-25
+Date: 2025-01-01
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/Benchmark/Timer.h
+++ b/inst/include/Rcpp/Benchmark/Timer.h
@@ -1,8 +1,6 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // Timer.h: Rcpp R/C++ interface class library -- Rcpp benchmark utility
 //
-// Copyright (C) 2012 - 2014  JJ Allaire, Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2025  JJ Allaire, Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -26,7 +24,9 @@
 #include <vector>
 #include <string>
 
-#define R_NO_REMAP
+#ifndef R_NO_REMAP
+    #define R_NO_REMAP
+#endif
 #include <Rinternals.h>
 
 #if defined(_WIN32)


### PR DESCRIPTION
I noticed a second `#define R_NO_REMAP` in the (very much optional) file `Benchmark/Timer.h` so adding a now-required preceding `#ifndef / #endif` around it as R 4.5.0 now defines `R_NO_REMAP` for C++ -- just like we have done since 2009 (!!). 
 There was an earlier PR #1296 where I protected the main #define, but missed this.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
