### PR TITLE
protect fresh proxy get() results in conversion and assignment operators

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-08-03  Kevin Ushey <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/api/meat/proxy.h: Protect fresh SEXPs returned
+	from proxy get() in conversion and assignment operators (#1491)
+	* inst/include/Rcpp/proxy/Binding.h: Idem
+	* inst/include/Rcpp/proxy/NamesProxy.h: Idem
+	* inst/include/Rcpp/proxy/SlotProxy.h: Idem
+	* inst/tinytest/cpp/misc.cpp: Add regression tests
+	* inst/tinytest/test_misc.R: Idem
+
 2026-07-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/api/meat/proxy.h
+++ b/inst/include/Rcpp/api/meat/proxy.h
@@ -37,7 +37,8 @@ AttributeProxyPolicy<CLASS>::AttributeProxy::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 AttributeProxyPolicy<CLASS>::AttributeProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
@@ -48,7 +49,8 @@ AttributeProxyPolicy<CLASS>::AttributeProxy::operator SEXP() const {
 template <typename CLASS>
 template <typename T>
 AttributeProxyPolicy<CLASS>::const_AttributeProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
@@ -68,13 +70,15 @@ NamesProxyPolicy<CLASS>::NamesProxy::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 NamesProxyPolicy<CLASS>::NamesProxy::operator T() const {
-    return as<T>( get() );
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
 template <typename T>
 NamesProxyPolicy<CLASS>::const_NamesProxy::operator T() const {
-    return as<T>( get() );
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 // SlotProxy
@@ -89,7 +93,8 @@ SlotProxyPolicy<CLASS>::SlotProxy::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 SlotProxyPolicy<CLASS>::SlotProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 // TagProxy
@@ -104,7 +109,8 @@ TagProxyPolicy<CLASS>::TagProxy::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 TagProxyPolicy<CLASS>::TagProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
@@ -115,7 +121,8 @@ TagProxyPolicy<CLASS>::TagProxy::operator SEXP() const {
 template <typename CLASS>
 template <typename T>
 TagProxyPolicy<CLASS>::const_TagProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
@@ -135,13 +142,15 @@ BindingPolicy<CLASS>::Binding::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 BindingPolicy<CLASS>::Binding::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
 template <typename T>
 BindingPolicy<CLASS>::const_Binding::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 // DottedPairProxy
@@ -163,20 +172,25 @@ DottedPairProxyPolicy<CLASS>::DottedPairProxy::operator=(const traits::named_obj
 template <typename CLASS>
 template <typename T>
 DottedPairProxyPolicy<CLASS>::DottedPairProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
 template <typename T>
 DottedPairProxyPolicy<CLASS>::const_DottedPairProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 // FieldProxy
 template <typename CLASS>
 typename FieldProxyPolicy<CLASS>::FieldProxy&
 FieldProxyPolicy<CLASS>::FieldProxy::operator=(const FieldProxyPolicy<CLASS>::FieldProxy& rhs) {
-    if (this != &rhs) set(rhs.get());
+    if (this != &rhs) {
+        Shield<SEXP> x(rhs.get());
+        set(x);
+    }
     return *this;
 }
 
@@ -191,13 +205,15 @@ FieldProxyPolicy<CLASS>::FieldProxy::operator=(const T& rhs) {
 template <typename CLASS>
 template <typename T>
 FieldProxyPolicy<CLASS>::FieldProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 template <typename CLASS>
 template <typename T>
 FieldProxyPolicy<CLASS>::const_FieldProxy::operator T() const {
-    return as<T>(get());
+    Shield<SEXP> x(get());
+    return as<T>(x);
 }
 
 }

--- a/inst/include/Rcpp/proxy/Binding.h
+++ b/inst/include/Rcpp/proxy/Binding.h
@@ -45,8 +45,12 @@ public:
             env.unlockBinding(name) ;
         }
         Binding& operator=(const Binding& rhs){
-            if( *this != rhs )
-                set( rhs.get() ) ;
+            // NB: '*this != rhs' previously used here would not compile
+            // when this operator was instantiated
+            if( env.get__() != rhs.env.get__() || name != rhs.name ) {
+                Shield<SEXP> x( rhs.get() ) ;
+                set(x) ;
+            }
             return *this ;
         }
 

--- a/inst/include/Rcpp/proxy/NamesProxy.h
+++ b/inst/include/Rcpp/proxy/NamesProxy.h
@@ -31,7 +31,10 @@ public:
 
         /* lvalue uses */
         NamesProxy& operator=(const NamesProxy& rhs) {
-            if( this != &rhs) set( rhs.get() ) ;
+            if( this != &rhs) {
+                Shield<SEXP> x( rhs.get() ) ;
+                set(x) ;
+            }
             return *this ;
         }
 

--- a/inst/include/Rcpp/proxy/SlotProxy.h
+++ b/inst/include/Rcpp/proxy/SlotProxy.h
@@ -33,7 +33,8 @@ public:
         }
 
         SlotProxy& operator=(const SlotProxy& rhs){
-            set( rhs.get() ) ;
+            Shield<SEXP> x( rhs.get() ) ;
+            set(x) ;
             return *this ;
         }
 
@@ -65,7 +66,8 @@ public:
         }
 
         template <typename T> operator T() const {
-          return as<T>( get() );
+          Shield<SEXP> x( get() );
+          return as<T>(x);
         }
         inline operator SEXP() const {
             return get() ;

--- a/inst/tinytest/cpp/misc.cpp
+++ b/inst/tinytest/cpp/misc.cpp
@@ -174,6 +174,16 @@ StretchyList named_stretchy_list() {
 }
 
 // [[Rcpp::export]]
+void copy_field_gc(Reference a, Reference b) {
+    a.field("x") = b.field("y");
+}
+
+// [[Rcpp::export]]
+void copy_binding_gc(Environment a, Environment b) {
+    a["x"] = b["y"];
+}
+
+// [[Rcpp::export]]
 void test_stop_variadic() {
     stop( "%s %d", "foo", 3 );
 }

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -129,6 +129,34 @@ expect_equal(stretchy_list(), pairlist( "foo", 1L, 3.2 ))
 #    test.named_StretchyList <- function(){
 expect_equal(named_stretchy_list(), pairlist( a = "foo", b = 1L, c = 3.2 ))
 
+#    test.FieldProxy.gc <- function(){
+## copying a field whose value is computed freshly on access must keep
+## that value protected across the assignment (#1491)
+FooGC <- setRefClass("FooGC", fields = list(
+    x = "ANY",
+    y = function(value) {
+        if (missing(value)) new.env(parent = emptyenv()) else stop("read-only")
+    }
+))
+a <- FooGC$new(x = NULL)
+b <- FooGC$new(x = NULL)
+gctorture(TRUE)
+for (i in 1:20)
+    copy_field_gc(a, b)
+gctorture(FALSE)
+expect_true(is.environment(a$x))
+
+#    test.Binding.gc <- function(){
+## same for environment-to-environment binding copies (#1491)
+ea <- new.env()
+eb <- new.env()
+makeActiveBinding("y", function() new.env(parent = emptyenv()), eb)
+gctorture(TRUE)
+for (i in 1:20)
+    copy_binding_gc(ea, eb)
+gctorture(FALSE)
+expect_true(is.environment(ea$x))
+
 #    test.stop.variadic <- function(){
 m <- tryCatch( test_stop_variadic(), error = function(e){
     conditionMessage(e)


### PR DESCRIPTION
Fixes #1491.

The proxy `operator T()` conversions and the proxy-to-proxy assignment operators passed the raw result of `get()` into allocating calls: `as<T>()` coercions on the conversion side, and `set()` implementations that allocate before capturing the value on the assignment side. When `get()` returns a freshly computed SEXP (an active binding or active RefClass field, a field access evaluated via `$`, an attribute expanded by `Rf_getAttrib()`), that object is referenced from nowhere the GC can see, and a collection inside the window frees it while still in use. See #1491 for the analysis, including why standard builds of recent R rarely surface this (internal protection in `coerceVector()` since R 4.1.0, and `R_UnwindProtect()` accidentally keeping eval results reachable via the continuation token).

Changes:

- `api/meat/proxy.h`: `Shield` the `get()` result in all thirteen `operator T()` conversions and in `FieldProxy::operator=(const FieldProxy&)`.
- `proxy/SlotProxy.h`: same for `const_SlotProxy::operator T()` (defined inline) and `SlotProxy::operator=(const SlotProxy&)`.
- `proxy/Binding.h`, `proxy/NamesProxy.h`: same for the proxy-to-proxy assignments.
- `Binding::operator=(const Binding&)` additionally had a latent compile error: its self-assignment guard `*this != rhs` is ambiguous (the template conversion operators make it match unrelated `!=` overloads), so the operator failed to compile whenever it was actually instantiated. The guard now compares the environment and name directly; the new regression test is this operator's first instantiation.
- Reviewed but intentionally not changed: `AttributeProxy::operator=(const AttributeProxy&)` (its `set()` shields immediately upon entry) and `generic_name_proxy::operator T()` in `vector/proxy.h` (its `get()` returns a parent-reachable element).

Verification:

- On an ASan/UBSan build of R-devel (r90339) with structure checking, the repro from #1491 fails with `unprotected object (0x...) encountered (was ENVSXP)` against current master and runs clean with this patch.
- New regression tests exercise `FieldProxy` and `Binding` copies from actively-computed values under `gctorture()`; they pass on standard builds and guard the fix on protect-checking builds such as CRAN's ASan setup.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests (checked locally with `RunAllRcppTests=yes` on R 4.6.1; `--no-manual --no-vignettes`, so the only flagged items were two vignette-packaging warnings from the local `--no-build-vignettes` build)
- [x] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
