### PR TITLE
Avoid -Wdeprecated-copy warnings

### DIFF
--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  RCPP_CXXFLAGS: "-Werror -Wcast-function-type"
+  RCPP_CXXFLAGS: "-Werror -Wcast-function-type -Wdeprecated-copy"
 
 jobs:
   ci:

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,12 @@
 	* inst/tinytest/testRcppInterfaceExporter/src/RcppExports.cpp: Idem
 	* inst/tinytest/testRcppInterfaceExporter/inst/include/testRcppInterfaceExporter_RcppExports.h: Idem
 
+	* .github/workflows/werror.yaml: Add -Wdeprecated-copy
+
+	* inst/include/Rcpp/date_datetime/newDateVector.h: Remove redundant custom
+	copy operator to avoid -Wdeprecated-copy warnings
+	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
+
 2026-09-01  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add new CI file with -Werror enabled

--- a/inst/include/Rcpp/date_datetime/newDateVector.h
+++ b/inst/include/Rcpp/date_datetime/newDateVector.h
@@ -48,14 +48,6 @@ namespace Rcpp {
             return v;
         }
 
-        inline newDateVector &operator=(const newDateVector &rhs) {
-            if (this != &rhs) {
-                NumericVector::operator=(rhs);
-            }
-
-            return *this;
-        }
-
         friend inline std::ostream &operator<<(std::ostream & s, const newDateVector d);
 
     private:

--- a/inst/include/Rcpp/date_datetime/newDatetimeVector.h
+++ b/inst/include/Rcpp/date_datetime/newDatetimeVector.h
@@ -56,15 +56,6 @@ namespace Rcpp {
             return v;
         }
 
-        inline newDatetimeVector &operator=(const newDatetimeVector &rhs) {
-            if (this != &rhs) {
-                NumericVector::operator=(rhs);
-                this->attr("tzone") = rhs.attr("tzone");
-            }
-
-            return *this;
-        }
-
         friend inline std::ostream &operator<<(std::ostream & s, const newDatetimeVector d);
 
     private:


### PR DESCRIPTION
Closes #1498. As discussed there, this was triggered by the _[rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming))_ in the `Date(time)Vector` classes. This removes the redundant copy constructor, delegating in the parent class (note that the `tzone` assignment was a no-op, because the value is already there).

Like the previous PR, this should be harmless. But anyway I checked `anytime`, which uses these classes, and all is good.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
