### PR TITLE
Header cleanup with C++11 as a baseline

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - {os: macOS-latest}
+          - {os: macos-latest}
+          - {os: macos-13}
           #- {os: ubuntu-latest}
 
     runs-on: ${{ matrix.os }}
@@ -24,10 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup
-        uses: eddelbuettel/github-actions/r-ci-setup@master
-
-      - name: Bootstrap
-        run: ./run.sh bootstrap
+        uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Dependencies
         run: ./run.sh install_deps

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+2025-03-15  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
+	* inst/include/Rcpp/platform/compiler.h: Simplified and shortened
+	establishing C++11 as baseline; further PRs to complete this
+	* inst/include/Rcpp/String.h: Unconditionally use std::hash with C++11
+	* inst/include/Rcpp/wrap.h: Unconditionally use static_assert
+	* inst/include/Rcpp/sugar/functions/sapply.h: Use std::result_of
+	(with C++11 or C++14) or std::invoke_result (C++17 or later)
+	* inst/include/Rcpp/sugar/functions/table.h: Use std::map
+	* inst/include/Rcpp/sugar/sets.h: Use std::unordered_{set,map}
+	* man/evalCpp.Rd: Update example
+	* src/api.cpp: Simplify rcpp_capabilities assignment
+
 2025-03-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.6
-Date: 2025-03-13
+Version: 1.0.14.7
+Date: 2025-03-15
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -734,24 +734,14 @@ namespace Rcpp {
 
 } // Rcpp
 
-/** hash can be in std or std::tr1 */
-#if defined(RCPP_USING_CXX11) || defined(HAS_TR1)
-namespace std
-{
-#ifndef RCPP_USING_CXX11
-namespace tr1 {
-#endif
+/** hash via std */
+namespace std {
     template <>
-    struct hash<Rcpp::String>
-    {
+    struct hash<Rcpp::String>  {
         size_t operator()(const Rcpp::String & s) const{
             return hash<string>()(s.get_cstring());
         }
     };
-#ifndef RCPP_USING_CXX11
 }
-#endif
-}
-#endif
 
 #endif

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,6)
-#define RCPP_DEV_VERSION_STRING "1.0.14.6"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,7)
+#define RCPP_DEV_VERSION_STRING "1.0.14.7"
 
 #endif

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -522,18 +522,12 @@ namespace Rcpp {
          * quite a cryptic message
          */
 	template <typename T>
-        inline SEXP wrap_dispatch_unknown_iterable(const T& object, ::Rcpp::traits::false_type) {
-            RCPP_DEBUG_1("wrap_dispatch_unknown_iterable<%s>(., false )", DEMANGLE(T))
-	    // here we know that T is not convertible to SEXP
-	    #ifdef HAS_STATIC_ASSERT
-                static_assert(!sizeof(T), "cannot convert type to SEXP");
-            #else
-                // leave the cryptic message
-                SEXP x = object;
-                return x;
-            #endif
-            return R_NilValue; // -Wall
-        }
+    inline SEXP wrap_dispatch_unknown_iterable(const T& object, ::Rcpp::traits::false_type) {
+        RCPP_DEBUG_1("wrap_dispatch_unknown_iterable<%s>(., false )", DEMANGLE(T))
+        // here we know that T is not convertible to SEXP
+        static_assert(!sizeof(T), "cannot convert type to SEXP");
+        return R_NilValue; // -Wall
+    }
 
 	template <typename T>
         inline SEXP wrap_dispatch_unknown_iterable__logical(const T& object, ::Rcpp::traits::true_type) {
@@ -936,7 +930,7 @@ namespace Rcpp {
          if (v != NULL)
              return Rf_mkString(v);
          else
-             return R_NilValue; 			// #nocov 
+             return R_NilValue; 			// #nocov
      }
 
      /**

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -1,8 +1,6 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
 // compiler.h: Rcpp R/C++ interface class library -- check compiler
 //
-// Copyright (C) 2012 - 2013  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
+// Copyright (C) 2012 - 2025  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
 //
 // This file is part of Rcpp.
 //
@@ -43,99 +41,72 @@
 # error "This compiler is not supported"
 #endif
 
+#if __cplusplus < 201103L
+# error "The C++ compilation standard is too old: use C++11 or newer."
+#endif
+
 #ifdef __GNUC__
     #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-    // g++ 4.5 does not seem to like some of the fast indexing
-    #if GCC_VERSION >= 40500
-        #define IS_GCC_450_OR_LATER
-    #endif
-    // g++ 4.6 switches from exception_defines.h to bits/exception_defines.h
-    #if GCC_VERSION < 40600
-        #define IS_EARLIER_THAN_GCC_460
-    #endif
-    #if GCC_VERSION >= 40600
-        #define IS_GCC_460_OR_LATER
-    #endif
 #endif
 
-// Check for the presence of C++0x (or later) support
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
-  #define RCPP_USING_CXX0X_OR_LATER
-#endif
+// TODO: Clean in a subsequent round
+#define RCPP_USING_CXX0X_OR_LATER
 
-// Check C++0x/11 features
+// Check C++11 features (could/should work generally)
 #if defined(__INTEL_COMPILER)
-    #if __cplusplus >= 201103L
-        #define RCPP_USING_CXX11
-        #if __INTEL_COMPILER >= 1210
-            #define HAS_VARIADIC_TEMPLATES
-        #endif
-        #if __INTEL_COMPILER >= 1100
-            #define HAS_STATIC_ASSERT
-        #endif
+    #define RCPP_USING_CXX11
+    #if __INTEL_COMPILER >= 1210
+        #define HAS_VARIADIC_TEMPLATES
+    #endif
+    #if __INTEL_COMPILER >= 1100
+        #define HAS_STATIC_ASSERT
     #endif
 #elif defined(__clang__)
-    #if __cplusplus >= 201103L
-        #define RCPP_USING_CXX11
-        #if __has_feature(cxx_variadic_templates)
-            #define HAS_VARIADIC_TEMPLATES
-        #endif
-        #if __has_feature(cxx_static_assert)
-            #define HAS_STATIC_ASSERT
-        #endif
+    #define RCPP_USING_CXX11
+    #if __has_feature(cxx_variadic_templates)
+        #define HAS_VARIADIC_TEMPLATES
+    #endif
+    #if __has_feature(cxx_static_assert)
+        #define HAS_STATIC_ASSERT
     #endif
 #elif defined(__GNUC__)
-    #ifdef __GXX_EXPERIMENTAL_CXX0X__
-        #if GCC_VERSION >= 40300
-            #define HAS_VARIADIC_TEMPLATES
-            #define HAS_STATIC_ASSERT
-        #endif
+    #define RCPP_USING_CXX11
+    #if __has_feature(cxx_variadic_templates)
+        #define HAS_VARIADIC_TEMPLATES
     #endif
-	#if GCC_VERSION >= 40800 && __cplusplus >= 201103L
-		#define RCPP_USING_CXX11
-	#endif
+    #if __has_feature(cxx_static_assert)
+        #define HAS_STATIC_ASSERT
+    #endif
 #endif
 
-// Check C++0x headers
+// Check C++0x headers (TODO remove when no longer needed below)
 #include <cmath>
 #if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
-    #if defined(__GLIBCXX__) && defined(__GXX_EXPERIMENTAL_CXX0X__)
-        #if GCC_VERSION >= 40400
-            #define HAS_CXX0X_UNORDERED_MAP
-            #define HAS_CXX0X_UNORDERED_SET
-            #define HAS_CXX0X_INITIALIZER_LIST
-        #endif
-    #endif
+    #define HAS_CXX0X_UNORDERED_MAP
+    #define HAS_CXX0X_UNORDERED_SET
+    #define HAS_CXX0X_INITIALIZER_LIST
 #elif defined(__clang__)
-    #if __cplusplus >= 201103L
-        #if __has_include(<unordered_map>)
-            #define HAS_CXX0X_UNORDERED_MAP
-        #endif
-        #if __has_include(<unordered_set>)
-            #define HAS_CXX0X_UNORDERED_SET
-        #endif
-        #if __has_include(<initializer_list>)
-            #define HAS_CXX0X_INITIALIZER_LIST
-        #endif
+    #if __has_include(<unordered_map>)
+        #define HAS_CXX0X_UNORDERED_MAP
+    #endif
+    #if __has_include(<unordered_set>)
+        #define HAS_CXX0X_UNORDERED_SET
+    #endif
+    #if __has_include(<initializer_list>)
+        #define HAS_CXX0X_INITIALIZER_LIST
     #endif
 #endif
 
-// Check TR1 Headers
+// Check TR1 Headers (TODO remove when no longer needed below)
 #if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
-    #if defined(__GLIBCXX__)
-        #if GCC_VERSION >= 40400 || ( GCC_VERSION >= 40201 && defined(__APPLE__) )
-            #define HAS_TR1_UNORDERED_MAP
-            #define HAS_TR1_UNORDERED_SET
-        #endif
-    #endif
+    #define HAS_TR1_UNORDERED_MAP
+    #define HAS_TR1_UNORDERED_SET
 #elif defined(__clang__)
-    #if __cplusplus >= 201103L
-        #if __has_include(<tr1/unordered_map>)
-            #define HAS_TR1_UNORDERED_MAP
-        #endif
-        #if __has_include(<tr1/unordered_set>)
-            #define HAS_TR1_UNORDERED_SET
-        #endif
+    #if __has_include(<tr1/unordered_map>)
+        #define HAS_TR1_UNORDERED_MAP
+    #endif
+    #if __has_include(<tr1/unordered_set>)
+        #define HAS_TR1_UNORDERED_SET
     #endif
 #endif
 
@@ -144,10 +115,11 @@
 #endif
 
 // Conditionally include headers
-#ifdef HAS_CXX0X_INITIALIZER_LIST
+// #ifdef HAS_CXX0X_INITIALIZER_LIST
 #include <initializer_list>
-#endif
+// #endif
 
+// TODO: Simplify further: First case should work generally
 #ifdef RCPP_USING_CXX11
     #if defined(HAS_CXX0X_UNORDERED_MAP)
         #include <unordered_map>

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -22,22 +22,17 @@
 
 // NB: A vast list valid identifiers is at these wiki pages:
 //     http://sourceforge.net/p/predef/wiki/Home/
-#if defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__clang__) || defined(__INTEL_COMPILER)
-#define GOOD_COMPILER_FOR_RCPP
-#else
+#if !defined(__GNUC__) && !defined(__SUNPRO_CC) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #error "This compiler is not supported"
 #endif
 
-// New simpler test and minimal standard: C++11 or else we die
+// Simpler test and minimal standard: C++11 or else we die
 #if __cplusplus < 201103L
 #error "The C++ compilation standard is too old: use C++11 or newer."
 #endif
 
-#ifdef __GNUC__
-    #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
-
 // C++11 features -- that used to be carefully tested for or worked around via CXX0X / TR1
+// These defines are all planned to get removed just how a number have already been removed. One at a time...
 #define RCPP_USING_CXX11
 #define HAS_VARIADIC_TEMPLATES
 #include <cmath>
@@ -49,7 +44,7 @@
 #define RCPP_USING_UNORDERED_SET
 #define RCPP_UNORDERED_SET std::unordered_set
 
-#ifdef __GNUC__
+#if defined(__GNUC__)
   #define RCPP_HAS_DEMANGLING
 #endif
 

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -40,7 +40,6 @@
 // C++11 features -- that used to be carefully tested for or worked around via CXX0X / TR1
 #define RCPP_USING_CXX11
 #define HAS_VARIADIC_TEMPLATES
-#define HAS_STATIC_ASSERT
 #include <cmath>
 #include <initializer_list>
 #include <unordered_map>

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -70,13 +70,10 @@
         #define HAS_STATIC_ASSERT
     #endif
 #elif defined(__GNUC__)
+    // given the check about __cplusplus we can unconditionally define
     #define RCPP_USING_CXX11
-    #if __has_feature(cxx_variadic_templates)
-        #define HAS_VARIADIC_TEMPLATES
-    #endif
-    #if __has_feature(cxx_static_assert)
-        #define HAS_STATIC_ASSERT
-    #endif
+    #define HAS_VARIADIC_TEMPLATES
+    #define HAS_STATIC_ASSERT
 #endif
 
 // Check C++0x headers (TODO remove when no longer needed below)

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -76,49 +76,37 @@
     #define HAS_STATIC_ASSERT
 #endif
 
-// Check C++0x headers (TODO remove when no longer needed below)
+// C++11 features -- that used to be carefully tested for or worked around via CXX0X / TR1
 #include <cmath>
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
-    #define HAS_CXX0X_UNORDERED_MAP
-    #define HAS_CXX0X_UNORDERED_SET
-    #define HAS_CXX0X_INITIALIZER_LIST
-#elif defined(__clang__)
-    #if __has_include(<unordered_map>)
-        #define HAS_CXX0X_UNORDERED_MAP
-    #endif
-    #if __has_include(<unordered_set>)
-        #define HAS_CXX0X_UNORDERED_SET
-    #endif
-    #if __has_include(<initializer_list>)
-        #define HAS_CXX0X_INITIALIZER_LIST
-    #endif
-#endif
+#define HAS_CXX0X_UNORDERED_MAP
+#define HAS_CXX0X_UNORDERED_SET
+#define HAS_CXX0X_INITIALIZER_LIST
 
-// Check TR1 Headers (TODO remove when no longer needed below)
-#if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
-    #define HAS_TR1_UNORDERED_MAP
-    #define HAS_TR1_UNORDERED_SET
-#elif defined(__clang__)
-    #if __has_include(<tr1/unordered_map>)
-        #define HAS_TR1_UNORDERED_MAP
-    #endif
-    #if __has_include(<tr1/unordered_set>)
-        #define HAS_TR1_UNORDERED_SET
-    #endif
-#endif
+// // Check TR1 Headers (TODO remove when no longer needed below)
+// #if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
+//     #define HAS_TR1_UNORDERED_MAP
+//     #define HAS_TR1_UNORDERED_SET
+// #elif defined(__clang__)
+//     #if __has_include(<tr1/unordered_map>)
+//         #define HAS_TR1_UNORDERED_MAP
+//     #endif
+//     #if __has_include(<tr1/unordered_set>)
+//         #define HAS_TR1_UNORDERED_SET
+//     #endif
+// #endif
 
-#if defined(HAS_TR1_UNORDERED_MAP) && defined(HAS_TR1_UNORDERED_SET)
-#define HAS_TR1
-#endif
+// #if defined(HAS_TR1_UNORDERED_MAP) && defined(HAS_TR1_UNORDERED_SET)
+// #define HAS_TR1
+// #endif
 
 // Conditionally include headers
 // #ifdef HAS_CXX0X_INITIALIZER_LIST
 #include <initializer_list>
 // #endif
 
-// TODO: Simplify further: First case should work generally
-#ifdef RCPP_USING_CXX11
-    #if defined(HAS_CXX0X_UNORDERED_MAP)
+// // TODO: Simplify further: First case should work generally
+// #ifdef RCPP_USING_CXX11
+//     #if defined(HAS_CXX0X_UNORDERED_MAP)
         #include <unordered_map>
         #define RCPP_USING_UNORDERED_MAP
         #define RCPP_UNORDERED_MAP std::unordered_map
@@ -126,8 +114,8 @@
     //     #include <map>
     //     #define RCPP_USING_MAP
     //     #define RCPP_UNORDERED_MAP std::map
-    #endif
-    #if defined(HAS_CXX0X_UNORDERED_SET)
+    // #endif
+    // #if defined(HAS_CXX0X_UNORDERED_SET)
         #include <unordered_set>
         #define RCPP_USING_UNORDERED_SET
         #define RCPP_UNORDERED_SET std::unordered_set
@@ -135,27 +123,27 @@
     //     #include <set>
     //     #define RCPP_USING_SET
     //     #define RCPP_UNORDERED_SET std::set
-    #endif
-#else
-    #if defined(HAS_TR1_UNORDERED_MAP)
-        #include <tr1/unordered_map>
-        #define RCPP_USING_TR1_UNORDERED_MAP
-        #define RCPP_UNORDERED_MAP std::tr1::unordered_map
-    // #else
-    //     #include <map>
-    //     #define RCPP_USING_MAP
-    //     #define RCPP_UNORDERED_MAP std::map
-    #endif
-    #if defined(HAS_TR1_UNORDERED_SET)
-        #include <tr1/unordered_set>
-        #define RCPP_USING_TR1_UNORDERED_SET
-        #define RCPP_UNORDERED_SET std::tr1::unordered_set
-    // #else
-    //     #include <set>
-    //     #define RCPP_USING_SET
-    //     #define RCPP_UNORDERED_SET std::set
-    #endif
-#endif
+    // #endif
+// #else
+//     #if defined(HAS_TR1_UNORDERED_MAP)
+//         #include <tr1/unordered_map>
+//         #define RCPP_USING_TR1_UNORDERED_MAP
+//         #define RCPP_UNORDERED_MAP std::tr1::unordered_map
+//     // #else
+//     //     #include <map>
+//     //     #define RCPP_USING_MAP
+//     //     #define RCPP_UNORDERED_MAP std::map
+//     #endif
+//     #if defined(HAS_TR1_UNORDERED_SET)
+//         #include <tr1/unordered_set>
+//         #define RCPP_USING_TR1_UNORDERED_SET
+//         #define RCPP_UNORDERED_SET std::tr1::unordered_set
+//     // #else
+//     //     #include <set>
+//     //     #define RCPP_USING_SET
+//     //     #define RCPP_UNORDERED_SET std::set
+//     #endif
+// #endif
 
 #ifdef __GNUC__
   #define RCPP_HAS_DEMANGLING

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -42,9 +42,6 @@
 #define HAS_VARIADIC_TEMPLATES
 #define HAS_STATIC_ASSERT
 #include <cmath>
-#define HAS_CXX0X_UNORDERED_MAP
-#define HAS_CXX0X_UNORDERED_SET
-#define HAS_CXX0X_INITIALIZER_LIST
 #include <initializer_list>
 #include <unordered_map>
 #define RCPP_USING_UNORDERED_MAP

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -122,38 +122,38 @@
         #include <unordered_map>
         #define RCPP_USING_UNORDERED_MAP
         #define RCPP_UNORDERED_MAP std::unordered_map
-    #else
-        #include <map>
-        #define RCPP_USING_MAP
-        #define RCPP_UNORDERED_MAP std::map
+    // #else
+    //     #include <map>
+    //     #define RCPP_USING_MAP
+    //     #define RCPP_UNORDERED_MAP std::map
     #endif
     #if defined(HAS_CXX0X_UNORDERED_SET)
         #include <unordered_set>
         #define RCPP_USING_UNORDERED_SET
         #define RCPP_UNORDERED_SET std::unordered_set
-    #else
-        #include <set>
-        #define RCPP_USING_SET
-        #define RCPP_UNORDERED_SET std::set
+    // #else
+    //     #include <set>
+    //     #define RCPP_USING_SET
+    //     #define RCPP_UNORDERED_SET std::set
     #endif
 #else
     #if defined(HAS_TR1_UNORDERED_MAP)
         #include <tr1/unordered_map>
         #define RCPP_USING_TR1_UNORDERED_MAP
         #define RCPP_UNORDERED_MAP std::tr1::unordered_map
-    #else
-        #include <map>
-        #define RCPP_USING_MAP
-        #define RCPP_UNORDERED_MAP std::map
+    // #else
+    //     #include <map>
+    //     #define RCPP_USING_MAP
+    //     #define RCPP_UNORDERED_MAP std::map
     #endif
     #if defined(HAS_TR1_UNORDERED_SET)
         #include <tr1/unordered_set>
         #define RCPP_USING_TR1_UNORDERED_SET
         #define RCPP_UNORDERED_SET std::tr1::unordered_set
-    #else
-        #include <set>
-        #define RCPP_USING_SET
-        #define RCPP_UNORDERED_SET std::set
+    // #else
+    //     #include <set>
+    //     #define RCPP_USING_SET
+    //     #define RCPP_UNORDERED_SET std::set
     #endif
 #endif
 

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -22,132 +22,39 @@
 
 // NB: A vast list valid identifiers is at these wiki pages:
 //     http://sourceforge.net/p/predef/wiki/Home/
-
-#undef GOOD_COMPILER_FOR_RCPP
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__clang__) || defined(__INTEL_COMPILER)
 #define GOOD_COMPILER_FOR_RCPP
-#endif
-#ifdef __SUNPRO_CC
-#define GOOD_COMPILER_FOR_RCPP
-#endif
-#ifdef __clang__
-#define GOOD_COMPILER_FOR_RCPP
-#endif
-#ifdef __INTEL_COMPILER
-#define GOOD_COMPILER_FOR_RCPP
+#else
+#error "This compiler is not supported"
 #endif
 
-#ifndef GOOD_COMPILER_FOR_RCPP
-# error "This compiler is not supported"
-#endif
-
+// New simpler test and minimal standard: C++11 or else we die
 #if __cplusplus < 201103L
-# error "The C++ compilation standard is too old: use C++11 or newer."
+#error "The C++ compilation standard is too old: use C++11 or newer."
 #endif
 
 #ifdef __GNUC__
     #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif
 
-// TODO: Clean in a subsequent round
-#define RCPP_USING_CXX0X_OR_LATER
-
-// Check C++11 features (could/should work generally)
-#if defined(__INTEL_COMPILER)
-    #define RCPP_USING_CXX11
-    #if __INTEL_COMPILER >= 1210
-        #define HAS_VARIADIC_TEMPLATES
-    #endif
-    #if __INTEL_COMPILER >= 1100
-        #define HAS_STATIC_ASSERT
-    #endif
-#elif defined(__clang__)
-    #define RCPP_USING_CXX11
-    #if __has_feature(cxx_variadic_templates)
-        #define HAS_VARIADIC_TEMPLATES
-    #endif
-    #if __has_feature(cxx_static_assert)
-        #define HAS_STATIC_ASSERT
-    #endif
-#elif defined(__GNUC__)
-    // given the check about __cplusplus we can unconditionally define
-    #define RCPP_USING_CXX11
-    #define HAS_VARIADIC_TEMPLATES
-    #define HAS_STATIC_ASSERT
-#endif
-
 // C++11 features -- that used to be carefully tested for or worked around via CXX0X / TR1
+#define RCPP_USING_CXX11
+#define HAS_VARIADIC_TEMPLATES
+#define HAS_STATIC_ASSERT
 #include <cmath>
 #define HAS_CXX0X_UNORDERED_MAP
 #define HAS_CXX0X_UNORDERED_SET
 #define HAS_CXX0X_INITIALIZER_LIST
-
-// // Check TR1 Headers (TODO remove when no longer needed below)
-// #if defined(__INTEL_COMPILER) || (defined(__GNUC__) && !defined(__clang__))
-//     #define HAS_TR1_UNORDERED_MAP
-//     #define HAS_TR1_UNORDERED_SET
-// #elif defined(__clang__)
-//     #if __has_include(<tr1/unordered_map>)
-//         #define HAS_TR1_UNORDERED_MAP
-//     #endif
-//     #if __has_include(<tr1/unordered_set>)
-//         #define HAS_TR1_UNORDERED_SET
-//     #endif
-// #endif
-
-// #if defined(HAS_TR1_UNORDERED_MAP) && defined(HAS_TR1_UNORDERED_SET)
-// #define HAS_TR1
-// #endif
-
-// Conditionally include headers
-// #ifdef HAS_CXX0X_INITIALIZER_LIST
 #include <initializer_list>
-// #endif
-
-// // TODO: Simplify further: First case should work generally
-// #ifdef RCPP_USING_CXX11
-//     #if defined(HAS_CXX0X_UNORDERED_MAP)
-        #include <unordered_map>
-        #define RCPP_USING_UNORDERED_MAP
-        #define RCPP_UNORDERED_MAP std::unordered_map
-    // #else
-    //     #include <map>
-    //     #define RCPP_USING_MAP
-    //     #define RCPP_UNORDERED_MAP std::map
-    // #endif
-    // #if defined(HAS_CXX0X_UNORDERED_SET)
-        #include <unordered_set>
-        #define RCPP_USING_UNORDERED_SET
-        #define RCPP_UNORDERED_SET std::unordered_set
-    // #else
-    //     #include <set>
-    //     #define RCPP_USING_SET
-    //     #define RCPP_UNORDERED_SET std::set
-    // #endif
-// #else
-//     #if defined(HAS_TR1_UNORDERED_MAP)
-//         #include <tr1/unordered_map>
-//         #define RCPP_USING_TR1_UNORDERED_MAP
-//         #define RCPP_UNORDERED_MAP std::tr1::unordered_map
-//     // #else
-//     //     #include <map>
-//     //     #define RCPP_USING_MAP
-//     //     #define RCPP_UNORDERED_MAP std::map
-//     #endif
-//     #if defined(HAS_TR1_UNORDERED_SET)
-//         #include <tr1/unordered_set>
-//         #define RCPP_USING_TR1_UNORDERED_SET
-//         #define RCPP_UNORDERED_SET std::tr1::unordered_set
-//     // #else
-//     //     #include <set>
-//     //     #define RCPP_USING_SET
-//     //     #define RCPP_UNORDERED_SET std::set
-//     #endif
-// #endif
+#include <unordered_map>
+#define RCPP_USING_UNORDERED_MAP
+#define RCPP_UNORDERED_MAP std::unordered_map
+#include <unordered_set>
+#define RCPP_USING_UNORDERED_SET
+#define RCPP_UNORDERED_SET std::unordered_set
 
 #ifdef __GNUC__
   #define RCPP_HAS_DEMANGLING
 #endif
-
 
 #endif

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -21,9 +21,8 @@
 #ifndef Rcpp__sugar__sapply_h
 #define Rcpp__sugar__sapply_h
 
-#if defined(RCPP_USING_CXX0X_OR_LATER)
-	#include <type_traits> // ::std::result_of
-#endif
+// This used to be conditional on a define and test in compiler.h
+#include <type_traits> // ::std::result_of
 
 namespace Rcpp{
 namespace sugar{
@@ -31,7 +30,7 @@ namespace sugar{
 template <typename Function, typename SugarExpression>
 struct sapply_application_result_of
 {
-#if defined(RCPP_USING_CXX0X_OR_LATER)
+#if __cplusplus >= 201103L
     #if __cplusplus < 201703L
         // deprecated by C++17, removed by C++2020, see https://en.cppreference.com/w/cpp/types/result_of
  	    typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
@@ -40,9 +39,10 @@ struct sapply_application_result_of
         typedef typename ::std::invoke_result<Function, typename SugarExpression::stored_type>::type type;
     #endif
 #else
+    // TODO this else branch can likely go
 	typedef typename ::Rcpp::traits::result_of<Function>::type type;
 #endif
-} ;
+};
 
 // template <typename Function, typename SugarExpression>
 // using sapply_application_result_of_t = typename sapply_application_result_of<Function, SugarExpression>::type;

--- a/inst/include/Rcpp/sugar/functions/table.h
+++ b/inst/include/Rcpp/sugar/functions/table.h
@@ -1,8 +1,6 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // table.h: Rcpp R/C++ interface class library -- table match
 //
-// Copyright (C) 2012 - 2013   Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
+// Copyright (C) 2012 - 2025   Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
 //
 // This file is part of Rcpp.
 //
@@ -55,36 +53,6 @@ private:
     R_xlen_t index ;
 } ;
 
-// we define a different Table class depending on whether we are using
-// std::map or not
-#ifdef RCPP_USING_MAP
-
-template <int RTYPE, typename TABLE_T>
-class Table {
-public:
-    typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
-
-    Table( const TABLE_T& table ): hash() {
-        std::for_each( table.begin(), table.end(), Inserter(hash) ) ;
-    }
-
-    inline operator IntegerVector() const {
-        R_xlen_t n = hash.size() ;
-        IntegerVector result = no_init(n) ;
-        CharacterVector names = no_init(n) ;
-        std::for_each( hash.begin(), hash.end(), Grabber<HASH, RTYPE>(result, names) ) ;
-        result.names() = names ;
-        return result ;
-    }
-
-private:
-    typedef RCPP_UNORDERED_MAP<STORAGE, int, internal::NAComparator<STORAGE> >HASH ;
-    typedef CountInserter<HASH,STORAGE> Inserter ;
-    HASH hash ;
-};
-
-#else
-
 template <int RTYPE, typename TABLE_T>
 class Table {
 public:
@@ -118,8 +86,6 @@ private:
 
 };
 
-#endif // USING_RCPP_MAP
-
 } // sugar
 
 template <int RTYPE, bool NA, typename T>
@@ -130,4 +96,3 @@ inline IntegerVector table( const VectorBase<RTYPE,NA,T>& x ){
 
 } // Rcpp
 #endif
-

--- a/inst/include/Rcpp/sugar/sets.h
+++ b/inst/include/Rcpp/sugar/sets.h
@@ -1,8 +1,6 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; tab-width: 8 -*-
-//
 // sets.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2025  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -22,40 +20,17 @@
 #ifndef Rcpp__sugar__sets_h
 #define Rcpp__sugar__sets_h
 
-#if __cplusplus >= 201103L
-    #define RCPP_UNORDERED_SET std::unordered_set
-    #define RCPP_UNORDERED_MAP std::unordered_map
+#define RCPP_UNORDERED_SET std::unordered_set
+#define RCPP_UNORDERED_MAP std::unordered_map
 
-    namespace std {
-        template<>
-        struct hash<Rcpp::String> {
-            std::size_t operator()(const Rcpp::String& key) const {
-                return pointer_hasher( key.get_sexp() ) ;
-            }
-            hash<SEXP> pointer_hasher ;
-        };
-    }
-
-#elif defined(HAS_TR1_UNORDERED_SET)
-    #define RCPP_UNORDERED_SET std::tr1::unordered_set
-    #define RCPP_UNORDERED_MAP std::tr1::unordered_map
-
-    namespace std {
-        namespace tr1 {
-            template<>
-            struct hash<Rcpp::String> {
-                std::size_t operator()(const Rcpp::String& key) const {
-                    return pointer_hasher( key.get_sexp() ) ;
-                }
-                hash<SEXP> pointer_hasher ;
-            };
+namespace std {
+    template<>
+    struct hash<Rcpp::String> {
+        std::size_t operator()(const Rcpp::String& key) const {
+            return pointer_hasher( key.get_sexp() ) ;
         }
-    }
-
-
-#else
-    #define RCPP_UNORDERED_SET std::set
-    #define RCPP_UNORDERED_MAP std::map
-#endif
+        hash<SEXP> pointer_hasher ;
+    };
+}
 
 #endif

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -236,11 +236,9 @@ public:
         std::transform( first, last, begin(), func) ;
     }
 
-#ifdef HAS_CXX0X_INITIALIZER_LIST
     Vector( std::initializer_list<init_type> list ) {
         assign( list.begin() , list.end() ) ;
     }
-#endif
 
     template <typename T>
     Vector& operator=( const T& x) {

--- a/man/evalCpp.Rd
+++ b/man/evalCpp.Rd
@@ -5,16 +5,16 @@
 Evaluate a C++ Expression
 }
 \description{
-Evaluates a C++ expression. This creates a C++ function using 
-\code{\link{cppFunction}} and calls it to get the result. 
+Evaluates a C++ expression. This creates a C++ function using
+\code{\link{cppFunction}} and calls it to get the result.
 }
 \usage{
-evalCpp(code, depends = character(), plugins = character(), includes = character(), 
+evalCpp(code, depends = character(), plugins = character(), includes = character(),
         rebuild = FALSE, cacheDir = getOption("rcpp.cache.dir", tempdir()),
         showOutput = verbose, verbose = getOption("verbose"))
 
-areMacrosDefined(names, depends = character(), includes = character(), 
-        rebuild = FALSE, showOutput = verbose, 
+areMacrosDefined(names, depends = character(), includes = character(),
+        rebuild = FALSE, showOutput = verbose,
         verbose = getOption("verbose"))
 }
 \arguments{
@@ -47,10 +47,10 @@ see \code{\link{cppFunction}}
 }
 }
 \note{
-    The result type of the C++ expression must be compatible with \code{Rcpp::wrap}.     
+    The result type of the C++ expression must be compatible with \code{Rcpp::wrap}.
 }
 \value{
-    The result of the evaluated C++ expression. 
+    The result of the evaluated C++ expression.
 }
 \seealso{
 \code{\link{sourceCpp}}, \code{\link{cppFunction}}
@@ -58,10 +58,11 @@ see \code{\link{cppFunction}}
 \examples{
 \dontrun{
 
-evalCpp( "__cplusplus" )
-evalCpp( "std::numeric_limits<double>::max()" )
-    
-areMacrosDefined( c("__cplusplus", "HAS_TR1" ) )
+evalCpp("__cplusplus")
+evalCpp("std::numeric_limits<double>::max()")
+
+# areMacrosDefined is no longer exported by accessible via ':::'
+Rcpp:::areMacrosDefined(c("__cplusplus", "GCC_VERSION"))
 
 }
 }

--- a/man/evalCpp.Rd
+++ b/man/evalCpp.Rd
@@ -62,7 +62,7 @@ evalCpp("__cplusplus")
 evalCpp("std::numeric_limits<double>::max()")
 
 # areMacrosDefined is no longer exported but accessible via ':::'
-Rcpp:::areMacrosDefined(c("__cplusplus", "GCC_VERSION"))
+Rcpp:::areMacrosDefined(c("__cplusplus", "RCPP_VERSION"))
 
 }
 }

--- a/man/evalCpp.Rd
+++ b/man/evalCpp.Rd
@@ -61,7 +61,7 @@ see \code{\link{cppFunction}}
 evalCpp("__cplusplus")
 evalCpp("std::numeric_limits<double>::max()")
 
-# areMacrosDefined is no longer exported by accessible via ':::'
+# areMacrosDefined is no longer exported but accessible via ':::'
 Rcpp:::areMacrosDefined(c("__cplusplus", "GCC_VERSION"))
 
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -171,32 +171,12 @@ SEXP as_character_externalptr(SEXP xp) {
 SEXP rcpp_capabilities() {
     Shield<SEXP> cap(Rf_allocVector(LGLSXP, 13));
     Shield<SEXP> names(Rf_allocVector(STRSXP, 13));
-    #ifdef HAS_VARIADIC_TEMPLATES
-        LOGICAL(cap)[0] = TRUE;
-    #else
-        LOGICAL(cap)[0] = FALSE;
-    #endif
-    #ifdef HAS_CXX0X_INITIALIZER_LIST
-        LOGICAL(cap)[1] = TRUE;
-    #else
-        LOGICAL(cap)[1] = FALSE;
-    #endif
-    /* exceptions are always supported */
-    LOGICAL(cap)[2] = TRUE;
-
-    #ifdef HAS_TR1_UNORDERED_MAP
-        LOGICAL(cap)[3] = TRUE;
-    #else
-       LOGICAL(cap)[3] = FALSE;
-    #endif
-
-    #ifdef HAS_TR1_UNORDERED_SET
-        LOGICAL(cap)[4] = TRUE;
-    #else
-        LOGICAL(cap)[4] = FALSE;
-    #endif
-
-    LOGICAL(cap)[5] = TRUE;
+    LOGICAL(cap)[0] = TRUE; // HAS_VARIADIC_TEMPLATES
+    LOGICAL(cap)[1] = TRUE; // HAS_CXX0X_INITIALIZER_LIST
+    LOGICAL(cap)[2] = TRUE; /* exceptions are always supported */
+    LOGICAL(cap)[3] = TRUE; // HAS_TR1_UNORDERED_MAP
+    LOGICAL(cap)[4] = TRUE; // HAS_TR1_UNORDERED_SET
+    LOGICAL(cap)[5] = TRUE; // Modules (TODO respect header choice ?)
 
     #ifdef RCPP_HAS_DEMANGLING
         LOGICAL(cap)[6] = TRUE;
@@ -204,7 +184,7 @@ SEXP rcpp_capabilities() {
        LOGICAL(cap)[6] = FALSE;
     #endif
 
-       LOGICAL(cap)[7] = FALSE;
+    LOGICAL(cap)[7] = FALSE; // Classic API
 
     #ifdef RCPP_HAS_LONG_LONG_TYPES
         LOGICAL(cap)[8] = TRUE;
@@ -212,23 +192,9 @@ SEXP rcpp_capabilities() {
         LOGICAL(cap)[8] = FALSE;
     #endif
 
-    #ifdef HAS_CXX0X_UNORDERED_MAP
-      LOGICAL(cap)[9] = TRUE;
-    #else
-      LOGICAL(cap)[9] = FALSE;
-    #endif
-
-    #ifdef HAS_CXX0X_UNORDERED_SET
-      LOGICAL(cap)[10] = TRUE;
-    #else
-      LOGICAL(cap)[10] = FALSE;
-    #endif
-
-    #ifdef RCPP_USING_CXX11
-      LOGICAL(cap)[11] = TRUE;
-    #else
-      LOGICAL(cap)[11] = FALSE;
-    #endif
+    LOGICAL(cap)[9] = TRUE; // HAS_CXX0X_UNORDERED_MAP
+    LOGICAL(cap)[10] = TRUE; // HAS_CXX0X_UNORDERED_SET
+    LOGICAL(cap)[11] = TRUE; // RCPP_USING_CXX11
 
     #ifdef RCPP_NEW_DATE_DATETIME_VECTORS
       LOGICAL(cap)[12] = TRUE;


### PR DESCRIPTION
Rcpp has worked very hard for very long to provide powerful idioms irrespective of the compiler encountered.  This was mostly due to 'modern C++' coming around very slowly when Rcpp got going.  It is now 2025, and C++11 itself starts to feel like 'legacy code' so we can move forward and discard accommodations for compilation standards older than C++11.  

This will allow us to remove a number of branches from numerous if/else blocks and remove included generated code.  Last years nice and very careful PR #1303 already went that way, we can now go further.  This PR starts by making the [platform/compiler.h](https://github.com/RcppCore/Rcpp/blob/master/inst/include/Rcpp/platform/compiler.h) header simpler by removing the various tests:  if C++11 is given, a number of things can be asserted and defined.  We can build on it and examine the different defines and one-by-one remove conditional use ... and eventually the define.  (While being careful.  Invariably one or two client packages may be using the define.)

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
