### PR TITLE
No longer require #ifdef for UNWIND_PROTECT, had been 'on' for long

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,13 @@
 	* inst/include/Rcpp/r_cast.h: Idem
 	* src/attributes.cpp: Idem
 	* src/barrier.cpp: Idem
+2026-01-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/RcppCommon.h: No longer require RCPP_USING_UNWIND_PROTECT
+	* inst/include/Rcpp/r/headers.h: Idem
+	* inst/include/Rcpp/api/meat/Rcpp_eval.h: Idem
+	* inst/tinytest/cpp/stack.cpp: No longer test with RCPP_USING_UNWIND_PROTECT
+	* inst/tinytest/test_interface.R: Idem
 
 2025-12-30  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rcpp
 Title: Seamless R and C++ Integration
-Version: 1.1.0.13
-Date: 2025-12-23
+Version: 1.1.0.13.1
+Date: 2026-01-04
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Romain", "Francois", role = "aut",

--- a/inst/include/Rcpp/api/meat/Rcpp_eval.h
+++ b/inst/include/Rcpp/api/meat/Rcpp_eval.h
@@ -1,4 +1,5 @@
-// Copyright (C) 2013 Romain Francois
+// Copyright (C) 2013 - 2025 Romain Francois
+// Copyright (C) 2026        Romain Francois and Dirk Eddelbuettel
 //
 // This file is part of Rcpp.
 //
@@ -24,8 +25,6 @@
 
 namespace Rcpp { namespace internal {
 
-#ifdef RCPP_USING_UNWIND_PROTECT
-
 struct EvalData {
     SEXP expr;
     SEXP env;
@@ -42,35 +41,15 @@ inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) { // #nocov
     return Rcpp_fast_eval(expr, env);  // #nocov
 }
 
-#else // R < 3.5.0
-
-// Fall back to Rf_eval() when the protect-unwind API is unavailable
-inline SEXP Rcpp_eval_impl(SEXP expr, SEXP env) {
-    return ::Rf_eval(expr, env);
-}
-
-#endif
-
 }} // namespace Rcpp::internal
 
 
 namespace Rcpp {
 
-#ifdef RCPP_USING_UNWIND_PROTECT
-
 inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
     internal::EvalData data(expr, env);
     return unwindProtect(&internal::Rcpp_protected_eval, &data);
 }
-
-#else
-
-inline SEXP Rcpp_fast_eval(SEXP expr, SEXP env) {
-    return Rcpp_eval(expr, env);
-}
-
-#endif
-
 
 inline SEXP Rcpp_eval(SEXP expr, SEXP env) {
 

--- a/inst/include/Rcpp/r/headers.h
+++ b/inst/include/Rcpp/r/headers.h
@@ -2,7 +2,7 @@
 //
 // Copyright (C) 2008 - 2009 Dirk Eddelbuettel
 // Copyright (C) 2009 - 2024 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2025        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2025 -      Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -99,10 +99,6 @@
 
 #ifdef RCPP_HAS_MAKEDEV_MACRO
 # pragma pop_macro("makedev")
-#endif
-
-#if !defined(RCPP_NO_UNWIND_PROTECT)
-# define RCPP_USING_UNWIND_PROTECT
 #endif
 
 #endif /* RCPP__R__HEADERS__H */

--- a/inst/include/RcppCommon.h
+++ b/inst/include/RcppCommon.h
@@ -1,10 +1,9 @@
 
-//
 // RcppCommon.h: Rcpp R/C++ interface class library -- common include and defines statements
 //
 // Copyright (C) 2008 - 2009  Dirk Eddelbuettel
 // Copyright (C) 2009 - 2020  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2021 - 2025  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2021 - 2026  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -132,9 +131,7 @@ namespace Rcpp {
 #include <Rcpp/exceptions.h>
 #include <Rcpp/proxy/proxy.h>
 
-#ifdef RCPP_USING_UNWIND_PROTECT
-  #include <Rcpp/unwindProtect.h>
-#endif
+#include <Rcpp/unwindProtect.h>
 
 #include <Rcpp/lang.h>
 #include <Rcpp/complex.h>

--- a/inst/tinytest/cpp/stack.cpp
+++ b/inst/tinytest/cpp/stack.cpp
@@ -65,10 +65,7 @@ SEXP maybeThrow(void* data) {
 SEXP testUnwindProtect(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
-
-#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect(&maybeThrow, &fail);
-#endif
     return out;
 }
 
@@ -77,11 +74,7 @@ SEXP testUnwindProtect(Environment indicator, bool fail) {
 SEXP testUnwindProtectLambda(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
-
-#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect([&] () { return maybeThrow(&fail); });
-#endif
-
     return out;
 }
 
@@ -100,10 +93,6 @@ struct FunctionObj {
 SEXP testUnwindProtectFunctionObject(Environment indicator, bool fail) {
     unwindIndicator my_data(indicator);
     SEXP out = R_NilValue;
-
-#ifdef RCPP_USING_UNWIND_PROTECT
     out = Rcpp::unwindProtect(FunctionObj(10, fail));
-#endif
-
     return out;
 }

--- a/inst/tinytest/test_interface.R
+++ b/inst/tinytest/test_interface.R
@@ -81,16 +81,18 @@ expect_equal(result, 0L)
 ## Now test client package without protected evaluation
 unlink(user_name, recursive = TRUE)
 unlink(paste0(user_name, "-tests"), recursive = TRUE)
-build_package(user_name, lib_path, config = "#define RCPP_NO_UNWIND_PROTECT")
 
-result <- tools::testInstalledPackage(user_name, lib.loc = lib_path, types = "test")
+## no longer supported in code
+## build_package(user_name, lib_path, config = "#define RCPP_NO_UNWIND_PROTECT")
 
-if (result) {
-    log <- file.path(paste0(user_name, "-tests"), "tests.Rout.fail")
-    cat(">> UNPROTECTED tests.Rout.fail", readLines(log), sep = "\n", file = stderr())
-}
+## result <- tools::testInstalledPackage(user_name, lib.loc = lib_path, types = "test")
 
-expect_equal(result, 0L)
+## if (result) {
+##     log <- file.path(paste0(user_name, "-tests"), "tests.Rout.fail")
+##     cat(">> UNPROTECTED tests.Rout.fail", readLines(log), sep = "\n", file = stderr())
+## }
+
+## expect_equal(result, 0L)
 
 on.exit({
     setwd(old_wd)


### PR DESCRIPTION
Closes #1436 

This PR removes the `#define` use of  `UNWIND_PROTECT` as well as the one override allowing it to remain unset.  Effectively we have had this one for a long time, and given the established baseline of R 3.5.0 or later and C++11 or later we can clearly default to using this unconditionally.  This should not constitute a change in behavior.  

A reverse-dependency run is ongoing; no issues expected and none seen so far.

The timing of the PR is a little closer to the upcoming 1.1.1 release than I usually like but as the PR has no new code and should really only be removing some conditional testing as scaffolding we may deem this to be part of the release.  Let me know what you think.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
