### PR TITLE
Support C++26 via plugin (closes #1380)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-05-06  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 	* R/Attributes.R: Support C++26 via plugin
 
 2025-05-05  Dirk Eddelbuettel  <edd@debian.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-05-06  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/Attributes.R: Support C++26 via plugin
+
 2025-05-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_sugar.R: Condition four NA-related tests away on

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.0.14.12
-Date: 2025-03-31
+Version: 1.0.14.13
+Date: 2025-05-06
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/R/Attributes.R
+++ b/R/Attributes.R
@@ -560,6 +560,13 @@ compileAttributes <- function(pkgdir = ".", verbose = getOption("verbose")) {
         list(env = list(PKG_CXXFLAGS ="-std=c++23"))
 }
 
+# built-in C++26 plugin for C++26
+.plugins[["cpp26"]] <- function() {
+    if (getRversion() >= "4.5")         # with recent R versions, R can decide
+        list(env = list(USE_CXX26 = "yes"))
+    else
+        list(env = list(PKG_CXXFLAGS ="-std=c++26"))
+}
 
 ## built-in C++1z plugin for C++17 standard under development
 ## note that as of Feb 2017 this is taken to be a moving target

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -30,7 +30,7 @@
 #define RCPP_VERSION_STRING     "1.0.14"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,12)
-#define RCPP_DEV_VERSION_STRING "1.0.14.12"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,0,14,13)
+#define RCPP_DEV_VERSION_STRING "1.0.14.13"
 
 #endif


### PR DESCRIPTION
New R version support C++26.  My R 4.5.0 installation has it in its `Makeconf`, albeit empty (as supposefly the compiler iot met at configure time for this binary was too old).  My local R-devel installation has it, and works with what is proposed here (using `g++-14`).   Also rolled the micro version as we commonly do to mark small changes such as this and the preceding PR.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
