### PR TITLE
Accommodate NA behavior on arm64/aarch64 for Linux as well

### DIFF
--- a/.github/workflows/linuxarm.yaml
+++ b/.github/workflows/linuxarm.yaml
@@ -1,10 +1,11 @@
 # Run CI for R using https://eddelbuettel.github.io/r-ci/
 
-name: macos
+name: linuxarm
 
 on:
-  push:
-  pull_request:
+  #push:
+  #pull_request:
+  workflow_dispatch:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
@@ -14,10 +15,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - {os: macos-latest}
-          - {os: macos-13}
           #- {os: ubuntu-latest}
-          #- {os: ubuntu-24.04-arm}
+          - {os: ubuntu-24.04-arm}
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master
 
+      - name: Sys.info
+        run: Rscript -e 'print(Sys.info()); print(.Platform)'
+
       - name: Dependencies
         run: ./run.sh install_deps
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master
 
-      - name: Sys.info
-        run: Rscript -e 'print(Sys.info()); print(.Platform)'
-
       - name: Dependencies
         run: ./run.sh install_deps
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -17,6 +17,7 @@ jobs:
           - {os: macos-latest}
           - {os: macos-13}
           #- {os: ubuntu-latest}
+          - {os: ubuntu-24.04-arm}
 
     runs-on: ${{ matrix.os }}
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,8 @@
 	* inst/tinytest/test_sugar.R: Condition four NA-related tests away on
 	arm64 on Linux too
 
-	* .github/workflows/macos.yaml (jobs): Add ubuntu-24.04-arm to matrix
+	* .github/workflows/linuxarm.yaml (jobs): Add ubuntu-24.04-arm as
+	optional workflow_dispatch run
 
 2025-04-15  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-05-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_sugar.R: Condition four NA-related tests away on
+	arm64 on Linux too
+
+	* .github/workflows/macos.yaml (jobs): Add ubuntu-24.04-arm to matrix
+
 2025-04-15  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/ci-4.4/Dockerfile: Added based on r-base:4.4.3

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -33,6 +33,8 @@
     \itemize{
       \item \code{Rcpp.package.skeleton()} creates \sQuote{URL} and
       \sQuote{BugReports} if given a GitHub username (Dirk in \ghpr{1358})
+      \item Tests involving NA propagation are skipped under linux-arm64 as
+      they are under macos-arm (Dirk in \ghpr{1379} closing \ghit{1378})
     }
   }
 }

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -24,8 +24,8 @@ Rcpp::sourceCpp("cpp/sugar.cpp")
 ## There are some (documented, see https://blog.r-project.org/2020/11/02/will-r-work-on-apple-silicon/index.html)
 ## issues with NA propagation on arm64 / macOS. We not (yet ?) do anything special so we just skip some tests
 isArmMacOs <- Sys.info()[["sysname"]] == "Darwin" && Sys.info()[["machine"]] == "arm64"
-## This also seems to hit arm64 on Linux
-isArmLinux <- Sys.info()[["sysname"]] == "Linux" && Sys.info()[["machine"]] == "arm64"
+## This also seems to hit arm64 on Linux (aka 'aarch64' here)
+isArmLinux <- Sys.info()[["sysname"]] == "Linux" && Sys.info()[["machine"]] == "aarch64"
 
 ## Needed for a change in R 3.6.0 reducing a bias in very large samples
 suppressWarnings(RNGversion("3.5.0"))

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2010 - 2024  Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
 ##  Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 ##
 ##  This file is part of Rcpp.
@@ -24,6 +24,8 @@ Rcpp::sourceCpp("cpp/sugar.cpp")
 ## There are some (documented, see https://blog.r-project.org/2020/11/02/will-r-work-on-apple-silicon/index.html)
 ## issues with NA propagation on arm64 / macOS. We not (yet ?) do anything special so we just skip some tests
 isArmMacOs <- Sys.info()[["sysname"]] == "Darwin" && Sys.info()[["machine"]] == "arm64"
+## This also seems to hit arm64 on Linux
+isArmLinux <- Sys.info()[["sysname"]] == "Linux" && Sys.info()[["machine"]] == "arm64"
 
 ## Needed for a change in R 3.6.0 reducing a bias in very large samples
 suppressWarnings(RNGversion("3.5.0"))
@@ -66,7 +68,7 @@ expect_true( ! fx( 1:10 ) )
 expect_true( fx( 6:10 ) )
 expect_true( fx( 5 ) )
 expect_true( ! fx( c(NA, 1) ) )
-if (!isArmMacOs) expect_true( is.na( fx( c(NA, 6) ) ) )
+if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(NA, 6) ) ) )
 
 
 #    test.sugar.all.one.equal <- function( ){
@@ -74,7 +76,7 @@ fx <- runit_all_one_equal
 expect_true( ! fx( 1 ) )
 expect_true( ! fx( 1:2 ) )
 expect_true( fx( rep(5,4) ) )
-if (!isArmMacOs) expect_true( is.na( fx( c(5,NA) ) ) )
+if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(5,NA) ) ) )
 expect_true(! fx( c(NA, 1) ) )
 
 
@@ -83,7 +85,7 @@ fx <- runit_all_not_equal_one
 expect_true( fx( 1 ) )
 expect_true( fx( 1:2 ) )
 expect_true( ! fx( 5 ) )
-if (!isArmMacOs) expect_true( is.na( fx( c(NA, 1) ) ) )
+if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(NA, 1) ) ) )
 expect_true( ! fx( c(NA, 5) ) )
 
 
@@ -1620,7 +1622,7 @@ expect_error(strimws(x[1], "invalid"), info = "strimws -- bad `which` argument")
 ## min/max
 #    test.sugar.min.max <- function() {
 ## min(empty) gives NA for integer, Inf for numeric (#844)
-if (!isArmMacOs) expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
+if (!isArmMacOs && !isArmLinux) expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
 if (!isArmMacOs) expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
 
 ## max(empty_ gives NA for integer, Inf for numeric (#844)

--- a/inst/tinytest/test_sugar.R
+++ b/inst/tinytest/test_sugar.R
@@ -23,9 +23,8 @@ Rcpp::sourceCpp("cpp/sugar.cpp")
 
 ## There are some (documented, see https://blog.r-project.org/2020/11/02/will-r-work-on-apple-silicon/index.html)
 ## issues with NA propagation on arm64 / macOS. We not (yet ?) do anything special so we just skip some tests
-isArmMacOs <- Sys.info()[["sysname"]] == "Darwin" && Sys.info()[["machine"]] == "arm64"
 ## This also seems to hit arm64 on Linux (aka 'aarch64' here)
-isArmLinux <- Sys.info()[["sysname"]] == "Linux" && Sys.info()[["machine"]] == "aarch64"
+isArm <- Sys.info()[["machine"]] == "arm64" || Sys.info()[["machine"]] == "aarch64"
 
 ## Needed for a change in R 3.6.0 reducing a bias in very large samples
 suppressWarnings(RNGversion("3.5.0"))
@@ -38,8 +37,8 @@ expect_equal( runit_abs(x,y) , list( abs(x), abs(y) ) )
 #    test.sugar.all.one.less <- function( ){
 expect_true( runit_all_one_less( 1 ) )
 expect_true( ! runit_all_one_less( 1:10 ) )
-if (!isArmMacOs) expect_true( is.na( runit_all_one_less( NA ) ) )
-if (!isArmMacOs) expect_true( is.na( runit_all_one_less( c( NA, 1)  ) ) )
+if (!isArm) expect_true( is.na( runit_all_one_less( NA ) ) )
+if (!isArm) expect_true( is.na( runit_all_one_less( c( NA, 1)  ) ) )
 expect_true( ! runit_all_one_less( c( 6, NA)  ) )
 
 
@@ -48,14 +47,14 @@ expect_true( ! runit_all_one_greater( 1 ) )
 expect_true( ! runit_all_one_greater( 1:10 ) )
 expect_true( runit_all_one_greater( 6:10 ) )
 expect_true( ! runit_all_one_greater( c(NA, 1) ) )
-if (!isArmMacOs) expect_true( is.na( runit_all_one_greater( c(NA, 6) ) ) )
+if (!isArm) expect_true( is.na( runit_all_one_greater( c(NA, 6) ) ) )
 
 
 #    test.sugar.all.one.less.or.equal <- function( ){
 expect_true( runit_all_one_less_or_equal( 1 ) )
 expect_true( ! runit_all_one_less_or_equal( 1:10 ) )
-if (!isArmMacOs) expect_true( is.na( runit_all_one_less_or_equal( NA ) ) )
-if (!isArmMacOs) expect_true( is.na( runit_all_one_less_or_equal( c( NA, 1)  ) ) )
+if (!isArm) expect_true( is.na( runit_all_one_less_or_equal( NA ) ) )
+if (!isArm) expect_true( is.na( runit_all_one_less_or_equal( c( NA, 1)  ) ) )
 expect_true( ! runit_all_one_less_or_equal( c( 6, NA)  ) )
 expect_true( runit_all_one_less_or_equal( 5 ) )
 
@@ -68,7 +67,7 @@ expect_true( ! fx( 1:10 ) )
 expect_true( fx( 6:10 ) )
 expect_true( fx( 5 ) )
 expect_true( ! fx( c(NA, 1) ) )
-if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(NA, 6) ) ) )
+if (!isArm) expect_true( is.na( fx( c(NA, 6) ) ) )
 
 
 #    test.sugar.all.one.equal <- function( ){
@@ -76,7 +75,7 @@ fx <- runit_all_one_equal
 expect_true( ! fx( 1 ) )
 expect_true( ! fx( 1:2 ) )
 expect_true( fx( rep(5,4) ) )
-if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(5,NA) ) ) )
+if (!isArm) expect_true( is.na( fx( c(5,NA) ) ) )
 expect_true(! fx( c(NA, 1) ) )
 
 
@@ -85,7 +84,7 @@ fx <- runit_all_not_equal_one
 expect_true( fx( 1 ) )
 expect_true( fx( 1:2 ) )
 expect_true( ! fx( 5 ) )
-if (!isArmMacOs && !isArmLinux) expect_true( is.na( fx( c(NA, 1) ) ) )
+if (!isArm) expect_true( is.na( fx( c(NA, 1) ) ) )
 expect_true( ! fx( c(NA, 5) ) )
 
 
@@ -1622,8 +1621,8 @@ expect_error(strimws(x[1], "invalid"), info = "strimws -- bad `which` argument")
 ## min/max
 #    test.sugar.min.max <- function() {
 ## min(empty) gives NA for integer, Inf for numeric (#844)
-if (!isArmMacOs && !isArmLinux) expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
-if (!isArmMacOs) expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
+if (!isArm) expect_true(is.na(intmin(integer(0))),    "min(integer(0))")
+if (!isArm) expect_equal(doublemin(numeric(0)), Inf, info = "min(numeric(0))")
 
 ## max(empty_ gives NA for integer, Inf for numeric (#844)
 expect_true(is.na(intmax(integer(0))),     "max(integer(0))")


### PR DESCRIPTION
Fixes #1378

The linux-on-arm platform is still reasonably rare and hence not one that CRAN tests for, by r-universe now does and this revealed that the same 'NA does not propagate well' issue we accommodate for macos-on-arm already.  This PR simply extends that treatmeant.

A new CI run has been added for linux-arm, it is by far the slowest so one open question is whether we should keep it for all runs.  Maybe a simpler approach is to take it out of the matrix it is currently in but submit a new yaml file with just the 'workflow_dispatch' option so that we dial in when we want to.  Thoughts?

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
