### PR TITLE
Expand libraries vignette with PACKAGE_types.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-01-25  Dirk Eddelbuettel  <edd@debian.org>
+
+	* vignettes/rmd/Rcpp-libraries.Rdm: Add mention of PACKAGE_types.h
+	* vignettes/rmd/Rcpp.bib: Add AsioHeaders
+	* inst/bib/Rcpp.bib: Idem
+
 2025-01-18  Ben Bolker  <bolker@mcmaster.ca>
 
 	* inst/NEWS.Rd: fix trivial typos in NEWS file

--- a/inst/bib/Rcpp.bib
+++ b/inst/bib/Rcpp.bib
@@ -80,6 +80,14 @@
   url =		 CRAN # "package=anytime"
 }
 
+@Manual{CRAN:AsioHeaders,
+  title =        {'Asio' C++ Header Files},
+  author =       {Dirk Eddelbuettel},
+  year =         {2024},
+  note =         {R package version 1.22.1},
+  url =		 CRAN # "package=AsioHeaders"
+}
+
 @Manual{CRAN:BH,
   title =        {BH: Boost C++ Header Files},
   author =       {Dirk Eddelbuettel and John W. Emerson and Michael

--- a/vignettes/rmd/Rcpp-libraries.Rmd
+++ b/vignettes/rmd/Rcpp-libraries.Rmd
@@ -165,7 +165,7 @@ package) containing the required \code{\#include} statement for the type(s) will
 compilation; see the 'Rcpp Attributes' vignette for details \citep{CRAN:Rcpp:Attributes}.
 
 It may also be a dependency on a fairly standard library available on most if
-not all systems.  The graphics formats bmp, jpeg or png may be example; text
+not all systems.  The graphics formats bmp, jpeg or png may be an example; text
 formats like JSON or XML are another.  One difficulty, though, may be that
 _run-time_ support does not always guarantee _compile-time_ support. In these
 cases, a `-dev` or `-devel` package may need to be installed.

--- a/vignettes/rmd/Rcpp-libraries.Rmd
+++ b/vignettes/rmd/Rcpp-libraries.Rmd
@@ -154,15 +154,24 @@ it.
 
 Given a basic package with C++ support, we can now turn to integrating the external
 package.  This complexity of this step can, as alluded to earlier, vary from very easy to
-very complex.  Simple cases include just depending on library headers which can either
-be copied to the package, or be provided by another package such as \pkg{BH}
-\citep{CRAN:BH}. It may also be a dependency on a fairly standard library available on
-most if not all systems.  The graphics formats bmp, jpeg or png may be example; text
-formats like JSON or XML are another.  One difficulty, though, may be that _run-time_
-support does not always guarantee _compile-time_ support. In these cases, a `-dev` or
-`-devel` package may need to be installed.
+very complex.  Simple cases include just depending on library headers which can either be
+copied to the package, or be provided by another package such as \pkg{BH} \citep{CRAN:BH}
+or \pkg{AsioHeaders} \citep{CRAN:AsioHeaders} or many other examples.
 
-In the concrete case of Corels, we
+One aspect worth noting is that if you include a type in your function interface it will
+also be part of the generated \code{RcppExports.cpp}. In this case adding a file
+\code{PACKAGE\_types.h} (where \code{PACKAGE} is to be replaced with the name of your
+package) containing the required \code{\#include} statement for the type(s) will permit
+compilation; see the 'Rcpp Attributes' vignette for details \citep{CRAN:Rcpp:Attributes}.
+
+It may also be a dependency on a fairly standard library available on most if
+not all systems.  The graphics formats bmp, jpeg or png may be example; text
+formats like JSON or XML are another.  One difficulty, though, may be that
+_run-time_ support does not always guarantee _compile-time_ support. In these
+cases, a `-dev` or `-devel` package may need to be installed.
+
+Here, we use a third approach and copy files. Discussing the two other means
+fully is beyond the scope of this shorter note. So in the concrete case of Corels, we
 
 - copied all existing C++ source and header files over into the `src/` directory;
 - renamed all header files from `*.hh` to `*.h` to comply with an R preference;

--- a/vignettes/rmd/Rcpp.bib
+++ b/vignettes/rmd/Rcpp.bib
@@ -80,6 +80,14 @@
   url =		 CRAN # "package=anytime"
 }
 
+@Manual{CRAN:AsioHeaders,
+  title =        {'Asio' C++ Header Files},
+  author =       {Dirk Eddelbuettel},
+  year =         {2024},
+  note =         {R package version 1.22.1},
+  url =		 CRAN # "package=AsioHeaders"
+}
+
 @Manual{CRAN:BH,
   title =        {BH: Boost C++ Header Files},
   author =       {Dirk Eddelbuettel and John W. Emerson and Michael


### PR DESCRIPTION
This comes from [a discussion over at RcppEigen](https://github.com/RcppCore/RcppEigen/issues/141) which revealed that our trick of using `PACKAGE_types.h` to declare types known to `RcppExports.cpp` is not as well known.  

So a brief reference was added to Rcpp-libraries vignette which is somewhat topical.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
