### PR TITLE
Update three more uses of attribute getting for R 4.6.0 or later

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-01-23  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/DataFrame.h (nrow): Use R_nrow() with R >= 4.6.0
+	* inst/include/Rcpp/proxy/AttributeProxy.h (attributeNames): Use
+	R_getAttribNames() with R >= 4.6.0;
+	* inst/include/Rcpp/proxy/AttributeProxy.h (hasAttribute): Use
+	R_hasAttrib with R >= 4.6.0
+
 2026-01-22  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // DataFrame.h: Rcpp R/C++ interface class library -- data frames
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2026  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of Rcpp.
 //
@@ -67,8 +66,12 @@ namespace Rcpp{
         // discussed in #1430 is also possible and preferable. We also switch
         // to returning R_xlen_t which as upcast from int is safe
         inline R_xlen_t nrow() const {
+#if R_VERSION < R_Version(4,6,0)
             Shield<SEXP> rn{Rf_getAttrib(Parent::get__(), R_RowNamesSymbol)};
             return Rf_xlength(rn);
+#else
+            return R_nrow(Parent::get__());
+#endif
         }
 
         template <typename T>


### PR DESCRIPTION
Closes #1432

Just before we came out with Rcpp 1.1.1 in January (entirely on schedule), R Core / Luke / CRAN rushed out another interim fix (we were not involved) building on the preceding one from December (which was needed as they had borked builds on R-devel).  This interim version switched to three more 'then new' accessors around attributes, and did so in a non-versioned way (hence breaking builds on R-release or older).   

Anyway, the three small changes are fine for R-devel so this PR brings them over, but this time properly conditioned.  Builds and checks on r-devel, and remains unchanged for all other versions so no hickups expected.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
