### PR TITLE
Replace use of deprecated CLOENV with R_ClosureEnv if R >= 4.5.0 (closes #1360)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,16 @@
+2025-03-10  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
+2025-03-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Function.h: Use R_ClosureEnv instead of
+	deprecated CLOENV if under R >= 4.5.0
+
 2025-03-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
-
 	* inst/include/Rcpp/config.h: Idem
 
 	* src/barrier.cpp (dataptr): Replace remaining DATAPTR with
@@ -21,7 +30,6 @@
 2025-02-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
-
 	* inst/include/Rcpp/config.h: Idem
 
 2025-01-31  Lev Kandel  <lmakhlis@google.com>
@@ -36,7 +44,6 @@
 2025-01-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
-
 	* inst/include/Rcpp/config.h: Idem
 
 2025-01-25  Dirk Eddelbuettel  <edd@debian.org>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.4
-Date: 2025-03-07
+Version: 1.0.14.5
+Date: 2025-03-10
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -12,7 +12,7 @@
       \item A last remaining \code{DATAPTR} use has been converted to
       \code{DATAPTR_RO} (Dirk in \ghpr{1359})
       \item Under R 4.5.0 or later, \code{R_ClosureEnv} is used instead of
-      \code{CLOENV} (Dirk in \ghpr{1360})
+      \code{CLOENV} (Dirk in \ghpr{1361} fixing \ghpr{1360})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,10 @@
     \itemize{
       \item The \code{std::string_view} type is now covered by \code{wrap()}
       (Lev Kandel in \ghpr{1356} as discussed in \ghit{1357})
+      \item A last remaining \code{DATAPTR} use has been converted to
+      \code{DATAPTR_RO} (Dirk in \ghpr{1359})
+      \item Under R 4.5.0 or later, \code{R_ClosureEnv} is used instead of
+      \code{CLOENV} (Dirk in \ghpr{1360})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -99,7 +99,11 @@ namespace Rcpp{
             if( TYPEOF(fun) != CLOSXP ) {
                 throw not_a_closure(Rf_type2char(TYPEOF(fun)));
             }
-            return CLOENV(fun) ;
+            #if (defined(R_VERSION) && R_VERSION >= R_Version(4,5,0))
+            return R_ClosureEnv(fun);
+            #else
+            return CLOENV(fun);
+            #endif
         }
 
         /**

--- a/inst/include/Rcpp/Symbol.h
+++ b/inst/include/Rcpp/Symbol.h
@@ -43,7 +43,7 @@ namespace Rcpp{
                 Storage::set__( x ) ;
                 break; /* nothing to do */
             case CHARSXP: {
-		#if R_VERSION >= R_Version(3,2,0)
+                #if R_VERSION >= R_Version(3,2,0)
                 SEXP charSym = Rf_installChar(x);       // R 3.2.0 or later have Rf_installChar
                 #else
                 SEXP charSym = Rf_install(CHAR(x));     // cannot be gc()'ed  once in symbol table
@@ -53,7 +53,7 @@ namespace Rcpp{
             }
             case STRSXP: {
                 /* FIXME: check that there is at least one element */
-		#if R_VERSION >= R_Version(3,2,0)
+                #if R_VERSION >= R_Version(3,2,0)
                 SEXP charSym = Rf_installChar(STRING_ELT(x, 0 ));     // R 3.2.0 or later have Rf_installChar
                 #else
                 SEXP charSym = Rf_install( CHAR(STRING_ELT(x, 0 )) ); // cannot be gc()'ed  once in symbol table

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,4)
-#define RCPP_DEV_VERSION_STRING "1.0.14.4"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,5)
+#define RCPP_DEV_VERSION_STRING "1.0.14.5"
 
 #endif


### PR DESCRIPTION
This addresses an issue raised by @bbolker in #1360: `CLOENV` is now flagged by R-devel.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
