### PR TITLE
Add R 4.5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
           - name: release
             cntr: rcpp/ci
             r: R
+          - name: r-4.5
+            cntr: rcpp/ci-4.5
+            r: R
           - name: r-4.4
             cntr: rcpp/ci-4.4
             r: R

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-05-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* docker/ci-4.5/Dockerfile: Added based on r-base:4.5.3
+	* .github/workflows/ci.yaml (jobs): Add rcpp/ci-4.5 to matrix
+
 2026-05-01  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/docker/ci-4.5/Dockerfile
+++ b/docker/ci-4.5/Dockerfile
@@ -1,0 +1,17 @@
+## Emacs, make this -*- mode: sh; -*-
+
+FROM r-base:4.5.3
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/RcppCore/Rcpp" \
+      maintainer="Dirk Eddelbuettel <edd@debian.org>"
+
+RUN apt-get update \
+        && apt-get install -y --no-install-recommends git \
+        && install.r inline pkgKitten rbenchmark tinytest
+
+ENV _R_CHECK_FORCE_SUGGESTS_=FALSE
+ENV _R_CHECK_TESTS_NLINES_=0
+ENV RunAllRcppTests=yes
+
+CMD ["bash"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update \
                 git \
         && install.r rbenchmark
 
-ENV _R_CHECK_FORCE_SUGGESTS_ FALSE
-ENV _R_CHECK_TESTS_NLINES_ 0
-ENV RunAllRcppTests yes
+ENV _R_CHECK_FORCE_SUGGESTS_=FALSE
+ENV _R_CHECK_TESTS_NLINES_=0
+ENV RunAllRcppTests=yes
 
 CMD ["bash"]


### PR DESCRIPTION
Routine update of CI matrix adding R 4.5.3 as it is now the new 'oldrel'

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
