### PR TITLE
Convert remaining DATAPTR to DATAPTR_RO

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2025-03-07  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+
+	* inst/include/Rcpp/config.h: Idem
+
 	* src/barrier.cpp (dataptr): Replace remaining DATAPTR with
 	DATAPTR_RO for suitable R greater than 3.5.0
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-03-07  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/barrier.cpp (dataptr): Replace remaining DATAPTR with
+	DATAPTR_RO for suitable R greater than 3.5.0
+
 2025-02-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/Rcpp.package.skeleton.R (Rcpp.package.skeleton): Support optional

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.3
-Date: 2025-02-11
+Version: 1.0.14.4
+Date: 2025-03-07
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,3)
-#define RCPP_DEV_VERSION_STRING "1.0.14.3"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,4)
+#define RCPP_DEV_VERSION_STRING "1.0.14.4"
 
 #endif

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -76,7 +76,13 @@ SEXP* get_vector_ptr(SEXP x) {
 
 // [[Rcpp::register]]
 void* dataptr(SEXP x) {
+#if R_VERSION >= R_Version(3,5,0)
+    // DATAPTR_RO was introduced with R 3.5.0
+    return const_cast<void*>(DATAPTR_RO(x));
+#else
+    // this will get your wrists slapped under recent R CMD check ...
     return DATAPTR(x);
+#endif
 }
 
 // [[Rcpp::register]]


### PR DESCRIPTION
As CRAN checks nag about the one remaining `DAtAPTR` use, a quick change to `DATAPTR_RO` which _should_ pass for all reasonable use cases.  Running full reverse-depends checks now (which will take its usual time ... measured in days now) to determine if anybody out there "is naughty" instead of nice.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
