### PR TITLE
Add \usage section to four attributes manual pages (Closes #1486)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-07-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* man/dependsAttribute.Rd: Add \usage{} section to appease R-devel
+	* man/exportAttribute.Rd: Idem
+	* man/interfacesAttribute.Rd: Idem
+	* man/pluginsAttribute.Rd: Idem
+
 2026-07-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Revert back to mentioning rcpp-devel as R-forge is back,

--- a/man/dependsAttribute.Rd
+++ b/man/dependsAttribute.Rd
@@ -4,10 +4,16 @@
 \title{Rcpp::depends Attribute}
 
 \description{
-The \code{Rcpp::depends} attribute is added to a C++ source file to indicate that it has a compilation dependency on one or more other packages. For example:
+The \code{Rcpp::depends} attribute is added to a C++ source file to indicate
+that it has a compilation dependency on one or more other packages. For example:
 \preformatted{
 // [[Rcpp::depends(RcppArmadillo)]]
 }
+}
+
+\usage{
+# In C++ code:
+#   // [[Rcpp::depends(...)]]
 }
 
 \arguments{

--- a/man/exportAttribute.Rd
+++ b/man/exportAttribute.Rd
@@ -7,9 +7,16 @@
 The \code{Rcpp::export} attribute is added to a C++ function definition to indicate that it should be made available as an R function. The \code{\link{sourceCpp}} and \code{\link{compileAttributes}} functions process the \code{Rcpp::export} attribute by generating the code required to call the C++ function from R.
 }
 
+\usage{
+# In C++ code:
+#  // [[Rcpp::export]]
+# or
+#  // [[Rcpp::export(name)]]
+}
+
 \arguments{
   \item{name}{
-    Specify an alternate name for the generated R function (optional, defaults to the name of the C++ function if not specified).
+    Specify an alternate (quoted) name for the generated R function (optional, defaults to the name of the C++ function if not specified).
 }
 }
 

--- a/man/interfacesAttribute.Rd
+++ b/man/interfacesAttribute.Rd
@@ -10,6 +10,11 @@ The \code{Rcpp::interfaces} attribute is added to a C++ source file to specify w
 }
 }
 
+\usage{
+# In C++ code:
+#   // [[Rcpp::interfaces(...)]]
+}
+
 \arguments{
  \item{\dots}{
     Interfaces to generate for exported functions within the source file. Valid values are \code{r} and \code{cpp}, and more than one interface can be specified.

--- a/man/pluginsAttribute.Rd
+++ b/man/pluginsAttribute.Rd
@@ -11,6 +11,11 @@ The \code{Rcpp::plugins} attribute is added to a C++ source file to specify the
 }
 }
 
+\usage{
+# In C++ code:
+#  // [[Rcpp::plugins(...)]]
+}
+
 \arguments{
  \item{\dots}{
    Plugins to add to the compilation.
@@ -19,10 +24,10 @@ The \code{Rcpp::plugins} attribute is added to a C++ source file to specify the
 
 \details{
 Plugins must be registered using the \code{\link{registerPlugin}}
-function. 
+function.
 
 When included within a \code{\link{sourceCpp}} translation unit,
-the configuration-related fields of the plugin (e.g. \code{env} and 
+the configuration-related fields of the plugin (e.g. \code{env} and
 \code{LinkingTo}) are utilized, however the code-generation fields
 (e.g. \code{includes} and \code{body}) are not.
 
@@ -48,4 +53,3 @@ int useCpp11() {
 }
 }
 }
-


### PR DESCRIPTION
This PR addresses the new nag from R-devel described in #1486.  It affects only four Rd files, so no new code and no new tests.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
