### PR TITLE
fix ListOf compile by not relying on get__() in attribute accessors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-06-26  Kevin Ushey <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/proxy/AttributeProxy.h: Do not rely on get__()
+	in attribute accessors so that classes such as ListOf compile
+	* inst/tinytest/cpp/ListOf.cpp: Added tests
+	* inst/tinytest/test_listof.R: Idem
+
 2026-06-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* vignettes/rmd/Rcpp.bib: Updated references

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -36,6 +36,9 @@
       has been fixed (Kevin in \ghpr{1475} fixing \ghit{1474})
       \item The \code{Nullable::operatorT()} has been added as a 'opt-out'
       (Dirk in \ghpr{1477} with coordination in \ghit{1472})
+      \item The attribute accessors in \code{AttributeProxyPolicy} no longer
+      rely on \code{get__()} so that classes such as \code{ListOf} compile
+      (Kevin in \ghpr{1484} fixing \ghit{1483})
     }
     \item Changes in Rcpp Documentation:
     \itemize{

--- a/inst/include/Rcpp/proxy/AttributeProxy.h
+++ b/inst/include/Rcpp/proxy/AttributeProxy.h
@@ -86,7 +86,7 @@ public:
             v.push_back(std::string(CHAR(STRING_ELT(attrs, i))));
         }
 #else
-        SEXP attrs = ATTRIB( static_cast<const CLASS&>(*this).get__());
+        SEXP attrs = ATTRIB( static_cast<const CLASS&>(*this) );
         while( attrs != R_NilValue ){
             v.push_back( std::string(CHAR(PRINTNAME(TAG(attrs)))) ) ;
             attrs = CDR( attrs ) ;
@@ -97,7 +97,7 @@ public:
 
     bool hasAttribute(const std::string& attr) const {
 #if R_VERSION >= R_Version(4, 6, 0)
-        return R_hasAttrib(static_cast<const CLASS&>(*this).get__(), Rf_install(attr.c_str()));
+        return R_hasAttrib(static_cast<const CLASS&>(*this), Rf_install(attr.c_str()));
 #else
         return static_cast<const CLASS&>(*this).attr(attr) != R_NilValue;
 #endif

--- a/inst/tinytest/cpp/ListOf.cpp
+++ b/inst/tinytest/cpp/ListOf.cpp
@@ -113,3 +113,13 @@ CharacterVector listof_names(ListOf<NumericVector> x) {
 SEXP listof_attr_foo(ListOf<NumericVector> x) {
     return x.attr("foo");
 }
+
+// [[Rcpp::export]]
+bool listof_has_attr(ListOf<NumericVector> x, std::string name) {
+    return x.hasAttribute(name);
+}
+
+// [[Rcpp::export]]
+std::vector<std::string> listof_attribute_names(ListOf<NumericVector> x) {
+    return x.attributeNames();
+}

--- a/inst/tinytest/test_listof.R
+++ b/inst/tinytest/test_listof.R
@@ -72,3 +72,15 @@ expect_equal(listof_names(l), c("a", "b", "c"))
 l <- list(a = 1L)
 attr(l, "foo") <- "bar"
 expect_equal(listof_attr_foo(l), "bar")
+
+#    test.ListOf.has.attribute <- function() {     # GH issue #1483
+l <- list(a = 1L)
+attr(l, "foo") <- "bar"
+expect_true(listof_has_attr(l, "foo"))
+expect_true(listof_has_attr(l, "names"))
+expect_false(listof_has_attr(l, "missing"))
+
+#    test.ListOf.attribute.names <- function() {   # GH issue #1483
+l <- list(a = 1L)
+attr(l, "foo") <- "bar"
+expect_true(all(c("names", "foo") %in% listof_attribute_names(l)))


### PR DESCRIPTION
Fixes #1483.

### Problem

`AttributeProxyPolicy<CLASS>` is a policy base class. Its `attributeNames()` and `hasAttribute()` members fetched the underlying `SEXP` via `static_cast<const CLASS&>(*this).get__()`. But `get__()` is not part of this policy -- it is provided by the *storage* policy (`PreserveStorage` / `NoProtectStorage`). `Vector`, `XPtr` and the macro-generated classes inherit a storage policy, so they have `get__()`; `ListOf<T>` inherits `AttributeProxyPolicy` *without* a storage policy and has only `get()` / `operator SEXP()`.

As a result, e.g. `RestRserve`'s `x.hasAttribute("names")` on a `ListOf<...>` failed to compile under R >= 4.6.0:

```
'const class Rcpp::ListOf<Rcpp::Vector<16> >' has no member named 'get__'; did you mean 'get'?
```

### Fix

Drop `.get__()` and rely on the implicit `operator SEXP()` conversion that all of these classes provide. This matches the adjacent `R_getAttribNames(static_cast<const CLASS&>(*this))` call (which already worked for `ListOf`) and is equivalent to the pre-4.6.0 `.attr()` path. Both the R >= 4.6.0 `hasAttribute()` and the pre-4.6.0 `attributeNames()` spot are fixed (the latter had the same latent bug for `ListOf`).

### Tests

Added `listof_has_attr` / `listof_attribute_names` exports and corresponding cases in `test_listof.R`. Full `test_listof.R` passes (20 results).
