### PR TITLE
protect new cons cell in named StretchyList::push_back()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,12 @@
 	* inst/include/Rcpp/proxy/NamesProxy.h: Idem
 	* inst/include/Rcpp/proxy/SlotProxy.h: Idem
 	* inst/tinytest/cpp/misc.cpp: Add regression tests
+
+2026-08-02  Kevin Ushey <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/api/meat/StretchyList.h: Protect the new cell
+	from collection during Rf_install() in named push_back() (#1489)
+	* inst/tinytest/cpp/misc.cpp: Add regression test
 	* inst/tinytest/test_misc.R: Idem
 
 2026-07-24  Dirk Eddelbuettel  <edd@debian.org>

--- a/inst/include/Rcpp/api/meat/StretchyList.h
+++ b/inst/include/Rcpp/api/meat/StretchyList.h
@@ -35,8 +35,8 @@ namespace Rcpp{
     template< typename T>
     StretchyList_Impl<StoragePolicy>& StretchyList_Impl<StoragePolicy>::push_back__impl( const T& obj, traits::true_type ){
         Shield<SEXP> s( wrap(obj.object) ) ;
-        SEXP tmp  = Rf_cons( s, R_NilValue );
         Symbol tag  = obj.name ;
+        SEXP tmp  = Rf_cons( s, R_NilValue );
         SET_TAG(tmp, tag) ;
         SEXP self = Storage::get__() ;
         SETCDR( CAR(self), tmp) ;

--- a/inst/tinytest/cpp/misc.cpp
+++ b/inst/tinytest/cpp/misc.cpp
@@ -174,6 +174,13 @@ StretchyList named_stretchy_list() {
 }
 
 // [[Rcpp::export]]
+StretchyList named_stretchy_list_dynamic(std::string name) {
+    StretchyList out;
+    out.push_back( Named(name, 42) );
+    return out;
+}
+
+// [[Rcpp::export]]
 void copy_field_gc(Reference a, Reference b) {
     a.field("x") = b.field("y");
 }

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -129,6 +129,17 @@ expect_equal(stretchy_list(), pairlist( "foo", 1L, 3.2 ))
 #    test.named_StretchyList <- function(){
 expect_equal(named_stretchy_list(), pairlist( a = "foo", b = 1L, c = 3.2 ))
 
+#    test.named_StretchyList_gc <- function(){
+## push_back() must keep the new cell protected across the Rf_install()
+## needed for a not-yet-interned tag name (#1489)
+name <- paste(sample(c(letters, LETTERS), 32, TRUE), collapse = "")
+gctorture(TRUE)
+result <- named_stretchy_list_dynamic(name)
+gctorture(FALSE)
+expected <- pairlist(42L)
+names(expected) <- name
+expect_equal(result, expected)
+
 #    test.FieldProxy.gc <- function(){
 ## copying a field whose value is computed freshly on access must keep
 ## that value protected across the assignment (#1491)


### PR DESCRIPTION
Fixes #1489.

The named variant of `StretchyList::push_back()` allocated the new cons cell before constructing the `Symbol` for its tag. If the tag name was not yet interned, `Rf_install()` could allocate and trigger a garbage collection that reclaimed the still-unreachable cell; `SET_TAG()` then wrote into a reclaimed node, which was subsequently linked into the list. See #1489 for a reproducible example via `Rcpp::sourceCpp()` and `gctorture()`.

The fix constructs the `Symbol` before calling `Rf_cons()`, matching the ordering already used by the named variant of `push_front()`.

Also adds a regression test exercising named `push_back()` with a freshly generated (never-interned) tag name under `gctorture()`; the test fails without the header change and passes with it.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests (checked locally with `RunAllRcppTests=yes` on R 4.6.1; `--no-manual --no-vignettes`, so the only flagged items were two vignette-packaging warnings from the local `--no-build-vignettes` build)
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
