### PR TITLE
Switch to R_getRegisteredNamespace 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Function.h: Further refinement for 4.6.0 to not
+	require R_NamespaceRegistry, using R_getRegisteredNamespace() instead
+
 2026-04-01  Mattias Ellert  <mattias.ellert@physics.uu.se>
 
 	* inst/discovery/cxx0x.R: Set execute permissions for script

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -70,9 +70,11 @@ namespace Rcpp{
         }
 
         Function_Impl(const std::string& name, const std::string& ns) {
-#if R_VERSION < R_Version(4,5,0)
+#if R_VERSION < R_Version(4,6,0)
             Shield<SEXP> env(Rf_findVarInFrame(R_NamespaceRegistry, Rf_install(ns.c_str())));
             if (env == R_UnboundValue)
+            Shield<SEXP> env(R_getRegisteredNamespace(ns.c_str()));
+            if (env == R_NilValue)
                 stop("there is no namespace called \"%s\"", ns);
 #else
             Shield<SEXP> env(R_getVarEx(Rf_install(ns.c_str()), R_NamespaceRegistry, FALSE, R_NilValue));

--- a/inst/include/Rcpp/Function.h
+++ b/inst/include/Rcpp/Function.h
@@ -70,14 +70,20 @@ namespace Rcpp{
         }
 
         Function_Impl(const std::string& name, const std::string& ns) {
-#if R_VERSION < R_Version(4,6,0)
+#if R_VERSION < R_Version(4,5,0)
+            // before R 4.5.0 we would use Rf_findVarInFrame
             Shield<SEXP> env(Rf_findVarInFrame(R_NamespaceRegistry, Rf_install(ns.c_str())));
             if (env == R_UnboundValue)
-            Shield<SEXP> env(R_getRegisteredNamespace(ns.c_str()));
+                stop("there is no namespace called \"%s\"", ns);
+#elif R_VERSION < R_Version(4,6,0) || R_SVN_REVISION < 89746
+            // during R 4.5.* and before final R 4.6.0 we could use R_getVarEx
+            // along with R_NamespaceRegistry but avoid R_UnboundValue
+            Shield<SEXP> env(R_getVarEx(Rf_install(ns.c_str()), R_NamespaceRegistry, FALSE, R_NilValue));
             if (env == R_NilValue)
                 stop("there is no namespace called \"%s\"", ns);
 #else
-            Shield<SEXP> env(R_getVarEx(Rf_install(ns.c_str()), R_NamespaceRegistry, FALSE, R_NilValue));
+            // late R 4.6.0 development got us R_getRegisteredNamespace
+            Shield<SEXP> env(R_getRegisteredNamespace(ns.c_str()));
             if (env == R_NilValue)
                 stop("there is no namespace called \"%s\"", ns);
 #endif


### PR DESCRIPTION
Closes #1468 

R-devel (very recently) added `R_getRegisteredNamespace()` allowing a lookup with in namespace without requiring the `R_NamespaceRegistry` symbol which is retired.

This minimal PR adjusts accordingly in one spot, and protects the condition by also selecting on the SVN commit number as the (automated) R-devel build we use in CI has not yet caught up.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
