### PR TITLE
Fix -Wextra

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-06-28  David Seifert  <soap@gentoo.org>
 
+	* inst/include/Rcpp/date_datetime/newDateVector.h: Explicitly default the
+	copy constructor (the class has a user-provided copy assignment operator)
+	to silence -Wdeprecated-copy-with-user-provided-copy under -Wextra
+	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
+
+2026-06-28  David Seifert  <soap@gentoo.org>
+
 	* inst/include/Rcpp/Module.h: Anonymize unused function parameters to
 	silence -Wunused-parameter (part of -Wextra)
 	* inst/include/Rcpp/Promise.h: Idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2026-06-28  David Seifert  <soap@gentoo.org>
+
+	* inst/include/Rcpp/Module.h: Anonymize unused function parameters to
+	silence -Wunused-parameter (part of -Wextra)
+	* inst/include/Rcpp/Promise.h: Idem
+	* inst/include/Rcpp/StretchyList.h: Idem
+	* inst/include/Rcpp/internal/wrap.h: Idem
+	* inst/include/Rcpp/module/Module_Field.h: Idem
+	* inst/include/Rcpp/sugar/functions/cbind.h: Idem
+	* inst/include/Rcpp/sugar/functions/is_na.h: Idem
+	* inst/include/Rcpp/sugar/matrix/col.h: Idem
+	* inst/include/Rcpp/sugar/matrix/row.h: Idem
+	* inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h: Idem
+	* inst/include/Rcpp/sugar/tools/safe_math.h: Idem
+	* inst/include/Rcpp/vector/Subsetter.h: Idem
+	* inst/include/Rcpp/vector/Vector.h: Idem
+	* src/api.cpp: Idem
+	* inst/tinytest/cpp/InternalFunction.cpp: Idem
+
 2026-06-23  Jeroen Ooms  <jeroenooms@gmail.com>
 
 	* Add templated integer-index overload on platforms without

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -205,7 +205,7 @@ namespace Rcpp{
 
     private:
         template <int... Is>
-        Class* get_new_impl(SEXP* args, int nargs, traits::index_sequence<Is...>) {
+        Class* get_new_impl(SEXP* args, int /*nargs*/, traits::index_sequence<Is...>) {
             return new Class( as<T>(args[Is])... ) ;
         }
     };
@@ -222,7 +222,7 @@ namespace Rcpp{
     class Factory : public Factory_Base<Class> {
     public:
         Factory( Class* (*fun)(T...) ) : ptr_fun(fun){}
-        virtual Class* get_new( SEXP* args, int nargs ){
+        virtual Class* get_new( SEXP* args, int /*nargs*/ ){
             return get_new( args, traits::make_index_sequence<sizeof...(T)>() ) ;
         }
         virtual int nargs(){ return sizeof...(T) ; }

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -77,7 +77,7 @@ namespace Rcpp{
             return Environment( PRENV(Storage::get__() ) ) ;
         }
 
-        inline void update(SEXP data){}
+        inline void update(SEXP /*data*/){}
 
     } ;
 

--- a/inst/include/Rcpp/StretchyList.h
+++ b/inst/include/Rcpp/StretchyList.h
@@ -48,7 +48,7 @@ namespace Rcpp{
             Storage::set__(r_cast<LISTSXP>(x)) ;
         }
 
-        void update(SEXP x){}
+        void update(SEXP /*x*/){}
 
         inline operator SEXP() const{
             return CDR(Storage::get__() );

--- a/inst/include/Rcpp/date_datetime/newDateVector.h
+++ b/inst/include/Rcpp/date_datetime/newDateVector.h
@@ -48,6 +48,8 @@ namespace Rcpp {
             return v;
         }
 
+        newDateVector(const newDateVector&) = default;
+
         inline newDateVector &operator=(const newDateVector &rhs) {
             if (this != &rhs) {
                 NumericVector::operator=(rhs);

--- a/inst/include/Rcpp/date_datetime/newDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/newDatetimeVector.h
@@ -56,6 +56,8 @@ namespace Rcpp {
             return v;
         }
 
+        newDatetimeVector(const newDatetimeVector&) = default;
+
         inline newDatetimeVector &operator=(const newDatetimeVector &rhs) {
             if (this != &rhs) {
                 NumericVector::operator=(rhs);

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -522,7 +522,7 @@ namespace Rcpp {
          * quite a cryptic message
          */
 	template <typename T>
-    inline SEXP wrap_dispatch_unknown_iterable(const T& object, ::Rcpp::traits::false_type) {
+    inline SEXP wrap_dispatch_unknown_iterable(const T& /*object*/, ::Rcpp::traits::false_type) {
         RCPP_DEBUG_1("wrap_dispatch_unknown_iterable<%s>(., false )", DEMANGLE(T))
         // here we know that T is not convertible to SEXP
         static_assert(!sizeof(T), "cannot convert type to SEXP");
@@ -906,7 +906,7 @@ namespace Rcpp {
      template <> inline SEXP wrap<Rcpp::String>(const Rcpp::String& object);
 
      template <typename T>
-     inline SEXP module_wrap_dispatch(const T& obj, Rcpp::traits::void_wrap_tag) {
+     inline SEXP module_wrap_dispatch(const T& /*obj*/, Rcpp::traits::void_wrap_tag) {
          return R_NilValue;
      }
 

--- a/inst/include/Rcpp/module/Module_Field.h
+++ b/inst/include/Rcpp/module/Module_Field.h
@@ -54,7 +54,7 @@ public:
 	prop_class(doc), ptr(ptr_), class_name(DEMANGLE(PROP)) {}
 
     SEXP get(Class* object) { return Rcpp::wrap( object->*ptr ) ; }
-    void set(Class* object, SEXP value) { throw std::range_error("read only data member") ; }
+    void set(Class* /*object*/, SEXP /*value*/) { throw std::range_error("read only data member") ; }
     bool is_readonly(){ return true ; }
     std::string get_class(){ return class_name; }
 

--- a/inst/include/Rcpp/sugar/functions/cbind.h
+++ b/inst/include/Rcpp/sugar/functions/cbind.h
@@ -151,11 +151,11 @@ public:
     
     inline R_xlen_t ncol() const { return 1; }
     
-    inline stored_type operator[](R_xlen_t i) const {
+    inline stored_type operator[](R_xlen_t /*i*/) const {
         return t;
     }
     
-    inline stored_type operator()(R_xlen_t i, R_xlen_t j) const {
+    inline stored_type operator()(R_xlen_t /*i*/, R_xlen_t /*j*/) const {
         return t;
     }
 };
@@ -443,7 +443,7 @@ inline typename Rcpp::traits::enable_if<
     has_stored_type<T>::value, 
     MakeBindableCall<T, true> 
 >::type 
-MakeBindable(const T& t) {
+MakeBindable(const T& /*t*/) {
     return MakeBindableCall<T, true>();
 }
 
@@ -452,7 +452,7 @@ inline typename Rcpp::traits::enable_if<
     !has_stored_type<T>::value, 
     MakeBindableCall<T, false> 
 >::type
-MakeBindable(const T& t) {
+MakeBindable(const T& /*t*/) {
     return MakeBindableCall<T, false>();
 }
 

--- a/inst/include/Rcpp/sugar/functions/is_na.h
+++ b/inst/include/Rcpp/sugar/functions/is_na.h
@@ -55,7 +55,7 @@ public:
 
 	IsNa( const BASE& obj_) : obj(obj_){}
 
-        inline int operator[]( R_xlen_t i ) const {
+        inline int operator[]( R_xlen_t /*i*/ ) const {
 		return FALSE ;
 	}
 

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -36,7 +36,7 @@ public:
 
 	Col( const LHS_TYPE& lhs) : nr( lhs.ncol() ), nc( lhs.ncol() ) {}
 
-	inline int operator()( int i, int j ) const {
+	inline int operator()( int /*i*/, int j ) const {
 		return j + 1 ;
 	}
 

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -36,7 +36,7 @@ public:
 
 	Row( const LHS_TYPE& lhs) : nr( lhs.nrow() ), nc( lhs.ncol() ) {}
 
-	inline int operator()( int i, int j ) const {
+	inline int operator()( int i, int /*j*/ ) const {
 		return i + 1 ;
 	}
 

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -54,7 +54,7 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int i) const { return rhs ; }
+	inline int rhs_is_na(int /*i*/) const { return rhs ; }
 	inline int rhs_is_not_na(int i) const {
 		STORAGE x = lhs[i] ;
 		return Rcpp::traits::is_na<RTYPE>(x) ? NA_INTEGER : op( x, rhs ) ;
@@ -93,7 +93,7 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int i) const { return rhs ; }
+	inline int rhs_is_na(int /*i*/) const { return rhs ; }
 	inline int rhs_is_not_na(int i) const {
 		return op( lhs[i], rhs ) ;
 	}

--- a/inst/include/Rcpp/sugar/tools/safe_math.h
+++ b/inst/include/Rcpp/sugar/tools/safe_math.h
@@ -68,7 +68,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_add(T a, T b, const char* caller = nullptr) { return a + b; }
+    safe_add(T a, T b, const char* /*caller*/ = nullptr) { return a + b; }
 
     // Subtraction
     template <typename T>
@@ -94,7 +94,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_sub(T a, T b, const char* caller = nullptr) { return a - b; }
+    safe_sub(T a, T b, const char* /*caller*/ = nullptr) { return a - b; }
 
     // Multiplication
     template <typename T>
@@ -123,7 +123,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_mul(T a, T b, const char* caller = nullptr) { return a * b; }
+    safe_mul(T a, T b, const char* /*caller*/ = nullptr) { return a * b; }
 
 } // namespace detail
 } // namespace sugar

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -147,7 +147,7 @@ private:
 #endif
     }
 
-    void get_indices( traits::identity< traits::int2type<INTSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<INTSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         int* ptr = INTEGER(rhs); // ok to use int * here, we'll catch any problems inside check_indices
         check_indices(ptr, rhs_n, lhs_n);
@@ -157,7 +157,7 @@ private:
         indices_n = rhs_n;
     }
 
-    void get_indices( traits::identity< traits::int2type<REALSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<REALSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         std::vector<R_xlen_t> tmp(rhs.size()); // create temp R_xlen_t type indices from reals
         for(size_t i = 0 ; i < tmp.size() ; ++i) {
@@ -170,7 +170,7 @@ private:
         indices_n = rhs_n;
     }
 
-    void get_indices( traits::identity< traits::int2type<STRSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<STRSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         SEXP names = Rf_getAttrib(lhs, R_NamesSymbol);
         if (Rf_isNull(names)) stop("names is null");
@@ -185,7 +185,7 @@ private:
         indices_n = indices.size();
     }
 
-    void get_indices( traits::identity< traits::int2type<LGLSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<LGLSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         if (lhs_n != rhs_n) {
             stop("logical subsetting requires vectors of identical size");

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -529,7 +529,7 @@ public:
     }
 
     template <typename U>
-    static void replace_element__dispatch( traits::false_type, iterator it, SEXP names, R_xlen_t index, const U& u){
+    static void replace_element__dispatch( traits::false_type, iterator it, SEXP /*names*/, R_xlen_t /*index*/, const U& u){
         *it = converter_type::get(u);
     }
 

--- a/inst/tinytest/cpp/InternalFunction.cpp
+++ b/inst/tinytest/cpp/InternalFunction.cpp
@@ -27,7 +27,7 @@ int add(int a, int b) {
 	return a + b;
 }
 
-void dummy(int a, int b) {
+void dummy(int /*a*/, int /*b*/) {
 	Rcpp::Rcout << "dummy called" << std::endl;
 }
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -226,7 +226,7 @@ SEXP rcpp_can_use_cxx11() {
 }
 
 // [[Rcpp::register]]
-SEXP stack_trace(const char* file, int line) {
+SEXP stack_trace(const char* /*file*/, int /*line*/) {
     return R_NilValue;
 }                                                               // #nocov end
 


### PR DESCRIPTION
Fixes for when building under `-Wextra`, particularly for users who want to compile their Rcpp code with `-Wextra`.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
