### PR TITLE
Silence three tests following PR #1413

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-12-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_system.R: Wrap suppressMessages() around three
+	tests for long-obsolete linker and compiler flags
+
 2025-12-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/tinytest/test_system.R
+++ b/inst/tinytest/test_system.R
@@ -1,5 +1,5 @@
 
-##  Copyright (C) 2016 - 2019  Dirk Eddelbuettel
+##  Copyright (C) 2016 - 2025  Dirk Eddelbuettel
 ##
 ##  This file is part of Rcpp.
 ##
@@ -24,9 +24,9 @@ inc_sys <- tools::file_path_as_absolute( base::system.file("include", package = 
 expect_equal(inc_rcpp, inc_sys, info = "Rcpp.system.file")
 
 #    test.RcppLd <- function() {
-expect_true(Rcpp:::RcppLdPath() == "", info = "RcppLdPath")
-expect_true(Rcpp:::RcppLdFlags() == "", info = "RcppLdFlags")
-expect_equal(Rcpp:::LdFlags(), NULL, info = "LdFlags")
+expect_true(suppressMessages(Rcpp:::RcppLdPath()) == "", info = "RcppLdPath")
+expect_true(suppressMessages(Rcpp:::RcppLdFlags()) == "", info = "RcppLdFlags")
+expect_equal(suppressMessages(Rcpp:::LdFlags()), NULL, info = "LdFlags")
 
 #    test.RcppCxx <- function() {
 expect_true(Rcpp:::canUseCXX0X(), info = "canUseCXX0X")


### PR DESCRIPTION
This is a minor 'quality of life' improvement to silence three tests that assert that the (old, unused) helpers for compiler and linker flags do the Right Thing (TM) and return nothing, but following #1413 emit a message.  Which we now suppress. 

When these get deprecated / warn we will change the tests or possibly add tests for warnings.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
