### PR TITLE
Make Nullable::operatorT() opt-out as downstream packages adjusted

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2026-05-05  Dirk Eddelbuettel  <edd@debian.org>
 
+	* inst/include/Rcpp/Nullable.h (Nullable): Switch operatorT() from
+	opt-in to opt-out as six downstream packages have updated at CRAN
+
 	* docker/ci-4.5/Dockerfile: Added based on r-base:4.5.3
 	* .github/workflows/ci.yaml (jobs): Add rcpp/ci-4.5 to matrix
 

--- a/inst/include/Rcpp/Nullable.h
+++ b/inst/include/Rcpp/Nullable.h
@@ -1,8 +1,7 @@
-// -*- mode: C++; c-indent-level: 4; c-basic-offset: 4; indent-tabs-mode: nil; -*-
-//
+
 // Nullable.h: Rcpp R/C++ interface class library -- SEXP container which can be NULL
 //
-// Copyright (C) 2015         Dirk Eddelbuettel and Daniel C. Dillon
+// Copyright (C) 2015-2026  Dirk Eddelbuettel and Daniel C. Dillon
 //
 // This file is part of Rcpp.
 //
@@ -81,7 +80,7 @@ namespace Rcpp {
             return m_sexp;
         }
 
-#if R_VERSION > R_Version(4,3,0) && defined(RCPP_ENABLE_NULLABLE_T)
+#if R_VERSION > R_Version(4,3,0) && !defined(RCPP_DISABLE_NULLABLE_T)
         /**
          * operator T() to return nullable object
          *


### PR DESCRIPTION
As discussed in #1472, and following up on #1471 / #1470, we were seeing side-effects in six package when `Nullable::operatorT()` was defined so we were keeping as an _opt-in_ feature.  The six packages have all adjusted so we can now flip this to _opt-out_. This allows any other package we have not met yet---and which may have a hick-up here too---to skip the definition and return to the 'as before' state.

Big thank you also to the six packages for adjusting.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
