### PR TITLE
Use lsInteral3 instead of lsInternal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-03-13  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 	* inst/include/Rcpp/Environment.h: Switch from R_lsInternal to
 	R_lsInternal3 as the former is now outlawed
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-03-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Environment.h: Switch from R_lsInternal to
+	R_lsInternal3 as the former is now outlawed
+
 2025-03-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.5
-Date: 2025-03-10
+Version: 1.0.14.6
+Date: 2025-03-13
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/Environment.h
+++ b/inst/include/Rcpp/Environment.h
@@ -84,7 +84,7 @@ namespace Rcpp{
          */
         SEXP ls(bool all) const {
             SEXP env = Storage::get__() ;
-            return R_lsInternal( env, all ? TRUE : FALSE ) ;
+            return R_lsInternal3(env, all ? TRUE : FALSE, TRUE);
             return R_NilValue ;
         }
 

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,5)
-#define RCPP_DEV_VERSION_STRING "1.0.14.5"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,6)
+#define RCPP_DEV_VERSION_STRING "1.0.14.6"
 
 #endif


### PR DESCRIPTION
This came to our attention via a CC in email from @kurthornik in the context of helping the @RfastOfficial team.  The change is benign as R has `Rf_lsInternal3` (with three arguments, we were not using the third for 'sorted or not') and asking 'blame' reveals this signature is at least 11 years old so we do not need a version check methinks.

This change is so cosmetic and we are not changing exposed APIs here so I may for once not bother to wait for the 2 1/2 days of a full reverse dependency check.  (And the first batch of CI from the commit before the PR was formed is all green too.)
 
#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
