### PR TITLE
convert c++ exceptions to r errors in module .External entry points

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-08-03  Kevin Ushey  <kevinushey@gmail.com>
+
+	* src/module.cpp (class__newInstance, CppMethod__invoke,
+	CppMethod__invoke_void, CppMethod__invoke_notvoid): Convert C++
+	exceptions to R errors at these .External entry points, so that
+	e.g. calling a method on an uninitialized module object raises
+	the intended R error rather than terminating the R session
+	(#1495)
+	* inst/tinytest/test_module.R: Add regression test
+
 2026-07-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/inst/tinytest/test_module.R
+++ b/inst/tinytest/test_module.R
@@ -102,6 +102,12 @@ x10 <- runif(10, 10.0, 20.0)
 set.seed(123)
 expect_equal(r$get(10), x10)
 
+## calling a method on an uninitialized module object (created via the
+## dummy-object path for classes without a default constructor) should
+## raise an R error rather than terminating the R session (#1495)
+r <- new( ModuleRandomizer )
+expect_error( r$get(10L), "not initialized" )
+
 #    test.Module.flexible.semantics <- function( ){
 expect_equal( test_reference( seq(0,10) ), 11L )
 expect_equal( test_const_reference( seq(0,10) ), 11L )

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -135,12 +135,14 @@ END_RCPP
 }														// #nocov end
 
 SEXP class__newInstance(SEXP args) {
+BEGIN_RCPP
     SEXP p = CDR(args);
 
     XP_Module module(CAR(p)); p = CDR(p);
     XP_Class clazz(CAR(p)); p = CDR(p);
     UNPACK_EXTERNAL_ARGS(cargs,p)
     return clazz->newInstance(cargs, nargs);
+END_RCPP
 }
 
 // relies on being set in .onLoad()
@@ -164,6 +166,7 @@ SEXP class__dummyInstance(SEXP args) {
 }
 
 SEXP CppMethod__invoke(SEXP args) {						// #nocov start
+BEGIN_RCPP
     SEXP p = CDR(args);
 
     // the external pointer to the class
@@ -180,9 +183,11 @@ SEXP CppMethod__invoke(SEXP args) {						// #nocov start
     UNPACK_EXTERNAL_ARGS(cargs,p)
 
     return clazz->invoke(met, obj, cargs, nargs);
-}														// #nocov end 
+END_RCPP
+}														// #nocov end
 
 SEXP CppMethod__invoke_void(SEXP args) {
+BEGIN_RCPP
     SEXP p = CDR(args);
 
     // the external pointer to the class
@@ -199,9 +204,11 @@ SEXP CppMethod__invoke_void(SEXP args) {
     UNPACK_EXTERNAL_ARGS(cargs,p)
     clazz->invoke_void(met, obj, cargs, nargs);
     return R_NilValue;
+END_RCPP
 }
 
 SEXP CppMethod__invoke_notvoid(SEXP args) {
+BEGIN_RCPP
     SEXP p = CDR(args);
 
     // the external pointer to the class
@@ -218,6 +225,7 @@ SEXP CppMethod__invoke_notvoid(SEXP args) {
     UNPACK_EXTERNAL_ARGS(cargs,p)
 
     return clazz->invoke_notvoid(met, obj, cargs, nargs);
+END_RCPP
 }
 
 namespace Rcpp{


### PR DESCRIPTION
Fixes #1495.

`CppMethod__invoke`, `CppMethod__invoke_void`, `CppMethod__invoke_notvoid`, and `class__newInstance` in `src/module.cpp` are `.External` entry points that can throw C++ exceptions -- most notably `CHECK_DUMMY_OBJ`'s `Rcpp::not_initialized`, the designed error for using a module object created via the dummy-object path (`new(Class)` with no arguments, for a class without a default constructor). With no `BEGIN_RCPP`/`END_RCPP` in these functions, the exception escapes into R's C evaluator uncaught and `std::terminate()` aborts the whole R session, instead of raising the intended R error. See #1495 for details.

Changes:

- `src/module.cpp`: wrap the four entry points in `BEGIN_RCPP`/`END_RCPP`, so exceptions are converted to R errors as elsewhere in Rcpp. On the `not_initialized` path this also unwinds the local `XPtr` objects properly before the R error is raised.
- `inst/tinytest/test_module.R`: regression test -- calling a method on an uninitialized `ModuleRandomizer` must raise the "C++ object not initialized" R error. Without the fix this test aborts the tinytest process.

One pre-existing quirk surfaced while testing (left unchanged, noting it here): when a dummy object is garbage collected, the reference class finalizer calls `class_<T>::run_finalizer()`, whose `XP(object)` rejects the dummy pointer (an environment), printing `Error: Expecting an external pointer: [type=environment].` at shutdown. That happens on current master for any dummy object whose finalizer runs and is independent of this change; it could be addressed separately by having `run_finalizer()` (or `CppObject__finalize`) skip the dummy instance.

Verification:

- The repro from #1495 aborts (`SIGABRT`, exit code 134) against current master and prints `caught R error: C++ object not initialized. (Missing default constructor?)` with exit code 0 against a build of this branch.
- `R CMD check` with `RunAllRcppTests=yes` passes on R 4.6.1.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests (checked locally with `RunAllRcppTests=yes` on R 4.6.1; `--no-manual --no-vignettes`, so the only flagged items were the two vignette-packaging warnings from the local `--no-build-vignettes` build)
- [x] Preferably, new tests were added which fail without the change (without the fix, the new test terminates the test process)
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
