### PR TITLE
Enhance Rcpp::Nullable::as with explicit cast (Closes #1470)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Nullable.h (Nullable): 'operator T()' is now
+	behind an opt-in #define
+
 2026-04-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2026-04-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
+2026-04-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/Rcpp/Nullable.h (as): Enhance by adding an explicit
+	Rcpp::as<T>() aiding cases where implicit as<> does not suffice
 
 2026-04-07  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2026-04-09  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/Nullable.h (T): Also add 'operator T()'
+
 2026-04-08  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/Rcpp/Nullable.h (as): Enhance by adding an explicit

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 	* DESCRIPTION (Version, Date): Roll micro version and date
 	* inst/include/Rcpp/Nullable.h (T): Also add 'operator T()'
+	(conditional on R (>= 4.3.0) as older versions croak)
 
 2026-04-08  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -82,6 +82,16 @@ namespace Rcpp {
         }
 
         /**
+         * operator T() to return nullable object
+         *
+         * @throw 'not initialized' if object has not been set
+         */
+        inline operator T() const {
+            checkIfSet();
+            return Rcpp::as<T>(m_sexp);
+        }
+
+        /**
          * get() accessor for object
          *
          * @throw 'not initialized' if object has not been set

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -81,7 +81,7 @@ namespace Rcpp {
             return m_sexp;
         }
 
-#if R_VERSION > R_Version(4,3,0)
+#if R_VERSION > R_Version(4,3,0) && defined(RCPP_ENABLE_NULLABLE_T)
         /**
          * operator T() to return nullable object
          *

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -126,7 +126,7 @@ namespace Rcpp {
         /**
          * Returns m_sexp as a T
          */
-        inline T as() { return get(); }
+        inline T as() { return Rcpp::as<T>(get()); }
 
         /**
          * Return a clone of m_sexp as a T

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -81,6 +81,7 @@ namespace Rcpp {
             return m_sexp;
         }
 
+#if R_VERSION > R_Version(4,3,0)
         /**
          * operator T() to return nullable object
          *
@@ -90,6 +91,7 @@ namespace Rcpp {
             checkIfSet();
             return Rcpp::as<T>(m_sexp);
         }
+#endif
 
         /**
          * get() accessor for object

--- a/inst/tinytest/cpp/misc.cpp
+++ b/inst/tinytest/cpp/misc.cpp
@@ -217,7 +217,6 @@ SEXP testNullableIsUsable(const Nullable<NumericMatrix>& M) {
     }
 }
 
-#if R_VERSION > R_Version(4,3,0)
 // [[Rcpp::export]]
 String testNullableString(Rcpp::Nullable<Rcpp::String> param = R_NilValue) {
   if (param.isNotNull())
@@ -225,7 +224,6 @@ String testNullableString(Rcpp::Nullable<Rcpp::String> param = R_NilValue) {
   else
     return String("");
 }
-#endif
 
 // [[Rcpp::export]]
 void messageWrapper(SEXP s) {

--- a/inst/tinytest/cpp/misc.cpp
+++ b/inst/tinytest/cpp/misc.cpp
@@ -217,6 +217,7 @@ SEXP testNullableIsUsable(const Nullable<NumericMatrix>& M) {
     }
 }
 
+#if R_VERSION > R_Version(4,3,0)
 // [[Rcpp::export]]
 String testNullableString(Rcpp::Nullable<Rcpp::String> param = R_NilValue) {
   if (param.isNotNull())
@@ -224,6 +225,7 @@ String testNullableString(Rcpp::Nullable<Rcpp::String> param = R_NilValue) {
   else
     return String("");
 }
+#endif
 
 // [[Rcpp::export]]
 void messageWrapper(SEXP s) {

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -169,10 +169,8 @@ expect_equal( testNullableIsUsable(M), M)
 expect_true(is.null(testNullableIsUsable(NULL)))
 
 ##    test.NullableString <- function() {
-if (getRversion() > "4.3.0") {
-    expect_equal(testNullableString(), "")
-    expect_equal(testNullableString("blah"), "blah")
-}
+expect_equal(testNullableString(), "")
+expect_equal(testNullableString("blah"), "blah")
 
 #    test.bib <- function() {
 expect_true(nchar(Rcpp:::bib()) > 0, info="bib file")

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -168,9 +168,11 @@ expect_equal( testNullableIsUsable(M), M)
 #    test.NullableIsUsableFalse <- function() {
 expect_true(is.null(testNullableIsUsable(NULL)))
 
-#    test.NullableString <- function() {
-expect_equal(testNullableString(), "")
-expect_equal(testNullableString("blah"), "blah")
+##    test.NullableString <- function() {
+if (getRversion() > "4.3.0") {
+    expect_equal(testNullableString(), "")
+    expect_equal(testNullableString("blah"), "blah")
+}
 
 #    test.bib <- function() {
 expect_true(nchar(Rcpp:::bib()) > 0, info="bib file")


### PR DESCRIPTION
As discussed in #1470 and building on this morning's discussion at the bottom of #1451, we can make `Nullable<T>` a little nicer.  And that is all this PR does:  for cases where the _implicit_ `as<>()` needs a nudge, we can hide the nudge inside that (member function) `as()` function body accessing the matching `as<>` for the given T.   A little bit of ellbow grease.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
