### PR TITLE
Fix ambiguous Vector::operator[] on platforms without LONG_VECTOR_SUPPORT (wasm32)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-23  Jeroen Ooms  <jeroenooms@gmail.com>
+
+	* Add templated integer-index overload on platforms without
+	LONG_VECTOR_SUPPORT such as wasm32 (PR #1482)
+
 2026-06-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* vignettes/rmd/Rcpp.bib: Updated references

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -21,6 +21,7 @@
 #define Rcpp__vector__Vector_h
 
 #include <Rcpp/vector/Subsetter.h>
+#include <type_traits>
 
 namespace Rcpp{
 
@@ -337,6 +338,20 @@ public:
 
     inline Proxy operator[]( R_xlen_t i ){ return cache.ref(i) ; }
     inline const_Proxy operator[]( R_xlen_t i ) const { return cache.ref(i) ; }
+#ifndef LONG_VECTOR_SUPPORT
+    // On platforms without long vector support (notably wasm32) R_xlen_t is
+    // int while ptrdiff_t is long, so subscripting with any wider integer
+    // type would otherwise be ambiguous with the built-in pointer subscript
+    // synthesised via the implicit Vector -> SEXP conversion. The template
+    // overloads below provide an exact-match member candidate for every
+    // integer index type other than R_xlen_t itself.
+    template <typename T>
+    inline typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, R_xlen_t>::value, Proxy>::type
+    operator[]( T i ){ return cache.ref(static_cast<R_xlen_t>(i)) ; }
+    template <typename T>
+    inline typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, R_xlen_t>::value, const_Proxy>::type
+    operator[]( T i ) const { return cache.ref(static_cast<R_xlen_t>(i)) ; }
+#endif
 
     inline Proxy operator()( const size_t& i) {
         return cache.ref( offset(i) ) ;


### PR DESCRIPTION
## Problem

On the wasm32 target (e.g. r-universe webR builds), packages that subscript an `Rcpp::Vector` with an integer index whose type is not exactly `R_xlen_t` now fail to compile with an overload-resolution ambiguity. The originally reported failure was in [`ulid`](https://github.com/r-universe/eddelbuettel/actions/runs/28045007824/job/83021268577) with a `long` index:

```
wrapper.cpp:33:10: error: use of overloaded operator '[]' is ambiguous
   (with operand types 'Rcpp::CharacterVector' (aka 'Vector<16>') and 'long')
   33 |         c[i] = ulid::Marshal(ulid::CreateNowRand());
```

with candidates:

- `Vector::operator[](R_xlen_t)` — `inst/include/Rcpp/vector/Vector.h:338`
- built-in `operator[](SEXPREC*, __ptrdiff_t)` — synthesised because `Rcpp::Vector` has an implicit `operator SEXP() const` via `PreserveStorage`.

The same shape of error also occurs in Rcpp's own headers (`newDateVector.h`, `newDatetimeVector.h`, `module/Module.h`, `module/class.h`, …) any time a member uses a `size_t` loop variable to subscript a `Vector`.

## Root cause

R defines `R_xlen_t` as `ptrdiff_t` only when `LONG_VECTOR_SUPPORT` is set (i.e. `sizeof(size_t) > 4`). On wasm32 that macro is **not** defined and `R_xlen_t` falls back to `int`, while `ptrdiff_t` remains `long`. So for `c[i]` with `i` of any integer type wider than `int`:

- Member candidate: identity on object, integral conversion on the index.
- Built-in candidate: user-defined conversion `Vector -> SEXP` on object, exact match (or narrower conversion) on the index.

The two implicit conversion sequences are mutually unrankable, so the call is ambiguous. On LP64 platforms `R_xlen_t == ptrdiff_t == long`, the member matches a `long` index exactly and wins outright; the ambiguity is wasm-specific.

## Fix

Add a SFINAE-constrained template overload of `Vector::operator[]` that accepts any integral index type other than `R_xlen_t` itself and delegates to the existing `R_xlen_t` overload with a `static_cast`. The template provides an identity match on the index argument, so it beats both:

- the non-template `R_xlen_t` overload (which would require an integral conversion), and
- the built-in pointer subscript (which would require a user-defined conversion on the object).

When the index is exactly `R_xlen_t`, the SFINAE constraint excludes the template and the existing non-template overload is selected as before.

The new overload is compiled only when `LONG_VECTOR_SUPPORT` is not defined, so the overload set on LP64 / LLP64 platforms is unchanged. Marking `operator SEXP()` `explicit` would be the alternative root-cause fix but is far too disruptive — implicit `SEXP` conversion is load-bearing for nearly every downstream package.

## Test plan

- [x] Existing CI matrix (Linux x86_64/arm64, macOS x86_64/arm64, Windows) — overload set unchanged on LP64/LLP64.
- [x] r-universe wasm build of an affected package (e.g. `ulid`) succeeds after this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)