### PR TITLE
Roll macos-13 to macos-14 for CI

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - {os: macos-latest}
-          - {os: macos-13}
+          - {os: macos-14}
           #- {os: ubuntu-latest}
           #- {os: ubuntu-24.04-arm}
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-11-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .github/workflows/macos.yaml (jobs): Roll macos-13 to macos-14
+
 2025-11-01 Iñaki Ucar <iucar@fedoraproject.org>
 
 	* inst/include/Rcpp/hash/IndexHash.h: Normalize values for all comparisons


### PR DESCRIPTION
As a non-macOS user and only infrequent user of macOS for CI, I had missed that macOS-13 was being phased out here so we were starting to encounter the brown-outs.  This PR rolls this to macos-14.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
