### PR TITLE
Prefix three messages with 'Rcpp:::' (closes #1456)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/RcppLdpath.R: Prefix three messages with 'Rcpp:::' to make it
+	more obvious where they originate from
+
 2026-05-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/R/RcppLdpath.R
+++ b/R/RcppLdpath.R
@@ -69,13 +69,13 @@ RcppCxxFlags <- function(cxx0x=FALSE) {
 CxxFlags <- function(cxx0x=FALSE) {				# #nocov start
     #.Deprecated(msg=paste("This function is now deprecated as R uses minimally",
     #                      "viable compilers om all platforme."))
-    message("'CxxFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
+    message("'Rcpp:::CxxFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppCxxFlags(cxx0x=cxx0x))				# #nocov end
 }
 
 ## LdFlags defaults to static linking on the non-Linux platforms Windows and OS X
 LdFlags <- function() {
-    message("'LdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
+    message("'Rcpp:::LdFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppLdFlags())
 }
 
@@ -94,6 +94,6 @@ RcppCxx0xFlags <- function() {								# #nocov start
 }
 
 Cxx0xFlags <- function() {
-    message("'Cxx0xFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
+    message("'Rcpp:::Cxx0xFlags' has not been needed since 2013 (!!) and may get removed in 2027. Please update your 'Makevars'.")
     cat(RcppCxx0xFlags())									# #nocov end
 }


### PR DESCRIPTION
Issue #1456 describes a suggested small 'quality of life' improvement for three messages that are displayed when a (long obsolete) accessor is used.  This PR now follows up on this.  No new code, just some modified display.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
