### PR TITLE
Remove RCPP_USING_CXX11 which is now implicit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-03-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/String.h: Remove explicit RCPP_USING_CXX11 as
+	use of C++11 (or newer) is both implicit and ensuredIdem
+	* inst/include/Rcpp/macros/dispatch.h: Idem
+	* inst/include/Rcpp/platform/compiler.h: Idem
+	* inst/include/Rcpp/unwindProtect.h: Idem
+	* inst/tinytest/cpp/wrap.cpp: Idem
+	* src/api.cpp: Idem
+
 2025-03-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-03-21  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 	* inst/include/Rcpp/String.h: Remove explicit RCPP_USING_CXX11 as
 	use of C++11 (or newer) is both implicit and ensuredIdem
 	* inst/include/Rcpp/macros/dispatch.h: Idem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.8
-Date: 2025-03-17
+Version: 1.0.14.9
+Date: 2025-03-21
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -19,6 +19,8 @@
       C++11 as the minunum (Dirk in \ghpr{1364} closing \ghit{1363})
       \item Variadic templates are now used onconditionally given C++11 (Dirk
       in \ghpr{1367} closing \ghit{1366})
+      \item Remove \code{RCPP_USING_CXX11} as a \code{#define} as C++11 is
+      now a given (Dirk in \ghpr{1369})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -30,7 +30,7 @@
     \item Changes in Rcpp Deployment:
     \itemize{
       \item \code{Rcpp.package.skeleton()} creates \sQuote{URL} and
-      \sQuote{BugReports} if given a GitHub username (Dirk \ghpr{1358})
+      \sQuote{BugReports} if given a GitHub username (Dirk in \ghpr{1358})
     }
   }
 }

--- a/inst/include/Rcpp/String.h
+++ b/inst/include/Rcpp/String.h
@@ -2,7 +2,7 @@
 // String.h: Rcpp R/C++ interface class library -- single string
 //
 // Copyright (C) 2012 - 2020  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2021 - 2023  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2021 - 2025  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -117,7 +117,7 @@ namespace Rcpp {
         String(const std::string& s, cetype_t enc = CE_UTF8) : data(R_NilValue), token(R_NilValue), buffer(s), valid(false), buffer_ready(true), enc(enc) {
             RCPP_STRING_DEBUG("String(const std::string&, cetype_t)");
         }
-#ifdef RCPP_USING_CXX11
+
         /** move constructor */
         String(String&& s) : data(s.data), token(s.token), buffer(std::move(s.buffer)), valid(s.valid), buffer_ready(s.buffer_ready), enc(s.enc) {
             // Erase s.
@@ -134,7 +134,7 @@ namespace Rcpp {
         String(std::string&& s, cetype_t enc = CE_UTF8) : data(R_NilValue), token(R_NilValue), buffer(s), valid(false), buffer_ready(true), enc(enc) {
             RCPP_STRING_DEBUG("String(std::string&&, cetype_t)");
         }
-#endif
+
         String(const std::wstring& s, cetype_t enc = CE_UTF8) : data(internal::make_charsexp(s)), token(R_NilValue), valid(true), buffer_ready(false), enc(enc) {
             token = Rcpp_PreciousPreserve(data);
             RCPP_STRING_DEBUG("String(const std::wstring&, cetype_t)");
@@ -267,7 +267,6 @@ namespace Rcpp {
             buffer_ready = true;
             return *this;
         }
-#ifdef RCPP_USING_CXX11
         inline String& operator=(String&& other) {
             data = other.data;
             token = other.token;
@@ -290,7 +289,6 @@ namespace Rcpp {
           buffer_ready = true;
           return *this;
         }
-#endif
         inline String& operator=(const char* s) {
             buffer = s;
             valid = false;

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,8)
-#define RCPP_DEV_VERSION_STRING "1.0.14.8"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,9)
+#define RCPP_DEV_VERSION_STRING "1.0.14.9"
 
 #endif

--- a/inst/include/Rcpp/macros/dispatch.h
+++ b/inst/include/Rcpp/macros/dispatch.h
@@ -3,7 +3,7 @@
 // dispatch.h: Rcpp R/C++ interface class library -- macros for dispatch
 //
 // Copyright (C) 2012 - 2016  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2016         Dirk Eddelbuettel, Romain Francois, Artem Klevtsov and Nathan Russell
+// Copyright (C) 2016 - 2025  Dirk Eddelbuettel, Romain Francois, Artem Klevtsov and Nathan Russell
 //
 // This file is part of Rcpp.
 //
@@ -23,14 +23,12 @@
 #ifndef Rcpp__macros__dispatch_h
 #define Rcpp__macros__dispatch_h
 
-//  The variadic macros below incorporate techniques presented by 
+//  The variadic macros below incorporate techniques presented by
 //  Stack Overflow user Richard Hansen in this answer
 //
-//      http://stackoverflow.com/a/11172679/1869097 
+//      http://stackoverflow.com/a/11172679/1869097
 //
 //  and are necessary to avoid the use of GNU compiler extensions.
-
-#ifdef RCPP_USING_CXX11
 
 #define ___RCPP_HANDLE_CASE___(___RTYPE___, ___FUN___, ___RCPPTYPE___, ...)                         \
   case ___RTYPE___:                                                                                 \
@@ -76,33 +74,5 @@
                 TWOORMORE, TWOORMORE, TWOORMORE, TWOORMORE, ONE, throwaway)
 #define RCPP_MACRO_SELECT_25TH(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,                   \
     a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, ...)           a25
-
-#else
-
-#define ___RCPP_HANDLE_CASE___(___RTYPE___, ___FUN___, ___OBJECT___,           \
-                               ___RCPPTYPE___)                                 \
-  case ___RTYPE___:                                                            \
-    return ___FUN___(::Rcpp::___RCPPTYPE___<___RTYPE___>(___OBJECT___));
-
-#define ___RCPP_RETURN___(__FUN__, __SEXP__, __RCPPTYPE__)                     \
-  SEXP __TMP__ = __SEXP__;                                                     \
-  switch (TYPEOF(__TMP__)) {                                                   \
-    ___RCPP_HANDLE_CASE___(INTSXP, __FUN__, __TMP__, __RCPPTYPE__)             \
-    ___RCPP_HANDLE_CASE___(REALSXP, __FUN__, __TMP__, __RCPPTYPE__)            \
-    ___RCPP_HANDLE_CASE___(RAWSXP, __FUN__, __TMP__, __RCPPTYPE__)             \
-    ___RCPP_HANDLE_CASE___(LGLSXP, __FUN__, __TMP__, __RCPPTYPE__)             \
-    ___RCPP_HANDLE_CASE___(CPLXSXP, __FUN__, __TMP__, __RCPPTYPE__)            \
-    ___RCPP_HANDLE_CASE___(STRSXP, __FUN__, __TMP__, __RCPPTYPE__)             \
-    ___RCPP_HANDLE_CASE___(VECSXP, __FUN__, __TMP__, __RCPPTYPE__)             \
-    ___RCPP_HANDLE_CASE___(EXPRSXP, __FUN__, __TMP__, __RCPPTYPE__)            \
-  default:                                                                     \
-    throw std::range_error("Not a vector");                                    \
-  }
-
-#define RCPP_RETURN_VECTOR(_FUN_, _SEXP_)                                      \
-  ___RCPP_RETURN___(_FUN_, _SEXP_, Vector)
-#define RCPP_RETURN_MATRIX(_FUN_, _SEXP_)                                      \
-  ___RCPP_RETURN___(_FUN_, _SEXP_, Matrix)
-#endif
 
 #endif

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -33,7 +33,6 @@
 
 // C++11 features -- that used to be carefully tested for or worked around via CXX0X / TR1
 // These defines are all planned to get removed just how a number have already been removed. One at a time...
-#define RCPP_USING_CXX11
 #include <cmath>
 #include <initializer_list>
 #include <unordered_map>

--- a/inst/include/Rcpp/unwindProtect.h
+++ b/inst/include/Rcpp/unwindProtect.h
@@ -2,7 +2,7 @@
 // unwind.h: Rcpp R/C++ interface class library -- Unwind Protect
 //
 // Copyright (C) 2018 - 2020  RStudio
-// Copyright (C) 2021         RStudio, Dirk Eddelbuettel and Iñaki Ucar
+// Copyright (C) 2021 - 2025  RStudio, Dirk Eddelbuettel and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -23,11 +23,7 @@
 #define RCPP_UNWINDPROTECT_H
 
 #include <csetjmp>
-
-#ifdef RCPP_USING_CXX11
 #include <functional>
-#endif
-
 
 namespace Rcpp { namespace internal {
 
@@ -45,12 +41,10 @@ inline void maybeJump(void* unwind_data, Rboolean jump) {
     }
 }
 
-#ifdef RCPP_USING_CXX11
 inline SEXP unwindProtectUnwrap(void* data) {
     std::function<SEXP(void)>* callback = (std::function<SEXP(void)>*) data;
     return (*callback)();
 }
-#endif
 
 }} // namespace Rcpp::internal
 
@@ -76,11 +70,9 @@ inline SEXP unwindProtect(SEXP (*callback)(void* data), void* data) {
                              token);
 }
 
-#ifdef RCPP_USING_CXX11
 inline SEXP unwindProtect(std::function<SEXP(void)> callback) {
     return unwindProtect(&internal::unwindProtectUnwrap, &callback);
 }
-#endif
 
 } // namespace Rcpp
 

--- a/inst/tinytest/cpp/wrap.cpp
+++ b/inst/tinytest/cpp/wrap.cpp
@@ -2,7 +2,7 @@
 //
 // wrap.cpp: Rcpp R/C++ interface class library -- wrap unit tests
 //
-// Copyright (C) 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2013 - 2025  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -167,10 +167,6 @@ SEXP nonnull_const_char(){
     const char *p = "foo";
     return wrap(p) ;
 }
-
-#ifdef RCPP_USING_CXX11
-// [[Rcpp::plugins(cpp11)]]
-#endif
 
 // [[Rcpp::export]]
 IntegerVector unordered_map_string_int(){

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -229,11 +229,7 @@ SEXP rcpp_can_use_cxx0x() {                                     // #nocov start
 
 // [[Rcpp::internal]]
 SEXP rcpp_can_use_cxx11() {
-    #if defined(RCPP_USING_CXX11)
-        return Rf_ScalarLogical(TRUE);
-    #else
-        return Rf_ScalarLogical(FALSE);
-    #endif
+    return Rf_ScalarLogical(TRUE);
 }
 
 // [[Rcpp::register]]


### PR DESCRIPTION
This PR, under the umbrella of meta issue #1365, builds upon PRs #1367 and #1364.  It is a little simpler as it merely removed `RCPP_USING_CXX11` wherever it is used (given that it is now always `#define`'d) and removes the stale `#else` cases, if any.  It all fit into one commit.

A reverse-depends run has been started and is about 100 packages in, this is not expected to reveal anything but we may as well let it run its course again.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
