### PR TITLE
Avoid -Wimplicit-fallthrough warnings

### DIFF
--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  RCPP_CXXFLAGS: "-Werror -Wcast-function-type -Wdeprecated-copy"
+  RCPP_CXXFLAGS: "-Werror -Wcast-function-type -Wdeprecated-copy -Wimplicit-fallthrough"
 
 jobs:
   ci:

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,13 @@
 	copy operator to avoid -Wdeprecated-copy warnings
 	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
 
+	* .github/workflows/werror.yaml: Add -Wimplicit-fallthrough
+
+	* inst/include/Rcpp/algo.h: Add explicit fallthrough comments to avoid
+	-Wimplicit-fallthrough warnings
+	* inst/include/Rcpp/vector/RangeIndexer.h: Idem
+	* inst/include/Rcpp/macros/unroll.h: Idem
+
 2026-09-01  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add new CI file with -Werror enabled

--- a/inst/include/Rcpp/algo.h
+++ b/inst/include/Rcpp/algo.h
@@ -64,14 +64,17 @@ inline bool __any( RandomAccessIterator __first, RandomAccessIterator __last, co
 	  if (*__first == __val)
 	    return true;
 	  ++__first;
+	  // fallthrough
 	case 2:
 	  if (*__first == __val)
 	    return true;
 	  ++__first;
+	  // fallthrough
 	case 1:
 	  if (*__first == __val)
 	    return true;
 	  ++__first;
+	  // fallthrough
 	case 0:
 	default:
 	  return false;

--- a/inst/include/Rcpp/macros/unroll.h
+++ b/inst/include/Rcpp/macros/unroll.h
@@ -33,11 +33,11 @@ for ( ; __trip_count > 0 ; --__trip_count) {   \
 }                                              \
 switch (n - i){                                \
   case 3:                                      \
-    *TARGET++ = SOURCE[i++] ;                  \
+    *TARGET++ = SOURCE[i++] ; /* fallthrough */ \
   case 2:                                      \
-    *TARGET++ = SOURCE[i++] ;                  \
+    *TARGET++ = SOURCE[i++] ; /* fallthrough */ \
   case 1:                                      \
-    *TARGET++ = SOURCE[i++] ;                  \
+    *TARGET++ = SOURCE[i++] ; /* fallthrough */ \
   case 0:                                      \
   default:                                     \
       {}                                       \

--- a/inst/include/Rcpp/vector/RangeIndexer.h
+++ b/inst/include/Rcpp/vector/RangeIndexer.h
@@ -35,11 +35,11 @@
     }                                                \
     switch (size_ - i){                              \
       case 3:                                        \
-          start[i] OP input[i] ; i++ ;               \
+          start[i] OP input[i] ; i++ ; /* fallthrough */ \
       case 2:                                        \
-          start[i] OP input[i] ; i++ ;               \
+          start[i] OP input[i] ; i++ ; /* fallthrough */ \
       case 1:                                        \
-          start[i] OP input[i] ; i++ ;               \
+          start[i] OP input[i] ; i++ ; /* fallthrough */ \
       case 0:                                        \
       default:                                       \
           return *this ;                             \


### PR DESCRIPTION
Closes #1504. We had some fallthrough comments in some places but not in others. This completes all cases.

Question: the `RCPP_LOOP_UNROLL_PTR` macro that I patch here too didn't raise any warning because it's not used at all. It's dead. I didn't find any references of client packages using it either. Should we just remove it?

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
