### PR TITLE
Simplify demangling checks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-10-21 Iñaki Ucar <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/exceptions_impl.h: use __has_include to simplify checks
+	to enable demangling, making them robust for more platforms
+
 2025-10-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/exceptions_impl.h
+++ b/inst/include/Rcpp/exceptions_impl.h
@@ -1,7 +1,8 @@
 // exceptions_impl.h: Rcpp R/C++ interface class library -- exceptions
 //
 // Copyright (C) 2012 - 2019  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2020         Dirk Eddelbuettel, Romain Francois, and Joshua N. Pritikin
+// Copyright (C) 2020 - 2024  Dirk Eddelbuettel, Romain Francois, and Joshua N. Pritikin
+// Copyright (C) 2025         Dirk Eddelbuettel, Romain Francois, Joshua N. Pritikin, and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -21,25 +22,15 @@
 #ifndef Rcpp__exceptions_impl__h
 #define Rcpp__exceptions_impl__h
 
-// disable demangler on platforms where we have no support
+// enable demangler on platforms where execinfo.h is present
 #ifndef RCPP_DEMANGLER_ENABLED
-# if defined(_WIN32)       || \
-    defined(__FreeBSD__)   || \
-    defined(__NetBSD__)    || \
-    defined(__OpenBSD__)   || \
-    defined(__DragonFly__) || \
-    defined(__CYGWIN__)    || \
-    defined(__sun)         || \
-    defined(_AIX)          || \
-    defined(__MUSL__)      || \
-    defined(__HAIKU__)     || \
-    defined(__ANDROID__)
-#  define RCPP_DEMANGLER_ENABLED 0
-# elif defined(__GNUC__)  || defined(__clang__)
-#  include <execinfo.h>
-#  define RCPP_DEMANGLER_ENABLED 1
-# else
-#  define RCPP_DEMANGLER_ENABLED 0
+# define RCPP_DEMANGLER_ENABLED 0
+# if defined __has_include
+#  if __has_include (<execinfo.h>)
+#   include <execinfo.h>
+#   undef RCPP_DEMANGLER_ENABLED
+#   define RCPP_DEMANGLER_ENABLED 1
+#  endif
 # endif
 #endif
 


### PR DESCRIPTION
Closes #1400. As discussed there, _technically_ `__has_include` was introduced in C++17, but in practice, being a preprocessor macro, compilers define it regardless of the standard set (tested locally with gcc and clang). Also, checking whether `__has_include` is defined first is safer as [recommended by gcc](https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html).

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
