### PR TITLE
Extend Rcpp.package.skeleton to support URL and BugReports

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2025-02-11  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Support optional
+	argument 'github_user' to populate URL and BugReports if given
+	* man/Rcpp.package.skeleton.Rd: Document new optional argument
+
+	* R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Default version
+	is now '0.0.1' and not '1.0'
+	* inst/tinytest/test_rcpp_package_skeleton.R: Adjust test accordingly
+	* inst/tinytest/test_expose_class.R: Idem
+
 2025-02-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/R/Rcpp.package.skeleton.R
+++ b/R/Rcpp.package.skeleton.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 - 2021  Dirk Eddelbuettel and Romain Francois
+# Copyright (C) 2009 - 2025  Dirk Eddelbuettel and Romain Francois
 #
 # This file is part of Rcpp.
 #
@@ -24,6 +24,7 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
                                   maintainer = if (missing(author)) "Your Name"
                                                else author,
                                   email = "your@email.com",
+                                  githubuser = NA_character_,
                                   license = "GPL (>= 2)") {
 
     havePkgKitten <- requireNamespace("pkgKitten", quietly=TRUE)
@@ -90,18 +91,26 @@ Rcpp.package.skeleton <- function(name = "anRpackage", list = character(),
                                          paste(splitname[-length(splitname)], collapse=" "),
                                          splitname[length(splitname)],
                                          email))
-        #x[, "Author"] <- author
-        #x[, "Maintainer"] <- sprintf("%s <%s>", maintainer, email)
+        fields_written <- c("Package", "Type", "Title", "Version", "Date",
+                            "Authors@R", "Description", "License", "Imports", "LinkingTo")
+        if (!is.na(githubuser)) {
+            x <- cbind(x, matrix("", 1, 1, dimnames=list("", "URL")))
+            x[1, "URL"] <- paste0("https://github.com/", githubuser, "/", name)
+            x <- cbind(x, matrix("", 1, 1, dimnames=list("", "BugReports")))
+            x[1, "BugReports"] <- paste0("https://github.com/", githubuser, "/", name, "/issues")
+
+            fields_written <- c("Package", "Type", "Title", "Version", "Date",
+                                "Authors@R", "Description", "URL", "BugReports",
+                                "License", "Imports", "LinkingTo")
+            }
+
         x[, "License"] <- license
         x[, "Title"] <- "Concise Summary of What the Package Does"
         x[, "Description"] <- "More about what it does (maybe more than one line)."
+        x[, "Version"] <- "0.0.1"
         message( " >> added Imports: Rcpp" )
         message( " >> added LinkingTo: Rcpp" )
-        write.dcf(x, file = DESCRIPTION)
-        write.dcf(x[1, c("Package", "Type", "Title", "Version", "Date",
-                         "Authors@R", "Description", "License", "Imports", "LinkingTo"),
-                    drop = FALSE],
-                  file = DESCRIPTION)
+        write.dcf(x[1, fields_written, drop = FALSE], file = DESCRIPTION)
     }
 
     ## add useDynLib and importFrom to NAMESPACE

--- a/inst/tinytest/test_attribute_package.R
+++ b/inst/tinytest/test_attribute_package.R
@@ -38,10 +38,10 @@ require(pkg, lib.loc = "templib", character.only = TRUE)
 
 # Test Package
 options(verbose=TRUE)
-expect_equal(test_no_attributes(list("{A}"), FALSE),list("{A}", FALSE)) 
+expect_equal(test_no_attributes(list("{A}"), FALSE),list("{A}", FALSE))
 expect_equal(test_signature(),list("{A}", TRUE))
 expect_equal(test_rng_false_signature_invisible_true(),list("{A}", TRUE))
-expect_equal(test_rng_false(list("{A}"), FALSE),list("{A}", FALSE)) 
+expect_equal(test_rng_false(list("{A}"), FALSE),list("{A}", FALSE))
 expect_equal(test_rng_true(list("{A}"), FALSE),list("{A}", FALSE))
 expect_equal(test_rng_true_signature(),list("{A}", TRUE))
 expect_equal(test_invisible_true_rng_true(list("{A}"), FALSE),list("{A}", FALSE))
@@ -105,7 +105,7 @@ expect_error({
 
 # test 3, from Enchufa2
 # This third example should not compile because of missing end bracket }
-# The bracket within the signature is taken as the end bracket, which results in 
+# The bracket within the signature is taken as the end bracket, which results in
 # invalid R code. There are some additional warnings due to the incorrect syntax
 expect_warning({
   expect_error({

--- a/inst/tinytest/test_expose_class.R
+++ b/inst/tinytest/test_expose_class.R
@@ -77,7 +77,7 @@ setwd(path)
 on.exit( setwd(owd), add=TRUE )
 R <- shQuote( file.path( R.home( component = "bin" ), "R" ))
 system( paste(R, "CMD build", pkg_path) )
-gz_name <- paste0(pkg_name, "_1.0.tar.gz")
+gz_name <- paste0(pkg_name, "_0.0.1.tar.gz")
 expect_true( file.exists(gz_name), info = "can successfully R CMD build the pkg")
 
 ## check install + require

--- a/inst/tinytest/test_rcpp_package_skeleton.R
+++ b/inst/tinytest/test_rcpp_package_skeleton.R
@@ -86,9 +86,9 @@ owd <- getwd()
 setwd(path)
 R <- shQuote( file.path( R.home( component = "bin" ), "R" ))
 system( paste(R, "CMD build", pkg_path) )
-checkTrue( file.exists("foo_1.0.tar.gz"), "can successfully R CMD build the pkg")
+checkTrue( file.exists("foo_0.0.1.tar.gz"), "can successfully R CMD build the pkg")
 dir.create("templib")
-install.packages("foo_1.0.tar.gz", file.path(path, "templib"), repos=NULL, type="source")
+install.packages("foo_0.0.1.tar.gz", file.path(path, "templib"), repos=NULL, type="source")
 require("foo", file.path(path, "templib"), character.only=TRUE)
 
 
@@ -141,7 +141,7 @@ checkTrue(file.exists( file.path(src_path, "rcpp_module.cpp")),
 
 on.exit(unlink(pkg_path, recursive=TRUE))
 on.exit( setwd(owd), add=TRUE )
-on.exit( unlink( file.path(path, "foo_1.0.tar.gz") ), add=TRUE)
+on.exit( unlink( file.path(path, "foo_0.0.1.tar.gz") ), add=TRUE)
 on.exit( unlink( file.path(path, "templib"), recursive=TRUE), add=TRUE )
 on.exit( unlink(pkg_path, recursive=TRUE), add=TRUE )
 on.exit(unlink(pkg_path, recursive=TRUE), add=TRUE)

--- a/man/Rcpp.package.skeleton.Rd
+++ b/man/Rcpp.package.skeleton.Rd
@@ -4,20 +4,20 @@
 Create a skeleton for a new package depending on Rcpp
 }
 \description{
-	\code{Rcpp.package.skeleton} automates the creation of 
-	a new source package that intends to use features of Rcpp. 
-	
+	\code{Rcpp.package.skeleton} automates the creation of
+	a new source package that intends to use features of Rcpp.
+
 	It is based on the \link[utils]{package.skeleton} function
 	which it executes first.
 }
 \usage{
-Rcpp.package.skeleton(name = "anRpackage", list = character(), 
-	environment = .GlobalEnv, path = ".", force = FALSE, 
+Rcpp.package.skeleton(name = "anRpackage", list = character(),
+	environment = .GlobalEnv, path = ".", force = FALSE,
 	code_files = character(), cpp_files = character(),
-	example_code = TRUE, attributes = TRUE, module = FALSE, 
-	author = "Your Name", 
-	maintainer = if(missing( author)) "Your Name" else author, 
-	email = "your@email.com", 
+	example_code = TRUE, attributes = TRUE, module = FALSE,
+	author = "Your Name",
+	maintainer = if(missing( author)) "Your Name" else author,
+	email = "your@email.com", githubuser = NA_character_,
 	license = "GPL (>= 2)"
 	)
 }
@@ -35,42 +35,43 @@ Rcpp.package.skeleton(name = "anRpackage", list = character(),
 	\item{author}{Author of the package.}
 	\item{maintainer}{Maintainer of the package.}
 	\item{email}{Email of the package maintainer.}
+	\item{githubuser}{GitHub username for URL and BugReports, if present.}
 	\item{license}{License of the package.}
 }
 \details{
-	In addition to \link[utils]{package.skeleton} : 
-	
-	The \samp{DESCRIPTION} file gains an Imports line requesting that 
+	In addition to \link[utils]{package.skeleton} :
+
+	The \samp{DESCRIPTION} file gains an Imports line requesting that
 	the package depends on Rcpp and a LinkingTo line so that the package
 	finds Rcpp header files.
-	
+
 	The \samp{NAMESPACE} gains a \code{useDynLib} directive as well
 	as an \code{importFrom(Rcpp, evalCpp} to ensure instantiation of Rcpp.
-	
-	The \samp{src} directory is created if it does not exists. 
-	
+
+	The \samp{src} directory is created if it does not exists.
+
 	If \code{cpp_files} are provided then they will be copied to the \samp{src}
 	directory.
-	
-	If the \code{example_code} argument is set to \code{TRUE}, 
+
+	If the \code{example_code} argument is set to \code{TRUE},
 	example files \samp{rcpp_hello_world.h} and \samp{rcpp_hello_world.cpp}
-	are also created in the \samp{src}. An R file \samp{rcpp_hello_world.R} is 
+	are also created in the \samp{src}. An R file \samp{rcpp_hello_world.R} is
 	expanded in the \samp{R} directory, the \code{rcpp_hello_world} function
 	defined in this files makes use of the C++ function \samp{rcpp_hello_world}
-	defined in the C++ file. These files are given as an example and should 
+	defined in the C++ file. These files are given as an example and should
 	eventually by removed from the generated package.
-	
+
 	If the \code{attributes} argument is \code{TRUE}, then rather than generate
 	the example files as described above, a single \samp{rcpp_hello_world.cpp}
-	file is created in the \samp{src} directory and it's attributes are 
-	compiled using the \code{\link{compileAttributes}} function. This leads to 
+	file is created in the \samp{src} directory and it's attributes are
+	compiled using the \code{\link{compileAttributes}} function. This leads to
 	the files \samp{RcppExports.R} and \samp{RcppExports.cpp} being generated.
-	They are automatically regenerated from \emph{scratch} each time 
-	\code{\link{compileAttributes}} is called. Therefore, one should 
+	They are automatically regenerated from \emph{scratch} each time
+	\code{\link{compileAttributes}} is called. Therefore, one should
 	\strong{not} modify by hand either of the \samp{RcppExports} files.
-	
-	If the \code{module} argument is \code{TRUE}, a sample Rcpp module will 
-	be generated as well. 
+
+	If the \code{module} argument is \code{TRUE}, a sample Rcpp module will
+	be generated as well.
 }
 \value{
 Nothing, used for its side effects
@@ -105,4 +106,3 @@ vignette( "Rcpp-modules" )
 }
 }
 \keyword{ programming }
-


### PR DESCRIPTION
This is a minor PR that adds the ability to use a 'githubuser' field which, when given, leads to URL and BugReports fields being added to DESCRIPTION.  It also flips default package version to a saner '0.0.1'.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
