### PR TITLE
Add DateVector and DatetimeVector default ctors (closes #1384)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-05-23  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/date_datetime/newDateVector.h: Add default
+	constructor
+	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
+
 2025-05-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 	constructor
 	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
 
+	* inst/tinytest/test_date.R: Add tests
+	* inst/tinytest/cpp/dates.cpp: Idem
+
 2025-05-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/date_datetime/newDateVector.h
+++ b/inst/include/Rcpp/date_datetime/newDateVector.h
@@ -2,7 +2,7 @@
 //
 // newDateVector.h: Rcpp R/C++ interface class library -- Date vector support
 //
-// Copyright (C) 2016         Dirk Eddelbuettel
+// Copyright (C) 2016 - 2025  Dirk Eddelbuettel
 //
 // This file is part of Rcpp.
 //
@@ -28,6 +28,10 @@ namespace Rcpp {
 
     class newDateVector : public NumericVector {
     public:
+        newDateVector() : NumericVector() {
+            setClass();
+        }
+
         template <int RTYPE, bool NA, typename VEC>
         newDateVector(const VectorBase<RTYPE,NA,VEC>& vec) : NumericVector(vec) {
             setClass();

--- a/inst/include/Rcpp/date_datetime/newDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/newDatetimeVector.h
@@ -28,10 +28,14 @@ namespace Rcpp {
 
     class newDatetimeVector : public NumericVector {
     public:
+        newDatetimeVector(const char* tz = "") : NumericVector() {
+            setClass(tz);
+        }
+
         template <int RTYPE, bool NA, typename VEC>
         newDatetimeVector(const VectorBase<RTYPE,NA,VEC>& other, const char* tz = "") :
             NumericVector(other) {
-            setClass(tz); 
+            setClass(tz);
         }
 
         newDatetimeVector(SEXP vec, const char* tz = "") :

--- a/inst/tinytest/cpp/dates.cpp
+++ b/inst/tinytest/cpp/dates.cpp
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // dates.cpp: Rcpp R/C++ interface class library -- Date + Datetime tests
 //
-// Copyright (C) 2010 - 2013   Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025   Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -245,4 +244,12 @@ bool has_na_dtv(const Rcpp::DatetimeVector d) {
     return Rcpp::is_true(Rcpp::any(Rcpp::is_na(d)));
 }
 
+// [[Rcpp::export]]
+Rcpp::DateVector default_ctor_datevector() {
+    return Rcpp::DateVector();
+}
 
+// [[Rcpp::export]]
+Rcpp::DatetimeVector default_ctor_datetimevector() {
+    return Rcpp::DatetimeVector();
+}

--- a/inst/tinytest/test_date.R
+++ b/inst/tinytest/test_date.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2010 - 2019   Dirk Eddelbuettel and Romain Francois
+##  Copyright (C) 2010 - 2025   Dirk Eddelbuettel and Romain Francois
 ##
 ##  This file is part of Rcpp.
 ##
@@ -241,3 +241,15 @@ dvt <- Sys.time() + 0:2
 expect_true(has_na_dtv(dvt) == FALSE, info="DatetimeVector.NAtest.withoutNA")
 dvt[1] <- NA
 expect_true(has_na_dtv(dvt) == TRUE, info="DatetimeVector.NAtest.withNA")
+
+## default ctor: date
+dv <- default_ctor_datevector()
+expect_true(inherits(dv, "Date"))
+expect_equal(length(dv), 0L)
+expect_equal(dv, as.Date(double()))
+
+## default ctor: datetime
+dtv <- default_ctor_datetimevector()
+expect_true(inherits(dtv, "POSIXct"))
+expect_equal(length(dtv), 0L)
+expect_equal(dtv, as.POSIXct(double(), origin="1970-01-01"))  # origin for R < 4.3.0

--- a/inst/tinytest/test_date.R
+++ b/inst/tinytest/test_date.R
@@ -246,7 +246,7 @@ expect_true(has_na_dtv(dvt) == TRUE, info="DatetimeVector.NAtest.withNA")
 dv <- default_ctor_datevector()
 expect_true(inherits(dv, "Date"))
 expect_equal(length(dv), 0L)
-expect_equal(dv, as.Date(double()))
+expect_equal(dv, as.Date(double(), origin="1970-01-01")) # origin for R < 4.3.0
 
 ## default ctor: datetime
 dtv <- default_ctor_datetimevector()


### PR DESCRIPTION
As discussed in #1384 these were omitted in earlier implementations, mostly due to sloppy thinking and a bias towards the data(time) in `std::vector`  use seen in another library that was interfaced at the very (very !!) beginning of Rcpp.   But that is simply not the R way of things, and while we did on pass over this (when the then `newDate*Vector` classes were added we still did not add empty constructors.  Which I now use more often for base types (think `integer()` etc) so we should have something like that here too.  

The PR itself is pretty minimal and just adds these new ctors, does not alter existing interfaces, and adds a handful of test predicates.

A complete reverse-dependency check is running but it will (as usual) be a good moment before it is done.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
