### PR TITLE
std::string_view support in Rcpp::wrap()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2025-01-31  Lev Kandel  <lmakhlis@google.com>
+
+	* inst/include/Rcpp/internal/wrap.h: Add support for std::string_view
+	* inst/include/Rcpp/traits/r_type_traits.h: Idem
+	* inst/include/Rcpp/traits/wrap_type_traits.h: Idem
+	* inst/include/RcppCommon.h: Include <string_view>
+	* inst/tinytest/cpp/wrap.cpp: Add unit test for wrap(std::string_view)
+	* inst/tinytest/test_wrap.R: Idem
+
 2025-01-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -66,6 +66,12 @@ namespace Rcpp {
             return make_charsexp__impl__cstring(st.c_str());
         }
 
+#if __cplusplus >= 201703L
+        inline SEXP make_charsexp__impl__cstring(std::string_view st) {
+            return Rf_mkCharLen(st.data(), st.size());
+        }
+#endif
+
     	template <typename T>
     	inline SEXP make_charsexp__impl(const T& s, Rcpp::traits::true_type) {
             return make_charsexp__impl__wstring(s);

--- a/inst/include/Rcpp/traits/r_type_traits.h
+++ b/inst/include/Rcpp/traits/r_type_traits.h
@@ -141,6 +141,9 @@ template<> struct r_type_traits<Rcomplex>{ typedef r_type_primitive_tag r_catego
 template<> struct r_type_traits<bool>{ typedef r_type_primitive_tag r_category ; } ;
 template<> struct r_type_traits<std::string>{ typedef r_type_string_tag r_category ; } ;
 template<> struct r_type_traits<std::wstring>{ typedef r_type_string_tag r_category ; } ;
+#if __cplusplus >= 201703L
+template<> struct r_type_traits<std::string_view>{ typedef r_type_string_tag r_category ; } ;
+#endif
 template<> struct r_type_traits<char>{ typedef r_type_string_tag r_category ; } ;
 template<> struct r_type_traits<wchar_t>{ typedef r_type_string_tag r_category ; } ;
 

--- a/inst/include/Rcpp/traits/wrap_type_traits.h
+++ b/inst/include/Rcpp/traits/wrap_type_traits.h
@@ -82,6 +82,9 @@ template <> struct wrap_type_traits<unsigned int> { typedef wrap_type_primitive_
 template <> struct wrap_type_traits<bool> { typedef wrap_type_primitive_tag wrap_category; } ;
 template <> struct wrap_type_traits<std::string> { typedef wrap_type_primitive_tag wrap_category; } ;
 template <> struct wrap_type_traits<std::wstring> { typedef wrap_type_primitive_tag wrap_category; } ;
+#if __cplusplus >= 201703L
+template <> struct wrap_type_traits<std::string_view> { typedef wrap_type_primitive_tag wrap_category; } ;
+#endif
 template <> struct wrap_type_traits<Rcpp::String> { typedef wrap_type_primitive_tag wrap_category; } ;
 template <> struct wrap_type_traits<char> { typedef wrap_type_primitive_tag wrap_category; } ;
 template <> struct wrap_type_traits<wchar_t> { typedef wrap_type_primitive_tag wrap_category; } ;

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -54,6 +54,9 @@ namespace Rcpp {
 #include <iomanip>
 #include <sstream>
 #include <string>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
 #include <list>
 #include <map>
 #include <set>

--- a/inst/tinytest/cpp/wrap.cpp
+++ b/inst/tinytest/cpp/wrap.cpp
@@ -308,6 +308,6 @@ SEXP vector_Foo(){
 // [[Rcpp::plugins(cpp17)]]
 // [[Rcpp::export]]
 SEXP test_wrap_string_view(){
-    std::string_view sv = "test string value";
-    return wrap(sv);
+    std::string_view sv = "test string value" ;
+    return wrap(sv) ;
 }

--- a/inst/tinytest/cpp/wrap.cpp
+++ b/inst/tinytest/cpp/wrap.cpp
@@ -304,3 +304,10 @@ SEXP vector_Foo(){
     vec[1] = Foo( 3 ) ;
     return wrap(vec) ;
 }
+
+// [[Rcpp::plugins(cpp17)]]
+// [[Rcpp::export]]
+SEXP test_wrap_string_view(){
+    std::string_view sv = "test string value";
+    return wrap(sv);
+}

--- a/inst/tinytest/test_wrap.R
+++ b/inst/tinytest/test_wrap.R
@@ -132,3 +132,6 @@ expect_equal(sapply( vector_Foo(), function(.) .$get() ), c(2, 3),
 
 #    test.wrap.custom.class <- function() {
 expect_equal(test_wrap_custom_class(), 42)
+
+#    test.wrap.custom.string_view <- function() {
+expect_equal(test_wrap_string_view(), "test string value")

--- a/inst/tinytest/test_wrap.R
+++ b/inst/tinytest/test_wrap.R
@@ -133,5 +133,5 @@ expect_equal(sapply( vector_Foo(), function(.) .$get() ), c(2, 3),
 #    test.wrap.custom.class <- function() {
 expect_equal(test_wrap_custom_class(), 42)
 
-#    test.wrap.custom.string_view <- function() {
+#    test.wrap.string_view <- function() {
 expect_equal(test_wrap_string_view(), "test string value")


### PR DESCRIPTION
Currently, `Rcpp::wrap()` treats a `std::string_view` argument by default as a generic container and creates a character vector from single characters. This is different from how `std::string` is handled. This change aligns the two, so that `wrap("foo"sv)` is equivalent to `wrap("foo"s)`. The added code is conditionally compiled for C++17. 

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
