### PR TITLE
Remove macros for unordered maps/sets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,8 +27,7 @@
 2025-03-24 Iñaki Ucar <iucar@fedoraproject.org>
 
 	* inst/include/Rcpp/platform/compiler.h: Remove definitions of
-	RCPP_USING_UNORDERED_MAP and RCPP_USING_UNORDERED_SET, deprecate macros
-	RCPP_UNORDERED_MAP and RCPP_UNORDERED_SET
+	RCPP_USING_UNORDERED_MAP and RCPP_USING_UNORDERED_SET
 	* inst/include/Rcpp/sugar/sets.h: Remove redefinition of macros
 	* inst/include/Rcpp/sugar/functions/self_match.h: Replace macros with
 	std::unordered_map and std::unordered_set respectively

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-03-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 2025-03-26 Iñaki Ucar <iucar@fedoraproject.org>
 
 	* inst/include/Rcpp/platform/compiler.h: Remove definitions of

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2025-03-26 Iñaki Ucar <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/platform/compiler.h: Remove definitions of
+	RCPP_USING_UNORDERED_MAP and RCPP_USING_UNORDERED_SET
+	* inst/include/Rcpp/sugar/sets.h: Remove redefinition of macros
+	* inst/include/Rcpp/sugar/functions/self_match.h: Replace macros with
+	std::unordered_map and std::unordered_set respectively
+	* inst/include/Rcpp/sugar/functions/setdiff.h: Idem
+	* inst/include/Rcpp/sugar/functions/table.h: Idem
+	* inst/tinytest/cpp/wrap.cpp: Idem
+
 2025-03-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
@@ -24,16 +35,6 @@
 	* inst/include/Rcpp/algorithm.h: Idem
 	* inst/include/Rcpp/traits/is_arithmetic.h: Idem
 	* inst/include/Rcpp/traits/longlong.h: Idem
-2025-03-24 Iñaki Ucar <iucar@fedoraproject.org>
-
-	* inst/include/Rcpp/platform/compiler.h: Remove definitions of
-	RCPP_USING_UNORDERED_MAP and RCPP_USING_UNORDERED_SET
-	* inst/include/Rcpp/sugar/sets.h: Remove redefinition of macros
-	* inst/include/Rcpp/sugar/functions/self_match.h: Replace macros with
-	std::unordered_map and std::unordered_set respectively
-	* inst/include/Rcpp/sugar/functions/setdiff.h: Idem
-	* inst/include/Rcpp/sugar/functions/table.h: Idem
-	* inst/tinytest/cpp/wrap.cpp: Idem
 
 2025-03-21  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,17 @@
 	* inst/include/Rcpp/algorithm.h: Idem
 	* inst/include/Rcpp/traits/is_arithmetic.h: Idem
 	* inst/include/Rcpp/traits/longlong.h: Idem
+2025-03-24 Iñaki Ucar <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/platform/compiler.h: Remove definitions of
+	RCPP_USING_UNORDERED_MAP and RCPP_USING_UNORDERED_SET, deprecate macros
+	RCPP_UNORDERED_MAP and RCPP_UNORDERED_SET
+	* inst/include/Rcpp/sugar/sets.h: Remove redefinition of macros
+	* inst/include/Rcpp/sugar/functions/self_match.h: Replace macros with
+	std::unordered_map and std::unordered_set respectively
+	* inst/include/Rcpp/sugar/functions/setdiff.h: Idem
+	* inst/include/Rcpp/sugar/functions/table.h: Idem
+	* inst/tinytest/cpp/wrap.cpp: Idem
 
 2025-03-21  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.10
-Date: 2025-03-24
+Version: 1.0.14.11
+Date: 2025-03-26
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,10)
-#define RCPP_DEV_VERSION_STRING "1.0.14.10"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,11)
+#define RCPP_DEV_VERSION_STRING "1.0.14.11"
 
 #endif

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -37,13 +37,9 @@
 #include <cmath>
 #include <initializer_list>
 #include <unordered_map>
-#define RCPP_UNORDERED_MAP \
-    _Pragma("GCC warning \"RCPP_UNORDERED_MAP is deprecated, use std::unordered_map instead\"") \
-    std::unordered_map
+#define RCPP_UNORDERED_MAP std::unordered_map // TODO deprecate
 #include <unordered_set>
-#define RCPP_UNORDERED_SET \
-    _Pragma("GCC warning \"RCPP_UNORDERED_SET is deprecated, use std::unordered_set instead\"") \
-    std::unordered_set
+#define RCPP_UNORDERED_SET std::unordered_set // TODO deprecate
 
 #if defined(__GNUC__)
   #define RCPP_HAS_DEMANGLING

--- a/inst/include/Rcpp/platform/compiler.h
+++ b/inst/include/Rcpp/platform/compiler.h
@@ -1,6 +1,7 @@
 // compiler.h: Rcpp R/C++ interface class library -- check compiler
 //
 // Copyright (C) 2012 - 2025  Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois, Kevin Ushey and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -36,11 +37,13 @@
 #include <cmath>
 #include <initializer_list>
 #include <unordered_map>
-#define RCPP_USING_UNORDERED_MAP
-#define RCPP_UNORDERED_MAP std::unordered_map
+#define RCPP_UNORDERED_MAP \
+    _Pragma("GCC warning \"RCPP_UNORDERED_MAP is deprecated, use std::unordered_map instead\"") \
+    std::unordered_map
 #include <unordered_set>
-#define RCPP_USING_UNORDERED_SET
-#define RCPP_UNORDERED_SET std::unordered_set
+#define RCPP_UNORDERED_SET \
+    _Pragma("GCC warning \"RCPP_UNORDERED_SET is deprecated, use std::unordered_set instead\"") \
+    std::unordered_set
 
 #if defined(__GNUC__)
   #define RCPP_HAS_DEMANGLING

--- a/inst/include/Rcpp/sugar/functions/self_match.h
+++ b/inst/include/Rcpp/sugar/functions/self_match.h
@@ -2,7 +2,8 @@
 //
 // self_match.h: Rcpp R/C++ interface class library -- self match
 //
-// Copyright (C) 2012   Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2024  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -57,7 +58,7 @@ public:
     inline operator IntegerVector() const { return result ; }
 
 private:
-    typedef RCPP_UNORDERED_MAP<STORAGE, int> HASH ;
+    typedef std::unordered_map<STORAGE, int> HASH ;
     typedef SelfInserter<HASH,STORAGE> Inserter ;
     HASH hash ;
     IntegerVector result ;

--- a/inst/include/Rcpp/sugar/functions/setdiff.h
+++ b/inst/include/Rcpp/sugar/functions/setdiff.h
@@ -2,7 +2,8 @@
 //
 // setdiff.h: Rcpp R/C++ interface class library -- setdiff
 //
-// Copyright (C) 2012 - 2014  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2024  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -60,7 +61,7 @@ namespace sugar{
         }
 
     private:
-        typedef RCPP_UNORDERED_SET<STORAGE> SET ;
+        typedef std::unordered_set<STORAGE> SET ;
         typedef typename SET::const_iterator ITERATOR ;
         SET lhs_set ;
         SET rhs_set ;
@@ -89,7 +90,7 @@ namespace sugar{
         }
 
     private:
-        typedef RCPP_UNORDERED_SET<STORAGE> SET ;
+        typedef std::unordered_set<STORAGE> SET ;
         typedef typename SET::const_iterator ITERATOR ;
         SET lhs_set ;
         SET rhs_set ;
@@ -123,7 +124,7 @@ namespace sugar{
         }
 
     private:
-        typedef RCPP_UNORDERED_SET<STORAGE> SET ;
+        typedef std::unordered_set<STORAGE> SET ;
         typedef typename SET::const_iterator ITERATOR ;
         SET intersect ;
 
@@ -148,7 +149,7 @@ namespace sugar{
         }
 
     private:
-        typedef RCPP_UNORDERED_SET<STORAGE> SET ;
+        typedef std::unordered_set<STORAGE> SET ;
         typedef typename SET::const_iterator ITERATOR ;
         SET result ;
 

--- a/inst/include/Rcpp/sugar/functions/table.h
+++ b/inst/include/Rcpp/sugar/functions/table.h
@@ -1,6 +1,7 @@
 // table.h: Rcpp R/C++ interface class library -- table match
 //
 // Copyright (C) 2012 - 2025   Dirk Eddelbuettel, Romain Francois, and Kevin Ushey
+// Copyright (C) 2025          Dirk Eddelbuettel, Romain Francois, Kevin Ushey and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -77,7 +78,7 @@ public:
     }
 
 private:
-    typedef RCPP_UNORDERED_MAP<STORAGE, int> HASH ;
+    typedef std::unordered_map<STORAGE, int> HASH ;
     typedef CountInserter<HASH,STORAGE> Inserter ;
     HASH hash ;
 

--- a/inst/include/Rcpp/sugar/sets.h
+++ b/inst/include/Rcpp/sugar/sets.h
@@ -20,9 +20,6 @@
 #ifndef Rcpp__sugar__sets_h
 #define Rcpp__sugar__sets_h
 
-#define RCPP_UNORDERED_SET std::unordered_set
-#define RCPP_UNORDERED_MAP std::unordered_map
-
 namespace std {
     template<>
     struct hash<Rcpp::String> {

--- a/inst/tinytest/cpp/wrap.cpp
+++ b/inst/tinytest/cpp/wrap.cpp
@@ -3,6 +3,7 @@
 // wrap.cpp: Rcpp R/C++ interface class library -- wrap unit tests
 //
 // Copyright (C) 2013 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -170,7 +171,7 @@ SEXP nonnull_const_char(){
 
 // [[Rcpp::export]]
 IntegerVector unordered_map_string_int(){
-    RCPP_UNORDERED_MAP< std::string, int > m ;
+    std::unordered_map< std::string, int > m ;
     m["b"] = 100;
     m["a"] = 200;
     m["c"] = 300;
@@ -179,7 +180,7 @@ IntegerVector unordered_map_string_int(){
 
 // [[Rcpp::export]]
 IntegerVector unordered_map_rcpp_string_int(StringVector v){
-    RCPP_UNORDERED_MAP< String, int > m ;
+    std::unordered_map< String, int > m ;
     m[v[0]] = 200;
     m[v[1]] = 100;
     m[v[2]] = 300;
@@ -188,7 +189,7 @@ IntegerVector unordered_map_rcpp_string_int(StringVector v){
 
 // [[Rcpp::export]]
 LogicalVector unordered_set_rcpp_string(StringVector x) {
-    RCPP_UNORDERED_SET<String> seen;
+    std::unordered_set<String> seen;
     LogicalVector out(x.size());
     for (int i = 0; i < x.size(); i++) {
         out[i] = !seen.insert(x[i]).second;
@@ -198,7 +199,7 @@ LogicalVector unordered_set_rcpp_string(StringVector x) {
 
 // [[Rcpp::export]]
 NumericVector unordered_map_string_double(){
-    RCPP_UNORDERED_MAP<std::string,double> m ;
+    std::unordered_map<std::string,double> m ;
     m["b"] = 100;
     m["a"] = 200;
     m["c"] = 300;
@@ -207,7 +208,7 @@ NumericVector unordered_map_string_double(){
 
 // [[Rcpp::export]]
 LogicalVector unordered_map_string_bool(){
-    RCPP_UNORDERED_MAP<std::string,bool> m ;
+    std::unordered_map<std::string,bool> m ;
     m["b"] = true;
     m["a"] = false;
     m["c"] = true;
@@ -216,7 +217,7 @@ LogicalVector unordered_map_string_bool(){
 
 // [[Rcpp::export]]
 RawVector unordered_map_string_Rbyte(){
-    RCPP_UNORDERED_MAP<std::string,Rbyte> m ;
+    std::unordered_map<std::string,Rbyte> m ;
     m["b"] = (Rbyte)0;
     m["a"] = (Rbyte)1;
     m["c"] = (Rbyte)2;
@@ -225,7 +226,7 @@ RawVector unordered_map_string_Rbyte(){
 
 // [[Rcpp::export]]
 CharacterVector unordered_map_string_string(){
-    RCPP_UNORDERED_MAP<std::string,std::string> m ;
+    std::unordered_map<std::string,std::string> m ;
 	m["b"] = "foo" ;
   	m["a"] = "bar" ;
   	m["c"] = "bling" ;
@@ -234,7 +235,7 @@ CharacterVector unordered_map_string_string(){
 
 // [[Rcpp::export]]
 List unordered_map_string_generic(){
-    RCPP_UNORDERED_MAP< std::string,std::vector<int> > m ;
+    std::unordered_map< std::string,std::vector<int> > m ;
     std::vector<int> b; b.push_back(1); b.push_back(2); m["b"] = b ;
     std::vector<int> a; a.push_back(1); a.push_back(2); a.push_back(2); m["a"] = a;
     std::vector<int> c; c.push_back(1); c.push_back(2); c.push_back(2); c.push_back(2); m["c"] = c;


### PR DESCRIPTION
Pretty simple one. Will rebase and mark as ready for review when #1371 is merged.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
