### PR TITLE
Use message() to signal very old helper functions are redundant (closes #1412)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-11-29  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/RcppLdpath.R: Revisit deprecation warnings via 'message()' to be
+	turned into warning or deprecation in 12 or more months 'when suitable'
+
 2025-11-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/r/check_r_headers.h: Add RCPP_NO_R_HEADERS_CHECK

--- a/R/RcppLdpath.R
+++ b/R/RcppLdpath.R
@@ -33,6 +33,7 @@ Rcpp.quoteNonStandard <- function(path) {
 RcppLdPath <- function() {
     #.Deprecated(msg=paste("This function is now deprecated as it has not",
     #                      "been needed since 2013."))
+    message("'RcppLdPath' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     ""
 }
 
@@ -47,6 +48,7 @@ RcppLdPath <- function() {
 RcppLdFlags <- function() {
     #.Deprecated(msg=paste("This function is now deprecated as it has not",
     #                      "been needed since 2013."))
+    message("'RcppLdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     ""
 }
 
@@ -67,11 +69,13 @@ RcppCxxFlags <- function(cxx0x=FALSE) {
 CxxFlags <- function(cxx0x=FALSE) {
     #.Deprecated(msg=paste("This function is now deprecated as R uses minimally",
     #                      "viable compilers om all platforme."))
+    message("'CxxFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppCxxFlags(cxx0x=cxx0x))				# #nocov
 }
 
 ## LdFlags defaults to static linking on the non-Linux platforms Windows and OS X
 LdFlags <- function() {
+    message("'LdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppLdFlags())
 }
 
@@ -83,11 +87,13 @@ RcppCapabilities <- capabilities <- function() .Call( rcpp_capabilities )
 RcppCxx0xFlags <- function() {
     #.Deprecated(msg=paste("This function is now deprecated as R uses minimally",
     #                      "viable compilers om all platforme."))
+    message("'RcppCxx0xFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     script <- Rcpp.system.file( "discovery", "cxx0x.R" )	# #nocov start
     flag <- capture.output( source( script ) )
     flag
 }
 
 Cxx0xFlags <- function() {
+    message("'Cxx0xFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppCxx0xFlags())									# #nocov end
 }


### PR DESCRIPTION
This simple PR addresses the issue raised in #1412 about the long-redundant helper functions that were prior to 2013 (!!) to constrct working `src/Makevars*` but have not been needed since.

A reverse-dependency check has been started.  I will keep it as 'draft' until that is done (likely Monday).

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
