### PR TITLE
protect module method and function results while wrapping in invoke

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-08-03  Kevin Ushey  <kevinushey@gmail.com>
+
+	* inst/include/Rcpp/module/class.h (invoke): Protect freshly
+	computed method results while wrapping them in the result list
+	(#1493)
+	* inst/include/Rcpp/module/Module.h (invoke): Idem for module
+	function results
+	* inst/tinytest/cpp/Module.cpp: Add regression test
+	* inst/tinytest/test_module.R: Idem
+
 2026-07-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/include/Rcpp/module/Module.h
+++ b/inst/include/Rcpp/module/Module.h
@@ -60,8 +60,9 @@ namespace Rcpp {
                 throw std::range_error( "incorrect number of arguments" ) ;
             }
 
+            Shield<SEXP> res( fun->operator()( args ) ) ;
             return List::create(
-                _["result"] = fun->operator()( args ),
+                _["result"] = static_cast<SEXP>(res),
                 _["void"]   = fun->is_void()
             ) ;
         }

--- a/inst/include/Rcpp/module/class.h
+++ b/inst/include/Rcpp/module/class.h
@@ -193,7 +193,8 @@
                 m->operator()( XP(object), args );
                 return Rcpp::List::create( true ) ;
             } else {
-                return Rcpp::List::create( false, m->operator()( XP(object), args ) ) ;
+                Shield<SEXP> res( m->operator()( XP(object), args ) ) ;
+                return Rcpp::List::create( false, static_cast<SEXP>(res) ) ;
             }
             END_RCPP
                 }

--- a/inst/tinytest/cpp/Module.cpp
+++ b/inst/tinytest/cpp/Module.cpp
@@ -136,6 +136,27 @@ double Test_get_x_pointer(ModuleTest* x) {
     return x->value;
 }
 
+class ModuleGadget {
+public:
+    ModuleGadget() {}
+
+    // void overload: forces dispatch through class_::invoke(), which
+    // wraps method results as list(voidness, result)
+    void value(int x) {
+        (void) x;
+    }
+
+    // non-void overload: nothing protects the raw SEXP result while
+    // class_::invoke() allocates the result list
+    SEXP value() {
+        SEXP x = Rf_allocVector(REALSXP, 3);
+        REAL(x)[0] = 1;
+        REAL(x)[1] = 2;
+        REAL(x)[2] = 3;
+        return x;
+    }
+};
+
 RCPP_MODULE(demoModule) {
     function("hello", &hello);
     function("bar"  , &bar  );
@@ -193,6 +214,12 @@ RCPP_MODULE(demoModule) {
         .constructor<double,double>()
 
         .method("get" , &ModuleRandomizer::get)
+        ;
+
+    class_<ModuleGadget>("ModuleGadget")
+        .constructor()
+        .method("value", static_cast<void (ModuleGadget::*)(int)>(&ModuleGadget::value))
+        .method("value", static_cast<SEXP (ModuleGadget::*)()>(&ModuleGadget::value))
         ;
 }
 

--- a/inst/tinytest/test_module.R
+++ b/inst/tinytest/test_module.R
@@ -109,15 +109,11 @@ expect_equal( test_const( seq(0,10) ), 11L )
 
 ## mixed-voidness method overloads dispatch through class_::invoke(),
 ## which must protect the freshly allocated method result while it
-## wraps it in the result list (#1493)
+## wraps it in the result list (#1493); under gctorture every
+## allocation triggers a collection, so a single call exercises the
+## unprotected window deterministically
 gadget <- new( ModuleGadget )
-ok <- TRUE
 gctorture(TRUE)
-for (i in 1:20) {
-    if (!identical(gadget$value(), c(1, 2, 3))) {
-        ok <- FALSE
-        break
-    }
-}
+res <- gadget$value()
 gctorture(FALSE)
-expect_true( ok )
+expect_identical( res, c(1, 2, 3) )

--- a/inst/tinytest/test_module.R
+++ b/inst/tinytest/test_module.R
@@ -106,3 +106,18 @@ expect_equal(r$get(10), x10)
 expect_equal( test_reference( seq(0,10) ), 11L )
 expect_equal( test_const_reference( seq(0,10) ), 11L )
 expect_equal( test_const( seq(0,10) ), 11L )
+
+## mixed-voidness method overloads dispatch through class_::invoke(),
+## which must protect the freshly allocated method result while it
+## wraps it in the result list (#1493)
+gadget <- new( ModuleGadget )
+ok <- TRUE
+gctorture(TRUE)
+for (i in 1:20) {
+    if (!identical(gadget$value(), c(1, 2, 3))) {
+        ok <- FALSE
+        break
+    }
+}
+gctorture(FALSE)
+expect_true( ok )


### PR DESCRIPTION
Fixes #1493.

In Rcpp modules, `class_<T>::invoke()` passed the freshly computed method result straight into `Rcpp::List::create()`, which allocates the result list and the voidness flag before the result is stored anywhere the garbage collector can see. A collection inside that window frees the result while it is still in use. `Module::invoke()` had the same shape for module functions, with a wider window (the result list's names are allocated too). See #1493 for the analysis, including why results returned as Rcpp objects are usually (but not reliably) masked by generational promotion.

Changes:

- `module/class.h`: `Shield` the method result in `class_::invoke()` before wrapping it in the result list.
- `module/Module.h`: same for the function result in `Module::invoke()`.
- `inst/tinytest/cpp/Module.cpp`, `inst/tinytest/test_module.R`: regression test exercising a method name with mixed-voidness overloads (the dispatch path that reaches `class_::invoke()`, previously uncovered) under `gctorture()`.

Verification:

- On an ASan/UBSan build of R-devel (r90339) with structure checking, the repro from #1493 fails with `unprotected object (0x...) encountered (was REALSXP)` against current master, and runs clean with this patch.
- The new regression test passes on standard builds and guards the fix on protect-checking builds such as CRAN's ASan setup.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests (checked locally with `RunAllRcppTests=yes` on R 4.6.1; `--no-manual --no-vignettes`, so the only flagged items were the two vignette-packaging warnings from the local `--no-build-vignettes` build)
- [x] Preferably, new tests were added which fail without the change (fails on protect-checking builds of R; on standard builds the use-after-free is silent)
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
