### PR TITLE
Avoid -Wunused-parameter warnings

### DIFF
--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    container: rocker/drd
+    container: eddelbuettel/drd:26.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  RCPP_CXXFLAGS: "-Werror -Wcast-function-type -Wdeprecated-copy -Wimplicit-fallthrough"
+  RCPP_CXXFLAGS: "-Werror -Wall -Wextra"
 
 jobs:
   ci:

--- a/ChangeLog
+++ b/ChangeLog
@@ -26,7 +26,8 @@
 	* inst/include/Rcpp/macros/unroll.h: Idem
 
 	* .github/workflows/werror.yaml: Add -Wall -Wextra, substituting the
-	previous ones, which enables them but also -Wunused-parameter and more
+	previous ones, which enables them but also -Wunused-parameter and more,
+	and switch to a container with gcc16
 
 	* src/api.cpp: Comment out parameters to avoid -Wunused-parameter warnings
 	* inst/include/Rcpp/Module.h: Idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,28 @@
 	* inst/include/Rcpp/vector/RangeIndexer.h: Idem
 	* inst/include/Rcpp/macros/unroll.h: Idem
 
+	* .github/workflows/werror.yaml: Add -Wall -Wextra, substituting the
+	previous ones, which enables them but also -Wunused-parameter and more
+
+	* src/api.cpp: Comment out parameters to avoid -Wunused-parameter warnings
+	* inst/include/Rcpp/Module.h: Idem
+	* inst/include/Rcpp/Promise.h: Idem
+	* inst/include/Rcpp/StretchyList.h: Idem
+	* inst/include/Rcpp/internal/wrap.h: Idem
+	* inst/include/Rcpp/module/Module_Field.h: Idem
+	* inst/include/Rcpp/sugar/functions/cbind.h: Idem
+	* inst/include/Rcpp/sugar/functions/is_na.h: Idem
+	* inst/include/Rcpp/sugar/matrix/col.h: Idem
+	* inst/include/Rcpp/sugar/matrix/row.h: Idem
+	* inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h: Idem
+	* inst/include/Rcpp/sugar/tools/safe_math.h: Idem
+	* inst/include/Rcpp/vector/Subsetter.h: Idem
+	* inst/include/Rcpp/vector/Vector.h: Idem
+	* inst/tinytest/cpp/InternalFunction.cpp: Idem
+	* inst/tinytest/cpp/attributes.cpp: Reference parameters in the body instead
+	* inst/tinytest/cpp/ListOf.cpp: Idem
+	* inst/tinytest/cpp/Vector.cpp: Idem
+
 2026-09-01  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add new CI file with -Werror enabled

--- a/inst/include/Rcpp/Module.h
+++ b/inst/include/Rcpp/Module.h
@@ -205,7 +205,7 @@ namespace Rcpp{
 
     private:
         template <int... Is>
-        Class* get_new_impl(SEXP* args, int nargs, traits::index_sequence<Is...>) {
+        Class* get_new_impl(SEXP* args, int /*nargs*/, traits::index_sequence<Is...>) {
             return new Class( as<T>(args[Is])... ) ;
         }
     };
@@ -222,7 +222,7 @@ namespace Rcpp{
     class Factory : public Factory_Base<Class> {
     public:
         Factory( Class* (*fun)(T...) ) : ptr_fun(fun){}
-        virtual Class* get_new( SEXP* args, int nargs ){
+        virtual Class* get_new( SEXP* args, int /*nargs*/ ){
             return get_new( args, traits::make_index_sequence<sizeof...(T)>() ) ;
         }
         virtual int nargs(){ return sizeof...(T) ; }

--- a/inst/include/Rcpp/Promise.h
+++ b/inst/include/Rcpp/Promise.h
@@ -77,7 +77,7 @@ namespace Rcpp{
             return Environment( PRENV(Storage::get__() ) ) ;
         }
 
-        inline void update(SEXP data){}
+        inline void update(SEXP /*data*/){}
 
     } ;
 

--- a/inst/include/Rcpp/StretchyList.h
+++ b/inst/include/Rcpp/StretchyList.h
@@ -48,7 +48,7 @@ namespace Rcpp{
             Storage::set__(r_cast<LISTSXP>(x)) ;
         }
 
-        void update(SEXP x){}
+        void update(SEXP /*x*/){}
 
         inline operator SEXP() const{
             return CDR(Storage::get__() );

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -906,7 +906,7 @@ namespace Rcpp {
      template <> inline SEXP wrap<Rcpp::String>(const Rcpp::String& object);
 
      template <typename T>
-     inline SEXP module_wrap_dispatch(const T& obj, Rcpp::traits::void_wrap_tag) {
+     inline SEXP module_wrap_dispatch(const T& /*obj*/, Rcpp::traits::void_wrap_tag) {
          return R_NilValue;
      }
 

--- a/inst/include/Rcpp/module/Module_Field.h
+++ b/inst/include/Rcpp/module/Module_Field.h
@@ -54,7 +54,7 @@ public:
 	prop_class(doc), ptr(ptr_), class_name(DEMANGLE(PROP)) {}
 
     SEXP get(Class* object) { return Rcpp::wrap( object->*ptr ) ; }
-    void set(Class* object, SEXP value) { throw std::range_error("read only data member") ; }
+    void set(Class* /*object*/, SEXP /*value*/) { throw std::range_error("read only data member") ; }
     bool is_readonly(){ return true ; }
     std::string get_class(){ return class_name; }
 

--- a/inst/include/Rcpp/sugar/functions/cbind.h
+++ b/inst/include/Rcpp/sugar/functions/cbind.h
@@ -151,11 +151,11 @@ public:
     
     inline R_xlen_t ncol() const { return 1; }
     
-    inline stored_type operator[](R_xlen_t i) const {
+    inline stored_type operator[](R_xlen_t /*i*/) const {
         return t;
     }
-    
-    inline stored_type operator()(R_xlen_t i, R_xlen_t j) const {
+
+    inline stored_type operator()(R_xlen_t /*i*/, R_xlen_t /*j*/) const {
         return t;
     }
 };
@@ -442,8 +442,8 @@ template <typename T>
 inline typename Rcpp::traits::enable_if<
     has_stored_type<T>::value, 
     MakeBindableCall<T, true> 
->::type 
-MakeBindable(const T& t) {
+>::type
+MakeBindable(const T& /*t*/) {
     return MakeBindableCall<T, true>();
 }
 
@@ -452,7 +452,7 @@ inline typename Rcpp::traits::enable_if<
     !has_stored_type<T>::value, 
     MakeBindableCall<T, false> 
 >::type
-MakeBindable(const T& t) {
+MakeBindable(const T& /*t*/) {
     return MakeBindableCall<T, false>();
 }
 

--- a/inst/include/Rcpp/sugar/functions/is_na.h
+++ b/inst/include/Rcpp/sugar/functions/is_na.h
@@ -55,7 +55,7 @@ public:
 
 	IsNa( const BASE& obj_) : obj(obj_){}
 
-        inline int operator[]( R_xlen_t i ) const {
+        inline int operator[]( R_xlen_t /*i*/ ) const {
 		return FALSE ;
 	}
 

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -36,7 +36,7 @@ public:
 
 	Col( const LHS_TYPE& lhs) : nr( lhs.ncol() ), nc( lhs.ncol() ) {}
 
-	inline int operator()( int i, int j ) const {
+	inline int operator()( int /*i*/, int j ) const {
 		return j + 1 ;
 	}
 

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -36,7 +36,7 @@ public:
 
 	Row( const LHS_TYPE& lhs) : nr( lhs.nrow() ), nc( lhs.ncol() ) {}
 
-	inline int operator()( int i, int j ) const {
+	inline int operator()( int i, int /*j*/ ) const {
 		return i + 1 ;
 	}
 

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -54,7 +54,7 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int i) const { return rhs ; }
+	inline int rhs_is_na(int /*i*/) const { return rhs ; }
 	inline int rhs_is_not_na(int i) const {
 		STORAGE x = lhs[i] ;
 		return Rcpp::traits::is_na<RTYPE>(x) ? NA_INTEGER : op( x, rhs ) ;
@@ -93,7 +93,7 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int i) const { return rhs ; }
+	inline int rhs_is_na(int /*i*/) const { return rhs ; }
 	inline int rhs_is_not_na(int i) const {
 		return op( lhs[i], rhs ) ;
 	}

--- a/inst/include/Rcpp/sugar/tools/safe_math.h
+++ b/inst/include/Rcpp/sugar/tools/safe_math.h
@@ -68,7 +68,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_add(T a, T b, const char* caller = nullptr) { return a + b; }
+    safe_add(T a, T b, const char* /*caller*/ = nullptr) { return a + b; }
 
     // Subtraction
     template <typename T>
@@ -94,7 +94,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_sub(T a, T b, const char* caller = nullptr) { return a - b; }
+    safe_sub(T a, T b, const char* /*caller*/ = nullptr) { return a - b; }
 
     // Multiplication
     template <typename T>
@@ -123,7 +123,7 @@ namespace detail {
 
     template <typename T>
     inline typename std::enable_if<!std::is_integral<T>::value, T>::type
-    safe_mul(T a, T b, const char* caller = nullptr) { return a * b; }
+    safe_mul(T a, T b, const char* /*caller*/ = nullptr) { return a * b; }
 
 } // namespace detail
 } // namespace sugar

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -147,7 +147,7 @@ private:
 #endif
     }
 
-    void get_indices( traits::identity< traits::int2type<INTSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<INTSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         int* ptr = INTEGER(rhs); // ok to use int * here, we'll catch any problems inside check_indices
         check_indices(ptr, rhs_n, lhs_n);
@@ -157,7 +157,7 @@ private:
         indices_n = rhs_n;
     }
 
-    void get_indices( traits::identity< traits::int2type<REALSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<REALSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         std::vector<R_xlen_t> tmp(rhs.size()); // create temp R_xlen_t type indices from reals
         for(size_t i = 0 ; i < tmp.size() ; ++i) {
@@ -170,7 +170,7 @@ private:
         indices_n = rhs_n;
     }
 
-    void get_indices( traits::identity< traits::int2type<STRSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<STRSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         SEXP names = Rf_getAttrib(lhs, R_NamesSymbol);
         if (Rf_isNull(names)) stop("names is null");
@@ -185,7 +185,7 @@ private:
         indices_n = indices.size();
     }
 
-    void get_indices( traits::identity< traits::int2type<LGLSXP> > t ) {
+    void get_indices( traits::identity< traits::int2type<LGLSXP> > /*t*/ ) {
         indices.reserve(rhs_n);
         if (lhs_n != rhs_n) {
             stop("logical subsetting requires vectors of identical size");

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -529,7 +529,7 @@ public:
     }
 
     template <typename U>
-    static void replace_element__dispatch( traits::false_type, iterator it, SEXP names, R_xlen_t index, const U& u){
+    static void replace_element__dispatch( traits::false_type, iterator it, SEXP /*names*/, R_xlen_t /*index*/, const U& u){
         *it = converter_type::get(u);
     }
 

--- a/inst/tinytest/cpp/InternalFunction.cpp
+++ b/inst/tinytest/cpp/InternalFunction.cpp
@@ -27,7 +27,7 @@ int add(int a, int b) {
 	return a + b;
 }
 
-void dummy(int a, int b) {
+void dummy(int /*a*/, int /*b*/) {
 	Rcpp::Rcout << "dummy called" << std::endl;
 }
 

--- a/inst/tinytest/cpp/ListOf.cpp
+++ b/inst/tinytest/cpp/ListOf.cpp
@@ -25,6 +25,7 @@ NumericVector test_sapply_sum(NVList x) {
 
 // [[Rcpp::export]]
 NVList test_assign(NVList x, NumericVector y, CharacterVector z) {
+    (void)z;
     x[1] = y;
     x[2] = 1;
     return x;

--- a/inst/tinytest/cpp/Vector.cpp
+++ b/inst/tinytest/cpp/Vector.cpp
@@ -802,6 +802,7 @@ LogicalVector logical_vector_from_bool_assign() {
 
 // [[Rcpp::export]]
 void no_op(int major) {
+    (void)major;
     //int minor = 1;
 }
 

--- a/inst/tinytest/cpp/attributes.cpp
+++ b/inst/tinytest/cpp/attributes.cpp
@@ -23,15 +23,18 @@ std::string parse_declaration_test(std::string msg = "Parse function declaration
 
 // [[Rcpp::export]]
 std::string parse_default_values_with_str_parenthesis(const char* a = "(", const char* b= ")", std::string msg = "Parse function header with parenthis inside default string values.") {
+	(void)a; (void)b;
 	return msg;
 }
 
 // [[Rcpp::export]]
 std::string parse_default_values_with_chr_parenthesis(char a = '(', char b= ')', std::string msg = "Parse function header with parenthis inside default char values.") {
+	(void)a; (void)b;
 	return msg;
 }
 
 // [[Rcpp::export]]
 std::string parse_default_values_with_chr_backslash(char a = '\\', std::string msg = "Parse function header with backslash inside default char values.") {
+	(void)a;
 	return msg;
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -226,7 +226,7 @@ SEXP rcpp_can_use_cxx11() {
 }
 
 // [[Rcpp::register]]
-SEXP stack_trace(const char* file, int line) {
+SEXP stack_trace(const char* /*file*/, int /*line*/) {
     return R_NilValue;
 }                                                               // #nocov end
 


### PR DESCRIPTION
Closes #1499, and closes #1497 by setting just `-Wall -Wextra` instead of all individual warnings we've been fixing.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
