### PR TITLE
Avoid -Wcast-function-type warnings

### DIFF
--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  RCPP_CXXFLAGS: "-Werror"
+  RCPP_CXXFLAGS: "-Werror -Wcast-function-type"
 
 jobs:
   ci:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2026-09-03  Iñaki Ucar <iucar@fedoraproject.org>
+
+	* .github/workflows/werror.yaml: Add -Wcast-function-type
+
+	* inst/include/Rcpp/routines.h: New function pointer RCPP_FUNC typedef used
+	as an intermediate cast target to avoid gcc's -Wcast-function-type warnings
+	* inst/include/Rcpp/Module.h: Idem
+	* src/rcpp_init.cpp: Idem
+
+	* src/attributes.cpp: Generate RCPP_FUNC-routed casts in interface code
+	* inst/examples/ConvolveBenchmarks/overhead_1.cpp: Update generated code
+	* inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp: Idem
+	* inst/tinytest/testRcppInterfaceExporter/inst/include/testRcppInterfaceExporter_RcppExports.h: Idem
+
 2026-09-01  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add new CI file with -Werror enabled

--- a/inst/examples/ConvolveBenchmarks/overhead_1.cpp
+++ b/inst/examples/ConvolveBenchmarks/overhead_1.cpp
@@ -12,7 +12,7 @@ SEXP overhead_cpp(SEXP a, SEXP b) {
 extern "C" void R_init_overhead_1(DllInfo *info){
 
      R_CallMethodDef callMethods[]  = {
-       {"overhead_cpp", (DL_FUNC) &overhead_cpp, 2},
+       {"overhead_cpp", (DL_FUNC) (RCPP_FUNC) &overhead_cpp, 2},
        {NULL, NULL, 0}
      };
 

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -113,7 +113,7 @@ namespace Rcpp {
             inline int nargs() { return sizeof...(T); }
             inline bool is_void() { return std::is_void<RESULT_TYPE>::value; }
             inline void signature(std::string& s, const char* name) { Rcpp::signature<RESULT_TYPE, T...>(s, name); }
-            inline DL_FUNC get_function_ptr() { return (DL_FUNC)ptr_fun; }
+            inline DL_FUNC get_function_ptr() { return (DL_FUNC)(RCPP_FUNC)ptr_fun; }
 
         private:
             RESULT_TYPE (*ptr_fun)(T...);

--- a/inst/include/Rcpp/routines.h
+++ b/inst/include/Rcpp/routines.h
@@ -25,6 +25,10 @@
 
 #include <Rcpp/iostream/Rstreambuf.h>
 
+// Necessary to cast a function pointer to a seemingly incompatible function
+// pointer type while avoiding gcc's -Wcast-function-type warnings.
+typedef void (*RCPP_FUNC)(void);
+
 #if defined(COMPILING_RCPP)
 
 // the idea is that this file should be generated automatically by Rcpp::register
@@ -79,7 +83,7 @@ SEXP          rcpp_get_current_error();
 
 namespace Rcpp {
 
-    #define GET_CALLABLE(__FUN__) (Fun) R_GetCCallable( "Rcpp", __FUN__ )
+    #define GET_CALLABLE(__FUN__) (Fun) (RCPP_FUNC) R_GetCCallable( "Rcpp", __FUN__ )
 
     inline attribute_hidden const char* type2name(SEXP x){
         typedef const char* (*Fun)(SEXP);

--- a/inst/tinytest/testRcppInterfaceExporter/inst/include/testRcppInterfaceExporter_RcppExports.h
+++ b/inst/tinytest/testRcppInterfaceExporter/inst/include/testRcppInterfaceExporter_RcppExports.h
@@ -15,7 +15,7 @@ namespace testRcppInterfaceExporter {
             Rcpp::Function require = Rcpp::Environment::base_env()["require"];
             require("testRcppInterfaceExporter", Rcpp::Named("quietly") = true);
             typedef int(*Ptr_validate)(const char*);
-            static Ptr_validate p_validate = (Ptr_validate)
+            static Ptr_validate p_validate = (Ptr_validate) (RCPP_FUNC)
                 R_GetCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_RcppExport_validate");
             if (!p_validate(sig)) {
                 throw Rcpp::function_not_exported(
@@ -29,7 +29,7 @@ namespace testRcppInterfaceExporter {
         static Ptr_test_cpp_interface p_test_cpp_interface = NULL;
         if (p_test_cpp_interface == NULL) {
             validateSignature("SEXP(*test_cpp_interface)(SEXP,bool)");
-            p_test_cpp_interface = (Ptr_test_cpp_interface)R_GetCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_test_cpp_interface");
+            p_test_cpp_interface = (Ptr_test_cpp_interface) (RCPP_FUNC)R_GetCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_test_cpp_interface");
         }
         RObject rcpp_result_gen;
         {

--- a/inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp
+++ b/inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp
@@ -60,14 +60,14 @@ static int _testRcppInterfaceExporter_RcppExport_validate(const char* sig) {
 
 // registerCCallable (register entry points for exported C++ functions)
 RcppExport SEXP _testRcppInterfaceExporter_RcppExport_registerCCallable() { 
-    R_RegisterCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_test_cpp_interface", (DL_FUNC)_testRcppInterfaceExporter_test_cpp_interface_try);
-    R_RegisterCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_RcppExport_validate", (DL_FUNC)_testRcppInterfaceExporter_RcppExport_validate);
+    R_RegisterCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_test_cpp_interface", (DL_FUNC) (RCPP_FUNC) _testRcppInterfaceExporter_test_cpp_interface_try);
+    R_RegisterCCallable("testRcppInterfaceExporter", "_testRcppInterfaceExporter_RcppExport_validate", (DL_FUNC) (RCPP_FUNC) _testRcppInterfaceExporter_RcppExport_validate);
     return R_NilValue;
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_testRcppInterfaceExporter_test_cpp_interface", (DL_FUNC) &_testRcppInterfaceExporter_test_cpp_interface, 2},
-    {"_testRcppInterfaceExporter_RcppExport_registerCCallable", (DL_FUNC) &_testRcppInterfaceExporter_RcppExport_registerCCallable, 0},
+    {"_testRcppInterfaceExporter_test_cpp_interface", (DL_FUNC) (RCPP_FUNC) &_testRcppInterfaceExporter_test_cpp_interface, 2},
+    {"_testRcppInterfaceExporter_RcppExport_registerCCallable", (DL_FUNC) (RCPP_FUNC) &_testRcppInterfaceExporter_RcppExport_registerCCallable, 0},
     {NULL, NULL, 0}
 };
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -2103,7 +2103,7 @@ namespace attributes {
             ostr() << "static const R_CallMethodDef CallEntries[] = {" << std::endl;
             for (std::size_t i=0;i<routineNames.size(); i++) {
                 ostr() << "    {\"" << routineNames[i] <<  "\", " <<
-                    "(DL_FUNC) &" << routineNames[i] << ", " <<
+                    "(DL_FUNC) (RCPP_FUNC) &" << routineNames[i] << ", " <<
                         routineArgs[i] <<  "}," << std::endl;
             }
             if (callEntries.size() > 0) {
@@ -2148,7 +2148,7 @@ namespace attributes {
         std::string indentStr(indent, ' ');
         ostr <<  indentStr << "R_RegisterCCallable(\"" << package() << "\", "
               << "\"" << packageCppPrefix() << "_" << exportedName << "\", "
-              << "(DL_FUNC)" << packageCppPrefix() << "_" << name << ");";
+              << "(DL_FUNC) (RCPP_FUNC) " << packageCppPrefix() << "_" << name << ");";
         return ostr.str();					// #nocov end
     }
 
@@ -2221,7 +2221,7 @@ namespace attributes {
 
         std::string ptrName = "p_" + validate;
         ostr() << "            static " << fnType << " " << ptrName << " = "
-               << "(" << fnType << ")" << std::endl
+               << "(" << fnType << ") (RCPP_FUNC)" << std::endl
                << "                "
                << getCCallable(exportValidationFunctionRegisteredName())
                << ";" << std::endl;
@@ -2279,7 +2279,7 @@ namespace attributes {
                        << "(\"" << function.signature() << "\");"
                        << std::endl;
                 ostr() << "            " << ptrName << " = "
-                       << "(" << fnType << ")"
+                       << "(" << fnType << ") (RCPP_FUNC)"
                        << getCCallable(packageCppPrefix() + "_" + function.name()) << ";"
                        << std::endl;
                 ostr() << "        }" << std::endl;

--- a/src/rcpp_init.cpp
+++ b/src/rcpp_init.cpp
@@ -25,8 +25,8 @@
 #include "internal.h"
 
 // borrowed from Matrix
-#define CALLDEF(name, n)  {#name, (DL_FUNC) &name, n}
-#define EXTDEF(name)  {#name, (DL_FUNC) &name, -1}
+#define CALLDEF(name, n)  {#name, (DL_FUNC) (RCPP_FUNC) &name, n}
+#define EXTDEF(name)  {#name, (DL_FUNC) (RCPP_FUNC) &name, -1}
 
 static R_CallMethodDef callEntries[]  = {
     CALLDEF(Class__name,1),
@@ -89,7 +89,7 @@ void registerFunctions(){
     using namespace Rcpp;
     using namespace Rcpp::internal;
 
-    #define RCPP_REGISTER(__FUN__) R_RegisterCCallable( "Rcpp", #__FUN__ , (DL_FUNC)__FUN__ );
+    #define RCPP_REGISTER(__FUN__) R_RegisterCCallable( "Rcpp", #__FUN__ , (DL_FUNC) (RCPP_FUNC) __FUN__ );
     RCPP_REGISTER(rcpp_get_stack_trace)
     RCPP_REGISTER(rcpp_set_stack_trace)
     RCPP_REGISTER(type2name)


### PR DESCRIPTION
Closes #1500. Addressing this one first because this flag is added by `-Wextra` and it gets in the way of other warnings.

As the [gcc manual suggests](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcast-function-type), and [others apply](https://github.com/postgres/postgres/blob/534db08f972852b77ea5e96e77d5fe45f3d8df93/src/include/c.h#L602-L607), I've defined a new `typedef void (*RCPP_FUNC)(void)` that is used as a generic intermediate cast. This affects not only our function casts, but also to the generated interfaces, so client packages will see this warning go away too only when they regenerate their interface with an updated version of Rcpp.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
