### PR TITLE
Use an int for fractional seconds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-01-21  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/date_datetime/Datetime.h: Fractional seconds type
+	switched to 'int' for consistency, print format string re-adjusted
+
 2026-01-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/date_datetime/Datetime.h (format): Correct a

--- a/inst/include/Rcpp/date_datetime/Datetime.h
+++ b/inst/include/Rcpp/date_datetime/Datetime.h
@@ -79,7 +79,7 @@ namespace Rcpp {
             if (res == 0) {
                 return std::string("");
             } else {
-                res = ::snprintf(txtsec, 63, "%s.%06u", txtiso, m_us);
+                res = ::snprintf(txtsec, 63, "%s.%06d", txtiso, m_us);
                 if (res <= 0) {
                     return std::string("");
                 } else {
@@ -93,7 +93,7 @@ namespace Rcpp {
     private:
         double m_dt;            // fractional seconds since epoch
         struct tm m_tm;         // standard time representation
-        unsigned int m_us;      // microsecond (to complement m_tm)
+        int m_us;               // microsecond (to complement m_tm)
 
         // update m_tm based on m_dt
         void update_tm() {


### PR DESCRIPTION
This is a follow-up to #1447 and #1448; it addresses the root cause that the fractional second part should be `int` as we actually cast explicitly as `int` and assign `NA_INTEGER`.  The `printf` format changed in #1448 is reverted back for `int` too.

The compiler was generally kind to us in the past here and did The Right Thing (TM).  The variable is also not used outside the file (unless via an accessor that returns `int`).

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
