### PR TITLE
Avoid a narrowing warning via explicit cast

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-09-04  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
 	* inst/include/Rcpp/internal/wrap.h (make_charsexp__impl__cstring):
 	Avoid a narrowing warning by casting explicitly
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-09-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/internal/wrap.h (make_charsexp__impl__cstring):
+	Avoid a narrowing warning by casting explicitly
+
 2025-08-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/tinytest/test_sugar.R: For r-devel, use apply(x, DIM, mean,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.1.0.2
-Date: 2025-07-20
+Version: 1.1.0.3
+Date: 2025-09-04
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -5,10 +5,17 @@
 
 \section{Changes in Rcpp release version 1.1.1 (2026-01-xx)}{
   \itemize{
+    \item Changes in Rcpp API:
+    \itemize{
+      \item An unused old R function for a compiler version check has been
+      removed after checking no known package uses it (Dirk in \ghpr{1395})
+      \item A narrowing warning is avoided via a cast (Dirk in \ghpr{1398})
+    }
     \item Changes in Rcpp Documentation:
     \itemize{
       \item Vignettes are now processed via a new "asis" processor adopted
       from \pkg{R.rsp} (Dirk in \ghpr{1394} fixing \ghit{1393})
+      \item R is now cited via its DOI (Dirk)
     }
   }
 }

--- a/inst/include/Rcpp/config.h
+++ b/inst/include/Rcpp/config.h
@@ -31,7 +31,7 @@
 #define RCPP_VERSION_STRING     "1.1.0"
 
 // the current source snapshot (using four components, if a fifth is used in DESCRIPTION we ignore it)
-#define RCPP_DEV_VERSION        RcppDevVersion(1,1,0,2)
-#define RCPP_DEV_VERSION_STRING "1.1.0.2"
+#define RCPP_DEV_VERSION        RcppDevVersion(1,1,0,3)
+#define RCPP_DEV_VERSION_STRING "1.1.0.3"
 
 #endif

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -68,7 +68,7 @@ namespace Rcpp {
 
 #if __cplusplus >= 201703L
         inline SEXP make_charsexp__impl__cstring(std::string_view st) {
-            return Rf_mkCharLen(st.data(), st.size());
+            return Rf_mkCharLen(st.data(), static_cast<int>(st.size()));
         }
 #endif
 


### PR DESCRIPTION
Brian Ripley runs his M1mac checks under `clnag++` with options `-Wall -pedantic -Wconversion -Wno-sign-conversion` and this throws up some narrowing warnings.  This minimal PR suppresses one where C++ `size()` returns `long int` and R wants an `int`.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
