### PR TITLE
fix memory leak in Rcpp::warning under tryCatch handlers

### DIFF
--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -32,6 +32,11 @@
       with current R versions (Dirk in \ghpr{1469} fixing \ghit{1468})
       \item The \code{Nullable::as()} exporter now uses an explicit cast to
       the templated type (Dirk in \ghpr{1471} fixing \ghit{1470})
+      \item A memory leak in the variadic \code{Rcpp::warning()} template
+      has been fixed by copying the formatted message into a stack buffer
+      before \code{Rf_warning()} is invoked, so the \code{std::string}
+      destructor runs even when an R warning handler triggers a
+      \code{longjmp} (Kevin fixing \ghit{1474})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/exceptions.h
+++ b/inst/include/Rcpp/exceptions.h
@@ -24,6 +24,7 @@
 #define Rcpp__exceptions__h
 
 #include <Rversion.h>
+#include <cstdio>
 
 #ifndef RCPP_DEFAULT_INCLUDE_CALL
 #define RCPP_DEFAULT_INCLUDE_CALL true
@@ -186,7 +187,17 @@ struct LongjumpException {
 
     template <typename... Args>
     inline void warning(const char* fmt, Args&&... args ) {
-        Rf_warning("%s", tfm::format(fmt, std::forward<Args>(args)... ).c_str());
+        // Rf_warning() may longjmp out of this frame (e.g. when the caller
+        // installs a warning handler via tryCatch(warning=...)). A longjmp
+        // skips C++ destructors, so the std::string returned by tfm::format()
+        // would leak its heap buffer. Copy into a stack buffer and let the
+        // std::string be destroyed before Rf_warning() is invoked.
+        char buf[8192];
+        {
+            const std::string msg = tfm::format(fmt, std::forward<Args>(args)...);
+            std::snprintf(buf, sizeof(buf), "%s", msg.c_str());
+        }
+        Rf_warning("%s", buf);
     }                                                           // #nocov end
 
     template <typename... Args>

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -117,3 +117,13 @@ expect_warning( DataFrame_PushZeroLength())
 ## issue #1232: push on empty data.frame
 df <- DataFrame_PushOnEmpty()
 expect_equal(ncol(df), 3L)
+
+## issue #1474: warning thrown from DataFrame::push_back used to leak the
+## formatted std::string when a tryCatch handler longjmp-ed past its dtor.
+## Loop a few iterations so valgrind makes any regression obvious.
+got_warning <- FALSE
+for (i in 1:5) {
+    tryCatch(DataFrame_PushWrongSize(),
+             warning = function(w) { got_warning <<- TRUE })
+}
+expect_true(got_warning)


### PR DESCRIPTION
## Summary

Fixes #1474.

The variadic `Rcpp::warning()` template formatted its message via `tfm::format()` into a `std::string` temporary whose destructor would be skipped if `Rf_warning()` `longjmp`-ed (e.g. when the caller used `tryCatch(warning = …)` or `withCallingHandlers(... invokeRestart("muffleWarning"))`). The heap buffer behind the formatted message would leak (78 bytes per call in the report).

The fix copies the formatted text into a stack `char[8192]` and lets the `std::string` be destroyed inside an inner block scope, *before* `Rf_warning()` is invoked. The `8192` matches the `BUFSIZE` constant R defines locally in `src/main/errors.c` for `Rf_warning`/`Rf_error`'s own message buffers; it isn't reachable through any public R header (the closest exposed constant, `GET_REGION_BUFSIZE` in `R_ext/Itermacros.h`, is for region iterators), so we hard-code the same numeric value.

## Audit of similar sites

While here I went through the rest of the codebase looking for the same pattern (a heap-owning C++ object alive on the stack when an R API call could `longjmp`).

**Confirmed safe:**

- `Rcpp::stop()` (both overloads) — throws a C++ exception, which unwinds normally.
- `Rcpp::Function::operator()`, `Rcpp_eval`, `Rcpp_fast_eval` — wrapped in `unwindProtect`, so an R `longjmp` is converted to a `LongjumpException` and C++ destructors run.
- `Rf_eval` calls in `forward_exception_to_r` / `forward_rcpp_exception_to_r` — at the BEGIN_RCPP/END_RCPP boundary, no C++ frames above to leak.
- `Rf_eval` calls in `barrier.cpp` — only `Shield<SEXP>` locals, which are safe under `longjmp` (R restores the protect stack).
- `Rf_error("Internal error: …")` at `exceptions.h:156` — literal-only, terminal failure path.
- Generated `Rf_error("%s", CHAR(rcpp_msgSEXP_gen))` in `attributes.cpp` — message comes from an R-managed SEXP.
- `R_ToplevelExec` use in `Interrupt.h` — catches `longjmp` internally.
- Various `throw` sites in `Vector.h`, `GreedyVector.h`, etc. — C++ exceptions, fine.

**Remaining caller-frame hazards (not fixable from inside Rcpp):**

These two overloads take a `const std::string&` and call an R API that may `longjmp`. The string's heap data lives in the *caller's* frame, so a `longjmp` would skip the caller's destructor regardless of what these functions do internally:

- `inst/include/Rcpp/exceptions.h:115` — `Rcpp::warning(const std::string& message)` → `Rf_warning`
- `inst/include/Rcpp/print.h:28` — `Rcpp::warningcall(SEXP, const std::string& s)` → `Rf_warningcall`

Neither is called from inside Rcpp itself (only `r_cast.h:164` invokes `Rcpp::warning`, and it uses the variadic form which is now safe), so this is a hazard for downstream users rather than a live leak in Rcpp. Worth a follow-up: either documentation, or wrapping the warning call in `R_UnwindProtect` to convert `longjmp` to a C++ exception so caller-frame destructors run.

## Test plan

- [x] `R CMD INSTALL` builds cleanly.
- [x] `tinytest` `test_dataframe.R` passes (33 tests, including the new regression).
- [x] `tinytest` `test_exceptions.R` passes (24 tests).
- [ ] Re-run the original Valgrind reproducer from #1474 and confirm the 78-byte "definitely lost" record is gone.