### PR TITLE
Enable lambdas in all sugar functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-03-31  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 2025-03-29 Iñaki Ucar <iucar@fedoraproject.org>
 
 	* inst/include/Rcpp/traits/result_of.h: Reimplement traits::result_of using

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2025-03-29 Iñaki Ucar <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/traits/result_of.h: Reimplement traits::result_of using
+	std::result_of (up to C++14) or std::invoke_result (C++17 or later), which
+	supports previous use cases and enables lambdas
+	* inst/include/Rcpp/sugar/functions/sapply.h: Use new result_of interface
+	* inst/include/Rcpp/sugar/functions/lapply.h: Idem
+	* inst/include/Rcpp/sugar/functions/mapply/mapply_2.h: Idem
+	* inst/include/Rcpp/sugar/functions/mapply/mapply_3.h: Idem
+	* inst/include/Rcpp/sugar/matrix/outer.h: Idem
+	* inst/tinytest/cpp/sugar.cpp: New tests for previous sugar functions
+	* inst/tinytest/test_sugar.R: Idem
+
 2025-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.11
-Date: 2025-03-26
+Version: 1.0.14.12
+Date: 2025-03-31
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,11)
-#define RCPP_DEV_VERSION_STRING "1.0.14.11"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,12)
+#define RCPP_DEV_VERSION_STRING "1.0.14.12"
 
 #endif

--- a/inst/include/Rcpp/sugar/functions/lapply.h
+++ b/inst/include/Rcpp/sugar/functions/lapply.h
@@ -2,7 +2,8 @@
 //
 // lapply.h: Rcpp R/C++ interface class library -- lapply
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -33,7 +34,7 @@ class Lapply : public VectorBase<
 > {
 public:
 	typedef Rcpp::VectorBase<RTYPE,NA,T> VEC ;
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T>::type result_type ;
 
 	Lapply( const VEC& vec_, Function fun_ ) :
 		vec(vec_), fun(fun_){}

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_2.h
@@ -2,7 +2,8 @@
 //
 // mapply_2.h: Rcpp R/C++ interface class library -- mapply_2
 //
-// Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -32,13 +33,13 @@ template <int RTYPE,
 >
 class Mapply_2 : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::traits::result_of<Function>::type
+		typename ::Rcpp::traits::result_of<Function, T_1, T_2>::type
 	>::rtype ,
 	true ,
 	Mapply_2<RTYPE,NA_1,T_1,NA_2,T_2,Function>
 > {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T_1, T_2>::type result_type ;
 
 	Mapply_2( const T_1& vec_1_, const T_2& vec_2_, Function fun_ ) :
 		vec_1(vec_1_), vec_2(vec_2_), fun(fun_){}
@@ -62,14 +63,14 @@ template <int RTYPE,
 class Mapply_2_Vector_Primitive : public
     VectorBase<
 	    Rcpp::traits::r_sexptype_traits<
-	    	typename ::Rcpp::traits::result_of<Function>::type
+	    	typename ::Rcpp::traits::result_of<Function, T_1>::type
 	    >::rtype ,
 	    true ,
 	    Mapply_2_Vector_Primitive<RTYPE,NA_1,T_1,PRIM_2,Function>
     >
 {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T_1>::type result_type ;
 
 	Mapply_2_Vector_Primitive( const T_1& vec_1_, PRIM_2 prim_2_, Function fun_ ) :
 		vec_1(vec_1_), prim_2(prim_2_), fun(fun_){}
@@ -93,14 +94,14 @@ template <int RTYPE,
 class Mapply_2_Primitive_Vector : public
     VectorBase<
 	    Rcpp::traits::r_sexptype_traits<
-	    	typename ::Rcpp::traits::result_of<Function>::type
+	    	typename ::Rcpp::traits::result_of<Function, T_2>::type
 	    >::rtype ,
 	    true ,
 	    Mapply_2_Primitive_Vector<RTYPE,PRIM_1,NA_2,T_2,Function>
     >
 {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T_2>::type result_type ;
 
 	Mapply_2_Primitive_Vector( PRIM_1 prim_1_, const T_2& vec_2_, Function fun_ ) :
 		prim_1(prim_1_), vec_2(vec_2_), fun(fun_){}

--- a/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
+++ b/inst/include/Rcpp/sugar/functions/mapply/mapply_3.h
@@ -2,7 +2,8 @@
 //
 // mapply_3.h: Rcpp R/C++ interface class library -- mapply_3
 //
-// Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -33,13 +34,13 @@ template <
 >
 class Mapply_3 : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::traits::result_of<Function>::type
+		typename ::Rcpp::traits::result_of<Function, T_1, T_2, T_3>::type
 	>::rtype ,
 	true ,
 	Mapply_3<RTYPE_1,NA_1,T_1,RTYPE_2,NA_2,T_2,RTYPE_3,NA_3,T_3,Function>
 > {
 public:
-	typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T_1, T_2, T_3>::type result_type ;
 
     typedef Rcpp::VectorBase<RTYPE_1,NA_1,T_1> VEC_1 ;
 	typedef Rcpp::VectorBase<RTYPE_2,NA_2,T_2> VEC_2 ;

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -22,9 +22,6 @@
 #ifndef Rcpp__sugar__sapply_h
 #define Rcpp__sugar__sapply_h
 
-// This used to be conditional on a define and test in compiler.h
-#include <type_traits> // ::std::result_of
-
 namespace Rcpp{
 namespace sugar{
 

--- a/inst/include/Rcpp/sugar/functions/sapply.h
+++ b/inst/include/Rcpp/sugar/functions/sapply.h
@@ -1,7 +1,8 @@
 
 // sapply.h: Rcpp R/C++ interface class library -- sapply
 //
-// Copyright (C) 2010 - 2023 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -27,36 +28,16 @@
 namespace Rcpp{
 namespace sugar{
 
-template <typename Function, typename SugarExpression>
-struct sapply_application_result_of
-{
-#if __cplusplus >= 201103L
-    #if __cplusplus < 201703L
-        // deprecated by C++17, removed by C++2020, see https://en.cppreference.com/w/cpp/types/result_of
- 	    typedef typename ::std::result_of<Function(typename SugarExpression::stored_type)>::type type;
-    #else
-        // since C++17, see https://en.cppreference.com/w/cpp/types/result_of
-        typedef typename ::std::invoke_result<Function, typename SugarExpression::stored_type>::type type;
-    #endif
-#else
-    // TODO this else branch can likely go
-	typedef typename ::Rcpp::traits::result_of<Function>::type type;
-#endif
-};
-
-// template <typename Function, typename SugarExpression>
-// using sapply_application_result_of_t = typename sapply_application_result_of<Function, SugarExpression>::type;
-
 template <int RTYPE, bool NA, typename T, typename Function, bool NO_CONVERSION>
 class Sapply : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type
+		typename ::Rcpp::traits::result_of<Function, T>::type
 	>::rtype ,
 	true ,
 	Sapply<RTYPE,NA,T,Function,NO_CONVERSION>
 > {
 public:
-	typedef typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T>::type result_type ;
 	const static int RESULT_R_TYPE =
 		Rcpp::traits::r_sexptype_traits<result_type>::rtype ;
 
@@ -87,13 +68,13 @@ private:
 template <int RTYPE, bool NA, typename T, typename Function>
 class Sapply<RTYPE,NA,T,Function,true> : public VectorBase<
 	Rcpp::traits::r_sexptype_traits<
-		typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type
+		typename ::Rcpp::traits::result_of<Function, T>::type
 	>::rtype ,
 	true ,
 	Sapply<RTYPE,NA,T,Function,true>
 > {
 public:
-	typedef typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type result_type ;
+	typedef typename ::Rcpp::traits::result_of<Function, T>::type result_type ;
 	const static int RESULT_R_TYPE =
 		Rcpp::traits::r_sexptype_traits<result_type>::rtype ;
 
@@ -124,15 +105,15 @@ template <int RTYPE, bool NA, typename T, typename Function >
 inline sugar::Sapply<
     RTYPE,NA,T,Function,
     traits::same_type<
-        typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type ,
-        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type >::rtype >::type
+        typename ::Rcpp::traits::result_of<Function, T>::type ,
+        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::traits::result_of<Function, T>::type >::rtype >::type
     >::value
 >
 sapply( const Rcpp::VectorBase<RTYPE,NA,T>& t, Function fun ){
 	return sugar::Sapply<RTYPE,NA,T,Function,
 	traits::same_type<
-        typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type ,
-        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::sugar::sapply_application_result_of<Function, T>::type >::rtype >::type
+        typename ::Rcpp::traits::result_of<Function, T>::type ,
+        typename Rcpp::traits::storage_type< traits::r_sexptype_traits< typename ::Rcpp::traits::result_of<Function, T>::type >::rtype >::type
     >::value >( t, fun ) ;
 }
 

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -2,7 +2,8 @@
 //
 // outer.h: Rcpp R/C++ interface class library -- outer
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -31,13 +32,13 @@ template <int RTYPE,
           typename Function >
 class Outer : public MatrixBase<
     Rcpp::traits::r_sexptype_traits<
-        typename ::Rcpp::traits::result_of<Function>::type
+        typename ::Rcpp::traits::result_of<Function, LHS_T, RHS_T>::type
 	>::rtype ,
             true ,
     Outer<RTYPE,LHS_NA,LHS_T,RHS_NA,RHS_T,Function>
 > {
 public:
-    typedef typename ::Rcpp::traits::result_of<Function>::type result_type ;
+    typedef typename ::Rcpp::traits::result_of<Function, LHS_T, RHS_T>::type result_type ;
     const static int RESULT_R_TYPE =
         Rcpp::traits::r_sexptype_traits<result_type>::rtype ;
 

--- a/inst/include/Rcpp/traits/result_of.h
+++ b/inst/include/Rcpp/traits/result_of.h
@@ -40,12 +40,7 @@ struct result_of{
 
 template <typename T>
 struct result_of<T>{
-    typename T::result_type type ;
-} ;
-
-template <typename RESULT_TYPE, typename... Args>
-struct result_of< RESULT_TYPE (*)(Args...) >{
-    typedef RESULT_TYPE type ;
+    typedef typename T::result_type type ;
 } ;
 
 }

--- a/inst/include/Rcpp/traits/result_of.h
+++ b/inst/include/Rcpp/traits/result_of.h
@@ -4,7 +4,7 @@
 // result_of.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
 // Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois, Iñaki Ucar
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/traits/result_of.h
+++ b/inst/include/Rcpp/traits/result_of.h
@@ -3,7 +3,8 @@
 //
 // result_of.h: Rcpp R/C++ interface class library -- traits to help wrap
 //
-// Copyright (C) 2010 - 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2024 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois, Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -26,24 +27,20 @@
 namespace Rcpp{
 namespace traits{
 
-template <typename T>
+template <typename T, typename... Args>
 struct result_of{
-	typedef typename T::result_type type ;
+#if __cplusplus < 201703L
+    // deprecated by C++17, removed by C++2020, see https://en.cppreference.com/w/cpp/types/result_of
+    typedef typename ::std::result_of<T(typename Args::stored_type...)>::type type;
+#else
+    // since C++17, see https://en.cppreference.com/w/cpp/types/result_of
+    typedef typename ::std::invoke_result<T, typename Args::stored_type...>::type type;
+#endif
 } ;
 
-template <typename RESULT_TYPE, typename INPUT_TYPE>
-struct result_of< RESULT_TYPE (*)(INPUT_TYPE) >{
-	typedef RESULT_TYPE type ;
-} ;
-
-template <typename RESULT_TYPE, typename U1, typename U2>
-struct result_of< RESULT_TYPE (*)(U1, U2) >{
-	typedef RESULT_TYPE type ;
-} ;
-
-template <typename RESULT_TYPE, typename U1, typename U2, typename U3>
-struct result_of< RESULT_TYPE (*)(U1, U2, U3) >{
-	typedef RESULT_TYPE type ;
+template <typename T>
+struct result_of<T>{
+    typename T::result_type type ;
 } ;
 
 }

--- a/inst/include/Rcpp/traits/result_of.h
+++ b/inst/include/Rcpp/traits/result_of.h
@@ -43,6 +43,11 @@ struct result_of<T>{
     typename T::result_type type ;
 } ;
 
+template <typename RESULT_TYPE, typename... Args>
+struct result_of< RESULT_TYPE (*)(Args...) >{
+    typedef RESULT_TYPE type ;
+} ;
+
 }
 }
 

--- a/inst/tinytest/cpp/sugar.cpp
+++ b/inst/tinytest/cpp/sugar.cpp
@@ -2,6 +2,7 @@
 // sugar.cpp: Rcpp R/C++ interface class library -- sugar unit tests
 //
 // Copyright (C) 2012 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -22,7 +23,6 @@
 using namespace Rcpp ;
 
 template <typename T>
-
 class square : public std::function<T(T)> {
 public:
 	T operator()( T t) const { return t*t ; }
@@ -222,8 +222,55 @@ NumericVector runit_na_omit( NumericVector xx ){
 }
 
 // [[Rcpp::export]]
-List runit_lapply( IntegerVector xx){
+List runit_lapply( NumericVector xx ){
+    List res = lapply( xx, square<double>() );
+    return res ;
+}
+
+// [[Rcpp::export]]
+List runit_lapply_rawfun( NumericVector xx){
+    List res = lapply( xx, raw_square );
+    return res ;
+}
+
+// [[Rcpp::export]]
+List runit_lapply_lambda(NumericVector xx){
+    List res = lapply(xx, [](double x) { return x*x; });
+    return res;
+}
+
+// [[Rcpp::export]]
+List runit_lapply_seq( IntegerVector xx){
     List res = lapply( xx, seq_len );
+    return res ;
+}
+
+// [[Rcpp::export]]
+NumericVector runit_mapply2(NumericVector xx, NumericVector yy){
+    NumericVector res = mapply(xx, yy, std::plus<double>());
+    return res;
+}
+
+// [[Rcpp::export]]
+NumericVector runit_mapply2_lambda(NumericVector xx, NumericVector yy){
+    NumericVector res = mapply(xx, yy, [](double x, double y) { return x+y; });
+    return res;
+}
+
+// [[Rcpp::export]]
+NumericVector runit_mapply3_lambda(NumericVector xx, NumericVector yy, NumericVector zz){
+    NumericVector res = mapply(xx, yy, zz, [](double x, double y, double z) { return x+y+z; });
+    return res;
+}
+
+// [[Rcpp::export]]
+LogicalVector runit_mapply2_logical(NumericVector xx, NumericVector yy){
+    return all(mapply(xx, yy, std::plus<double>()) < 100.0);
+}
+
+// [[Rcpp::export]]
+List runit_mapply2_list(IntegerVector xx, IntegerVector yy){
+    List res = mapply(xx, yy, seq);
     return res ;
 }
 
@@ -325,6 +372,12 @@ NumericVector runit_sapply( NumericVector xx ){
 NumericVector runit_sapply_rawfun( NumericVector xx){
     NumericVector res = sapply( xx, raw_square );
     return res ;
+}
+
+// [[Rcpp::export]]
+NumericVector runit_sapply_lambda(NumericVector xx){
+    NumericVector res = sapply(xx, [](double x) { return x*x; });
+    return res;
 }
 
 // [[Rcpp::export]]
@@ -441,6 +494,12 @@ IntegerVector runit_rev( IntegerVector xx ){
 // [[Rcpp::export]]
 NumericMatrix runit_outer( NumericVector xx, NumericVector yy){
     NumericMatrix m = outer( xx, yy, std::plus<double>() ) ;
+    return m ;
+}
+
+// [[Rcpp::export]]
+NumericMatrix runit_outer_lambda(NumericVector xx, NumericVector yy){
+    NumericMatrix m = outer(xx, yy, [](double x, double y) { return x + y; });
     return m ;
 }
 

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -1,5 +1,6 @@
 
-##  Copyright (C) 2010 - 2023  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2010 - 2024  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 ##
 ##  This file is part of Rcpp.
 ##
@@ -302,7 +303,47 @@ expect_equal( fx( c(1:10) ), fx( c(1:10) ) )
 
 #    test.sugar.lapply <- function( ){
 fx <- runit_lapply
+expect_equal( fx( 1:10 ), as.list((1:10)^2) )
+
+
+#    test.sugar.lapply.rawfun <- function( ){
+fx <- runit_lapply_rawfun
+expect_equal( fx( 1:10 ), as.list((1:10)^2) )
+
+
+#    test.sugar.lapply.lambda <- function( ){
+fx <- runit_lapply_lambda
+expect_equal( fx( 1:10 ), as.list((1:10)^2) )
+
+
+#    test.sugar.lapply.seq <- function( ){
+fx <- runit_lapply_seq
 expect_equal( fx( 1:10 ), lapply( 1:10, seq_len ) )
+
+
+#    test.sugar.mapply2 <- function( ){
+fx <- runit_mapply2
+expect_equal( fx(1:10, 1:10) , 1:10+1:10 )
+
+
+#    test.sugar.mapply2.lambda <- function( ){
+fx <- runit_mapply2_lambda
+expect_equal( fx(1:10, 1:10) , 1:10+1:10 )
+
+
+#    test.sugar.mapply3.lambda <- function( ){
+fx <- runit_mapply3_lambda
+expect_equal( fx(1:10, 1:10, 1:10) , 1:10+1:10+1:10 )
+
+
+#    test.sugar.mapply2.logical <- function( ){
+fx <- runit_mapply2_logical
+expect_true( fx(1:10, 1:10)  )
+
+
+#    test.sugar.mapply2.list <- function( ){
+fx <- runit_mapply2_list
+expect_equal( fx(1:10, 1:10*2) , mapply(seq, 1:10, 1:10*2) )
 
 
 #    test.sugar.minus <- function( ){
@@ -377,6 +418,11 @@ expect_equal( fx(1:10) , (1:10)^2 )
 
 #    test.sugar.sapply.rawfun <- function( ){
 fx <- runit_sapply_rawfun
+expect_equal( fx(1:10) , (1:10)^2 )
+
+
+#    test.sugar.sapply.lambda <- function( ){
+fx <- runit_sapply_lambda
 expect_equal( fx(1:10) , (1:10)^2 )
 
 
@@ -487,6 +533,13 @@ expect_equal(fx(1:100), list( pos = 96:100, neg = 6:100 ))
 
 #    test.sugar.matrix.outer <- function( ){
 fx <- runit_outer
+x <- 1:2
+y <- 1:5
+expect_equal( fx(x,y) , outer(x,y,"+") )
+
+
+#    test.sugar.matrix.outer.lambda <- function( ){
+fx <- runit_outer_lambda
 x <- 1:2
 y <- 1:5
 expect_equal( fx(x,y) , outer(x,y,"+") )


### PR DESCRIPTION
Part of #1365, as discussed in #1370. Takes the idea in #296 that enabled lambdas for sapply, and generalizes it as a variadic `result_of` that now is applied to lapply, mapply and outer too, enabling lambdas for them too.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
