### PR TITLE
Correct a printf format string reflecting 'unsigned int'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-01-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/date_datetime/Datetime.h (format): Correct a
+	format string reflecting 'unsigned int' rather than 'int'
+
 2026-01-12  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/date_datetime/Datetime.h
+++ b/inst/include/Rcpp/date_datetime/Datetime.h
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // Datetime.h: Rcpp R/C++ interface class library -- Datetime (POSIXct)
 //
-// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2026  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -80,7 +79,7 @@ namespace Rcpp {
             if (res == 0) {
                 return std::string("");
             } else {
-                res = ::snprintf(txtsec, 63, "%s.%06d", txtiso, m_us);
+                res = ::snprintf(txtsec, 63, "%s.%06u", txtiso, m_us);
                 if (res <= 0) {
                     return std::string("");
                 } else {


### PR DESCRIPTION
Closes #1447 

Corrects a format string for the `unsigned int` variable used

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
