### PR TITLE
Mask definition of Rf_error to avoid longjmp issues

### DIFF
--- a/inst/include/Rcpp/macros/mask.h
+++ b/inst/include/Rcpp/macros/mask.h
@@ -21,15 +21,13 @@
 #define Rcpp_macros_mask_h
 
 #ifndef RCPP_NO_MASK_RF_ERROR
-#ifdef RCPP_MASK_RF_ERROR
 #define Rf_error(...) \
-    _Pragma("GCC warning \"Use of Rf_error() instead of Rcpp::stop(). Calls \
+    _Pragma("GCC error \"Use of Rf_error() instead of Rcpp::stop(). Calls \
 to Rf_error() in C++ contexts are unsafe: consider using Rcpp::stop() instead, \
 or define RCPP_NO_MASK_RF_ERROR if this is a false positive. More info:\n\
  - https://github.com/RcppCore/Rcpp/issues/1247\n\
  - https://github.com/RcppCore/Rcpp/pull/1402\"") \
     Rf_error(__VA_ARGS__)
-#endif
 #endif
 
 #endif


### PR DESCRIPTION
Closes #1247. It turns out we are generating a call to `Rf_error` in `RcppExports.cpp` for C++ interfaces. I think that code path is obsolete, and it should never run with unwind-protect, but I prefer to keep this PR safe and simple. So to be able to undef, call `Rf_error` then define again, I put the definition into a separate file without guards, so that it can be included more than once. Please let me know if there's a better way and/or you'd like this definition in another place.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [ ] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
