### PR TITLE
Fix -Wconversion warnings

### DIFF
--- a/.github/workflows/werror.yml
+++ b/.github/workflows/werror.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  RCPP_CXXFLAGS: "-Werror -Wall -Wextra"
+  RCPP_CXXFLAGS: "-Werror -Wall -Wextra -Wconversion"
 
 jobs:
   ci:

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,51 @@
 	* inst/include/Rcpp/vector/Vector.h: Idem
 	* inst/tinytest/cpp/InternalFunction.cpp: Idem
 
+	* .github/workflows/werror.yaml: Add -Wconversion
+
+	* inst/include/Rcpp/macros/interface.h: Mark GenericProxy constructor as
+	explicit to resolve ambiguities with validated SEXP constructors
+	* inst/include/Rcpp/vector/Vector.h: Idem
+	* inst/include/Rcpp/DataFrame.h: Idem with ad hoc constructor
+	* inst/include/Rcpp/vector/ListOf.h: In this case, the implicit conversion
+	of ListOf<T> e.g. from List is intentional, so the previously generic
+	constructor now gets restricted to cases that are convertible to SEXP
+
+	* inst/include/Rcpp/stats/dpq/dpq.h: Expand and homogenize R_xlen_t use
+	* inst/include/Rcpp/sugar/functions/head.h: Idem
+	* inst/include/Rcpp/vector/MatrixColumn.h: Idem
+	* inst/include/Rcpp/vector/MatrixRow.h: Idem
+	* inst/include/Rcpp/vector/RangeIndexer.h: Idem
+	* inst/include/Rcpp/internal/wrap.h: Idem and fix potential integer overflow
+	* inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h: Idem and
+	fix a bug where rhs_is_na may return NaN instead of NA_INTEGER
+	* inst/include/Rcpp/Language.h: Revert incorrect use of R_xlen_t
+	* inst/include/Rcpp/vector/SubMatrix.h: Idem, because Matrix rows and cols
+	are restricted to int anyway
+
+	* src/date.cpp: Add missing explicit integer narrowing
+	* inst/tinytest/cpp/dates.cpp: Add static_cast to time_t
+	* inst/tinytest/cpp/language.cpp: Fix implicit cast to int
+	* inst/tinytest/cpp/Matrix.cpp: Idem
+	* inst/tinytest/cpp/Module.cpp: Idem
+	* inst/tinytest/cpp/String.cpp: Idem
+	* inst/tinytest/cpp/Vector.cpp: Idem
+	* inst/include/Rcpp/vector/Matrix.h: Idem
+	* inst/include/Rcpp/vector/Vector.h: Idem
+	* inst/include/Rcpp/sugar/Range.h: Idem
+	* inst/include/Rcpp/sugar/functions/seq_along.h: Idem
+	* inst/include/Rcpp/sugar/functions/rowSums.h: Idem
+	* inst/include/Rcpp/sugar/functions/sample.h: Idem
+	* inst/include/Rcpp/sugar/matrix/col.h: Idem
+	* inst/include/Rcpp/sugar/matrix/diag.h: Idem
+	* inst/include/Rcpp/sugar/matrix/lower_tri.h: Idem
+	* inst/include/Rcpp/sugar/matrix/outer.h: Idem
+	* inst/include/Rcpp/sugar/matrix/row.h: Idem
+	* inst/include/Rcpp/sugar/matrix/upper_tri.h: Idem
+	* inst/include/Rcpp/sugar/functions/var.h: Add static_cast to double
+	* inst/include/Rcpp/vector/Subsetter.h: Add several necessary static_cast
+	* inst/include/Rcpp/vector/MatrixBase.h: Idem
+
 2026-09-03  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add -Wcast-function-type

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,27 +1,4 @@
-2026-09-04  Dirk Eddelbuettel  <edd@debian.org>
-
-	* DESCRIPTION (Version, Date): Roll micro version and date
-	* inst/include/Rcpp/config.h: Idem
-
-2026-09-04  Iñaki Ucar <iucar@fedoraproject.org>
-
-	* inst/include/Rcpp/Module.h: Update copyright
-	* inst/include/Rcpp/StretchyList.h: Idem
-	* inst/include/Rcpp/algo.h: Idem
-	* inst/include/Rcpp/config.h: Idem
-	* inst/include/Rcpp/date_datetime/newDateVector.h: Idem
-	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
-	* inst/include/Rcpp/internal/wrap.h: Idem
-	* inst/include/Rcpp/macros/unroll.h: Idem
-	* inst/include/Rcpp/module/Module_Field.h: Idem
-	* inst/include/Rcpp/sugar/functions/cbind.h: Idem
-	* inst/include/Rcpp/sugar/functions/is_na.h: Idem
-	* inst/include/Rcpp/sugar/matrix/col.h: Idem
-	* inst/include/Rcpp/sugar/matrix/row.h: Idem
-	* inst/include/Rcpp/vector/RangeIndexer.h: Idem
-	* inst/include/Rcpp/vector/Subsetter.h: Idem
-	* inst/include/Rcpp/vector/Vector.h: Idem
-	* inst/tinytest/cpp/InternalFunction.cpp: Idem
+2026-09-05  Iñaki Ucar <iucar@fedoraproject.org>
 
 	* .github/workflows/werror.yaml: Add -Wconversion
 
@@ -67,6 +44,31 @@
 	* inst/include/Rcpp/sugar/functions/var.h: Add static_cast to double
 	* inst/include/Rcpp/vector/Subsetter.h: Add several necessary static_cast
 	* inst/include/Rcpp/vector/MatrixBase.h: Idem
+
+2026-09-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll micro version and date
+	* inst/include/Rcpp/config.h: Idem
+
+2026-09-04  Iñaki Ucar <iucar@fedoraproject.org>
+
+	* inst/include/Rcpp/Module.h: Update copyright
+	* inst/include/Rcpp/StretchyList.h: Idem
+	* inst/include/Rcpp/algo.h: Idem
+	* inst/include/Rcpp/config.h: Idem
+	* inst/include/Rcpp/date_datetime/newDateVector.h: Idem
+	* inst/include/Rcpp/date_datetime/newDatetimeVector.h: Idem
+	* inst/include/Rcpp/internal/wrap.h: Idem
+	* inst/include/Rcpp/macros/unroll.h: Idem
+	* inst/include/Rcpp/module/Module_Field.h: Idem
+	* inst/include/Rcpp/sugar/functions/cbind.h: Idem
+	* inst/include/Rcpp/sugar/functions/is_na.h: Idem
+	* inst/include/Rcpp/sugar/matrix/col.h: Idem
+	* inst/include/Rcpp/sugar/matrix/row.h: Idem
+	* inst/include/Rcpp/vector/RangeIndexer.h: Idem
+	* inst/include/Rcpp/vector/Subsetter.h: Idem
+	* inst/include/Rcpp/vector/Vector.h: Idem
+	* inst/tinytest/cpp/InternalFunction.cpp: Idem
 
 2026-09-03  Iñaki Ucar <iucar@fedoraproject.org>
 

--- a/inst/include/Rcpp/DataFrame.h
+++ b/inst/include/Rcpp/DataFrame.h
@@ -1,7 +1,8 @@
 
 // DataFrame.h: Rcpp R/C++ interface class library -- data frames
 //
-// Copyright (C) 2010 - 2026  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -47,7 +48,7 @@ namespace Rcpp{
         }
 
         template <typename T>
-        DataFrame_Impl( const T& obj ) ;
+        explicit DataFrame_Impl( const T& obj ) ;
 
         DataFrame_Impl& operator=( DataFrame_Impl& other){
             if (*this != other) set__(other);

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -1,8 +1,8 @@
 
 // Language.h: Rcpp R/C++ interface class library -- language objects (calls)
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/Language.h
+++ b/inst/include/Rcpp/Language.h
@@ -1,7 +1,8 @@
 
 // Language.h: Rcpp R/C++ interface class library -- language objects (calls)
 //
-// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -189,7 +190,7 @@ namespace Rcpp{
         class unary_call : public std::function<RESULT_TYPE(T)> {
     public:
         unary_call( Language call_ ) : call(call_), proxy(call_,1) {}
-        unary_call( Language call_, R_xlen_t index ) : call(call_), proxy(call_,index){}
+        unary_call( Language call_, int index ) : call(call_), proxy(call_,index){}
         unary_call( Function fun ) : call( fun, R_NilValue), proxy(call,1) {}
 
         RESULT_TYPE operator()( const T& object ){
@@ -206,7 +207,7 @@ namespace Rcpp{
         class binary_call : public std::function<RESULT_TYPE(T1,T2)> {
     public:
         binary_call( Language call_ ) : call(call_), proxy1(call_,1), proxy2(call_,2) {}
-        binary_call( Language call_, R_xlen_t index1, R_xlen_t index2 ) : call(call_), proxy1(call_,index1), proxy2(call_,index2){}
+        binary_call( Language call_, int index1, int index2 ) : call(call_), proxy1(call_,index1), proxy2(call_,index2){}
         binary_call( Function fun) : call(fun, R_NilValue, R_NilValue), proxy1(call,1), proxy2(call,2){}
 
         RESULT_TYPE operator()( const T1& o1, const T2& o2 ){

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -564,7 +564,7 @@ namespace Rcpp {
 	template <typename T>
         inline SEXP wrap_dispatch_matrix_logical(const T& object, ::Rcpp::traits::true_type) {
             int nr = object.nrow(), nc = object.ncol();
-            Shield<SEXP> res(Rf_allocVector(LGLSXP, nr * nc));
+            Shield<SEXP> res(Rf_allocVector(LGLSXP, static_cast<R_xlen_t>(nr) * nc));
             int k=0;
             int* p = LOGICAL(res);
             for (int j=0; j<nc; j++)
@@ -581,7 +581,7 @@ namespace Rcpp {
         inline SEXP wrap_dispatch_matrix_primitive(const T& object) {
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<STORAGE>::rtype;
             int nr = object.nrow(), nc = object.ncol();
-            Shield<SEXP> res(Rf_allocVector(RTYPE, nr*nc));
+            Shield<SEXP> res(Rf_allocVector(RTYPE, static_cast<R_xlen_t>(nr)*nc));
 
             int k=0;
             STORAGE* p = r_vector_start< RTYPE>(res);
@@ -603,7 +603,7 @@ namespace Rcpp {
 	template <typename T>
         inline SEXP wrap_dispatch_matrix_not_logical(const T& object, ::Rcpp::traits::r_type_string_tag) {
             int nr = object.nrow(), nc = object.ncol();
-            Shield<SEXP> res(Rf_allocVector(STRSXP, nr*nc));
+            Shield<SEXP> res(Rf_allocVector(STRSXP, static_cast<R_xlen_t>(nr)*nc));
 
             int k=0;
             for (int j=0; j<nc; j++)
@@ -619,7 +619,7 @@ namespace Rcpp {
     	template <typename T>
         inline SEXP wrap_dispatch_matrix_not_logical(const T& object, ::Rcpp::traits::r_type_generic_tag) {
             int nr = object.nrow(), nc = object.ncol();
-            Shield<SEXP> res(Rf_allocVector(VECSXP, nr*nc));
+            Shield<SEXP> res(Rf_allocVector(VECSXP, static_cast<R_xlen_t>(nr)*nc));
 
             int k=0;
             for (int j=0; j<nc; j++)

--- a/inst/include/Rcpp/internal/wrap.h
+++ b/inst/include/Rcpp/internal/wrap.h
@@ -665,12 +665,12 @@ namespace Rcpp {
 
 	template <typename T, typename elem_type>
         inline SEXP wrap_dispatch_importer__impl__prim(const T& object, ::Rcpp::traits::false_type) {
-            int size = object.size();
+            R_xlen_t size = object.size();
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<elem_type>::rtype;
             Shield<SEXP> x(Rf_allocVector(RTYPE, size));
             typedef typename ::Rcpp::traits::storage_type<RTYPE>::type CTYPE;
             CTYPE* start = r_vector_start<RTYPE>(x);
-            for (int i=0; i<size; i++) {
+            for (R_xlen_t i=0; i<size; i++) {
 		start[i] = object.get(i);
             }
             return x;
@@ -679,12 +679,12 @@ namespace Rcpp {
 
     	template <typename T, typename elem_type>
     	inline SEXP wrap_dispatch_importer__impl__prim(const T& object, ::Rcpp::traits::true_type) {
-            int size = object.size();
+            R_xlen_t size = object.size();
             const int RTYPE = ::Rcpp::traits::r_sexptype_traits<elem_type>::rtype;
             Shield<SEXP> x(Rf_allocVector(RTYPE, size));
             typedef typename ::Rcpp::traits::storage_type<RTYPE>::type CTYPE;
             CTYPE* start = r_vector_start<RTYPE>(x);
-            for (int i=0; i<size; i++) {
+            for (R_xlen_t i=0; i<size; i++) {
 		start[i] = caster<elem_type,CTYPE>(object.get(i));
             }
             return x;
@@ -698,9 +698,9 @@ namespace Rcpp {
 
 	template <typename T, typename elem_type>
         inline SEXP wrap_dispatch_importer__impl(const T& object, ::Rcpp::traits::r_type_string_tag) {
-            int size = object.size();
+            R_xlen_t size = object.size();
             Shield<SEXP> x(Rf_allocVector(STRSXP, size));
-            for (int i=0; i<size; i++) {
+            for (R_xlen_t i=0; i<size; i++) {
 		SET_STRING_ELT(x, i, make_charsexp(object.get(i)));
             }
             return x;
@@ -708,9 +708,9 @@ namespace Rcpp {
 
     	template <typename T, typename elem_type>
     	inline SEXP wrap_dispatch_importer__impl(const T& object, ::Rcpp::traits::r_type_generic_tag) {
-            int size = object.size();
+            R_xlen_t size = object.size();
             Shield<SEXP> x(Rf_allocVector(VECSXP, size));
-            for (int i=0; i<size; i++) {
+            for (R_xlen_t i=0; i<size; i++) {
 		SET_VECTOR_ELT(x, i, object.wrap(i));
             }
             return x;

--- a/inst/include/Rcpp/macros/interface.h
+++ b/inst/include/Rcpp/macros/interface.h
@@ -1,4 +1,5 @@
-// Copyright (C) 2013 Romain Francois
+// Copyright (C) 2013 - 2025  Romain Francois
+// Copyright (C) 2026         Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -31,7 +32,7 @@ __CLASS__& operator=(const __CLASS__& rhs) {                                   \
     return Storage::copy__(rhs) ;                                              \
 }                                                                              \
 template <typename Proxy>                                                      \
-__CLASS__( const GenericProxy<Proxy>& proxy ){                                 \
+explicit __CLASS__( const GenericProxy<Proxy>& proxy ){                        \
     Storage::set__( proxy.get() ) ;                                            \
 }
 
@@ -42,7 +43,7 @@ __CLASS__& operator=(const __CLASS__& rhs) {                                   \
     return Storage::copy__(rhs) ;                                              \
 }                                                                              \
 template <typename Proxy>                                                      \
-__CLASS__( const GenericProxy<Proxy>& proxy ){                                 \
+explicit __CLASS__( const GenericProxy<Proxy>& proxy ){                        \
     Storage::set__( proxy.get() ) ;                                            \
 }
 

--- a/inst/include/Rcpp/stats/dpq/dpq.h
+++ b/inst/include/Rcpp/stats/dpq/dpq.h
@@ -2,7 +2,8 @@
 //
 // dpq.h: Rcpp R/C++ interface class library -- normal distribution
 //
-// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -38,11 +39,11 @@ public:
     D0( FunPtr ptr_, const VEC_TYPE& vec_, bool log_ ) :
         ptr(ptr_), vec(vec_), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -59,11 +60,11 @@ public:
     D1( FunPtr ptr_, const VEC_TYPE& vec_, double p0_ , bool log_) :
         ptr(ptr_), vec(vec_), p0(p0_), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -81,11 +82,11 @@ public:
     D2( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_ , bool log_) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -103,11 +104,11 @@ public:
     D3( FunPtr ptr_, const VEC_TYPE& vec_, double p0_, double p1_, double p2_ , bool log_ ) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, p2, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -129,11 +130,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -153,11 +154,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -178,11 +179,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -201,11 +202,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, p2, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -227,11 +228,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -250,11 +251,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -274,11 +275,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;
@@ -298,11 +299,11 @@ public:
         bool lower_tail = true, bool log_ = false ) :
         ptr(ptr_), vec(vec_), p0(p0_), p1(p1_), p2(p2_), lower(lower_tail), log(log_) {}
 
-    inline double operator[]( int i) const {
+    inline double operator[]( R_xlen_t i) const {
         return ptr( vec[i], p0, p1, p2, lower, log );
     }
 
-    inline int size() const { return vec.size(); }
+    inline R_xlen_t size() const { return vec.size(); }
 
 private:
     FunPtr ptr ;

--- a/inst/include/Rcpp/stats/dpq/dpq.h
+++ b/inst/include/Rcpp/stats/dpq/dpq.h
@@ -2,8 +2,8 @@
 //
 // dpq.h: Rcpp R/C++ interface class library -- normal distribution
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/sugar/Range.h
+++ b/inst/include/Rcpp/sugar/Range.h
@@ -2,7 +2,8 @@
 //
 // Range.h: Rcpp R/C++ interface class library --
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -36,8 +37,8 @@ namespace Rcpp{
             return end_ - start + 1;
         }
 
-        inline R_xlen_t operator[]( R_xlen_t i) const {
-            return start + i ;
+        inline int operator[]( R_xlen_t i) const {
+            return static_cast<int>(start + i) ;
         }
 
         Range& operator++() {

--- a/inst/include/Rcpp/sugar/functions/head.h
+++ b/inst/include/Rcpp/sugar/functions/head.h
@@ -2,8 +2,8 @@
 //
 // head.h: Rcpp R/C++ interface class library -- head
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/sugar/functions/head.h
+++ b/inst/include/Rcpp/sugar/functions/head.h
@@ -2,7 +2,8 @@
 //
 // head.h: Rcpp R/C++ interface class library -- head
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -44,7 +45,7 @@ public:
 
 private:
 	const VEC_TYPE& object ;
-	int n ;
+	R_xlen_t n ;
 } ;
 
 } // sugar

--- a/inst/include/Rcpp/sugar/functions/rowSums.h
+++ b/inst/include/Rcpp/sugar/functions/rowSums.h
@@ -120,7 +120,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nr);
 
         for (j = 0; j < nc; j++) {
@@ -164,7 +164,7 @@ public:                                                                         
     {}                                                                                                      \
                                                                                                             \
     return_vector get() const {                                                                             \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                    \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                     \
         return_vector res(nr);                                                                              \
                                                                                                             \
         for (j = 0; j < nc; j++) {                                                                          \
@@ -207,7 +207,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nr);
 
         stored_type current = stored_type();
@@ -248,7 +248,7 @@ public:                                                                         
     {}                                                                                                      \
                                                                                                             \
     return_vector get() const {                                                                             \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                    \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                     \
         return_vector res(nr);                                                                              \
                                                                                                             \
         stored_type current = stored_type();                                                                \
@@ -301,7 +301,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nc);
 
         for (j = 0; j < nc; j++) {
@@ -337,7 +337,7 @@ public:                                                                         
     {}                                                                                                      \
                                                                                                             \
     return_vector get() const {                                                                             \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                    \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                     \
         return_vector res(nc);                                                                              \
                                                                                                             \
         for (j = 0; j < nc; j++) {                                                                          \
@@ -380,7 +380,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nc);
 
         stored_type current = stored_type();
@@ -421,7 +421,7 @@ public:                                                                         
     {}                                                                                                      \
                                                                                                             \
     return_vector get() const {                                                                             \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                    \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                     \
         return_vector res(nc);                                                                              \
                                                                                                             \
         stored_type current = stored_type();                                                                \
@@ -477,7 +477,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nr);
 
         for (j = 0; j < nc; j++) {
@@ -517,7 +517,7 @@ public:                                                                         
     {}                                                                                                          \
                                                                                                                 \
     return_vector get() const {                                                                                 \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                        \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                         \
         return_vector res(nr);                                                                                  \
                                                                                                                 \
         for (j = 0; j < nc; j++) {                                                                              \
@@ -564,7 +564,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nr);
 
         std::vector<R_xlen_t> n_ok(nr, 0);
@@ -616,7 +616,7 @@ public:                                                                         
     {}                                                                                                          \
                                                                                                                 \
     return_vector get() const {                                                                                 \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                        \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                         \
         return_vector res(nr);                                                                                  \
                                                                                                                 \
         std::vector<R_xlen_t> n_ok(nr, 0);                                                                      \
@@ -677,7 +677,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nc);
 
         for (j = 0; j < nc; j++) {
@@ -717,7 +717,7 @@ public:                                                                         
     {}                                                                                                          \
                                                                                                                 \
     return_vector get() const {                                                                                 \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                        \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                         \
         return_vector res(nc);                                                                                  \
                                                                                                                 \
         for (j = 0; j < nc; j++) {                                                                              \
@@ -764,7 +764,7 @@ public:
     {}
 
     return_vector get() const {
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());
         return_vector res(nc);
 
         std::vector<R_xlen_t> n_ok(nc, 0);
@@ -816,7 +816,7 @@ public:                                                                         
     {}                                                                                                          \
                                                                                                                 \
     return_vector get() const {                                                                                 \
-        R_xlen_t i, j, nr = ref.nrow(), nc = ref.ncol();                                                        \
+        int i, j, nr = static_cast<int>(ref.nrow()), nc = static_cast<int>(ref.ncol());                         \
         return_vector res(nc);                                                                                  \
                                                                                                                 \
         std::vector<R_xlen_t> n_ok(nc, 0);                                                                      \

--- a/inst/include/Rcpp/sugar/functions/sample.h
+++ b/inst/include/Rcpp/sugar/functions/sample.h
@@ -2,7 +2,8 @@
 //
 // sample.h: Rcpp R/C++ interface class library -- sample
 //
-// Copyright (C) 2016 Nathan Russell
+// Copyright (C) 2016 - 2025 Nathan Russell
+// Copyright (C) 2026        Nathan Russell and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -113,7 +114,7 @@ inline Vector<INTSXP> SampleReplace(Vector<REALSXP>& p, int n, int k, bool one_b
 template <int RTYPE>
 inline Vector<RTYPE> SampleReplace(Vector<REALSXP>& p, int k, const Vector<RTYPE>& ref)
 {
-    int n = ref.size();
+    int n = static_cast<int>(ref.size());
 
     Vector<INTSXP> perm = no_init(n);
     Vector<RTYPE> ans = no_init(k);
@@ -200,7 +201,7 @@ inline Vector<INTSXP> WalkerSample(const Vector<REALSXP>& p, int n, int nans, bo
 template <int RTYPE>
 inline Vector<RTYPE> WalkerSample(const Vector<REALSXP>& p, int nans, const Vector<RTYPE>& ref)
 {
-    int n = ref.size();
+    int n = static_cast<int>(ref.size());
 
     Vector<INTSXP> a = no_init(n);
     Vector<RTYPE> ans = no_init(nans);
@@ -294,7 +295,7 @@ inline Vector<INTSXP> SampleNoReplace(Vector<REALSXP>& p, int n, int nans, bool 
 template <int RTYPE>
 inline Vector<RTYPE> SampleNoReplace(Vector<REALSXP>& p, int nans, const Vector<RTYPE>& ref)
 {
-    int n = ref.size();
+    int n = static_cast<int>(ref.size());
 
     Vector<INTSXP> perm = no_init(n);
     Vector<RTYPE> ans = no_init(nans);
@@ -366,7 +367,7 @@ inline Vector<INTSXP> EmpiricalSample(int n, int size, bool replace, bool one_ba
 template <int RTYPE>
 inline Vector<RTYPE> EmpiricalSample(int size, bool replace, const Vector<RTYPE>& ref)
 {
-    int n = ref.size();
+    int n = static_cast<int>(ref.size());
 
     Vector<RTYPE> ans = no_init(size);
     typename Vector<RTYPE>::iterator ians = ans.begin(), eans = ans.end();
@@ -436,7 +437,7 @@ template <int RTYPE>
 inline Vector<RTYPE>
 sample(const Vector<RTYPE>& x, int size, bool replace = false, sugar::probs_t probs = R_NilValue)
 {
-    int n = x.size();
+    int n = static_cast<int>(x.size());
 
     if (probs.isNotNull()) {
         Vector<REALSXP> p = clone(probs.get());

--- a/inst/include/Rcpp/sugar/functions/seq_along.h
+++ b/inst/include/Rcpp/sugar/functions/seq_along.h
@@ -2,7 +2,8 @@
 //
 // seq_along.h: Rcpp R/C++ interface class library -- any
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -29,8 +30,8 @@ class SeqLen : public VectorBase< INTSXP,false,SeqLen > {
 public:
         SeqLen( R_xlen_t len_ ) : len(len_){}
 
-        inline R_xlen_t operator[]( R_xlen_t i ) const {
-		return 1 + i ;
+        inline int operator[]( R_xlen_t i ) const {
+		return static_cast<int>(1 + i) ;
 	}
         inline R_xlen_t size() const { return len ; }
 

--- a/inst/include/Rcpp/sugar/functions/var.h
+++ b/inst/include/Rcpp/sugar/functions/var.h
@@ -2,8 +2,9 @@
 //
 // var.h: Rcpp R/C++ interface class library -- var
 //
-// Copyright (C) 2011 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2015 Wush Wu
+// Copyright (C) 2011 - 2014 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2015 - 2025 Dirk Eddelbuettel, Romain Francois and Wush Wu
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois, Wush Wu and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -39,7 +40,7 @@ public:
         double sum_squared_deviations = 0.0;
         for (R_xlen_t i = 0; i != sample_size; ++i)
             sum_squared_deviations += std::pow(object[i] - average, 2.0);
-        return sum_squared_deviations / (sample_size - 1);
+        return sum_squared_deviations / static_cast<double>(sample_size - 1);
     }
 
 private:
@@ -61,7 +62,7 @@ public:
             const Rcomplex deviation = object[i] - average;
             sum_squared_deviations_magnitudes += deviation.r * deviation.r + deviation.i * deviation.i;
         }
-        return sum_squared_deviations_magnitudes / (sample_size - 1);
+        return sum_squared_deviations_magnitudes / static_cast<double>(sample_size - 1);
     }
 
 private:

--- a/inst/include/Rcpp/sugar/matrix/col.h
+++ b/inst/include/Rcpp/sugar/matrix/col.h
@@ -35,7 +35,7 @@ class Col : public MatrixBase<
 public:
 	typedef Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T> LHS_TYPE ;
 
-	Col( const LHS_TYPE& lhs) : nr( lhs.ncol() ), nc( lhs.ncol() ) {}
+	Col( const LHS_TYPE& lhs) : nr( static_cast<int>(lhs.ncol()) ), nc( static_cast<int>(lhs.ncol()) ) {}
 
 	inline int operator()( int /*i*/, int j ) const {
 		return j + 1 ;

--- a/inst/include/Rcpp/sugar/matrix/diag.h
+++ b/inst/include/Rcpp/sugar/matrix/diag.h
@@ -2,7 +2,8 @@
 //
 // diag.h: Rcpp R/C++ interface class library -- diag
 //
-// Copyright (C) 2010 - 2011 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -32,13 +33,13 @@ public:
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
 	Diag_Extractor( const MAT_TYPE& object_ ) : object(object_), n(0) {
-		int nr = object.nrow() ;
-		int nc = object.ncol() ;
+		int nr = static_cast<int>(object.nrow()) ;
+		int nc = static_cast<int>(object.ncol()) ;
 		n = (nc < nr ) ? nc : nr ;
 	}
 
-	inline STORAGE operator[]( int i ) const {
-		return object( i, i ) ;
+	inline STORAGE operator[]( R_xlen_t i ) const {
+		return object( static_cast<int>(i), static_cast<int>(i) ) ;
 	}
 	inline R_xlen_t size() const { return n; }
 
@@ -54,7 +55,7 @@ public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename Rcpp::traits::storage_type<RTYPE>::type STORAGE ;
 
-	Diag_Maker( const VEC_TYPE& object_ ) : object(object_), n(object_.size()) {}
+	Diag_Maker( const VEC_TYPE& object_ ) : object(object_), n(static_cast<int>(object_.size())) {}
 
 	inline STORAGE operator()( int i, int j ) const {
 		return (i==j) ? object[i] : 0 ;

--- a/inst/include/Rcpp/sugar/matrix/lower_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/lower_tri.h
@@ -3,7 +3,8 @@
 // lower_tri.h: Rcpp R/C++ interface class library -- lower.tri
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2017    Dirk Eddelbuettel, Romain Francois, and Nathan Russell
+// Copyright (C) 2017 - 2025 Dirk Eddelbuettel, Romain Francois, and Nathan Russell
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois, Nathan Russell and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -32,8 +33,8 @@ public:
     typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
     LowerTri(const T& lhs, bool diag)
-        : nr(lhs.nrow()),
-          nc(lhs.ncol()),
+        : nr(static_cast<int>(lhs.nrow())),
+          nc(static_cast<int>(lhs.ncol())),
           getter(diag ? (&LowerTri::get_diag_true) : (&LowerTri::get_diag_false))
     {}
 

--- a/inst/include/Rcpp/sugar/matrix/outer.h
+++ b/inst/include/Rcpp/sugar/matrix/outer.h
@@ -52,7 +52,7 @@ public:
     typedef typename Rcpp::traits::storage_type<RESULT_R_TYPE>::type STORAGE ;
 
     Outer( const LHS_TYPE& lhs_, const RHS_TYPE& rhs_, Function fun_ ) :
-        lhs(lhs_), rhs(rhs_), fun(fun_), nr(lhs_.size()), nc(rhs_.size()) {}
+        lhs(lhs_), rhs(rhs_), fun(fun_), nr(static_cast<int>(lhs_.size())), nc(static_cast<int>(rhs_.size())) {}
 
     inline STORAGE operator()( int i, int j ) const {
         return converter_type::get( fun( lhs[i], rhs[j] ) );

--- a/inst/include/Rcpp/sugar/matrix/row.h
+++ b/inst/include/Rcpp/sugar/matrix/row.h
@@ -35,7 +35,7 @@ class Row : public MatrixBase<
 public:
 	typedef Rcpp::MatrixBase<RTYPE,LHS_NA,LHS_T> LHS_TYPE ;
 
-	Row( const LHS_TYPE& lhs) : nr( lhs.nrow() ), nc( lhs.ncol() ) {}
+	Row( const LHS_TYPE& lhs) : nr( static_cast<int>(lhs.nrow()) ), nc( static_cast<int>(lhs.ncol()) ) {}
 
 	inline int operator()( int i, int /*j*/ ) const {
 		return i + 1 ;

--- a/inst/include/Rcpp/sugar/matrix/upper_tri.h
+++ b/inst/include/Rcpp/sugar/matrix/upper_tri.h
@@ -3,7 +3,8 @@
 // upper_tri.h: Rcpp R/C++ interface class library -- upper.tri
 //
 // Copyright (C) 2010 - 2017 Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2017        Dirk Eddelbuettel, Romain Francois, and Nathan Russell
+// Copyright (C) 2017 - 2025 Dirk Eddelbuettel, Romain Francois, and Nathan Russell
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois, Nathan Russell and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -32,8 +33,8 @@ public:
     typedef Rcpp::MatrixBase<RTYPE, NA, T> MatBase;
 
     UpperTri(const T& lhs, bool diag)
-        : nr(lhs.nrow()),
-          nc(lhs.ncol()),
+        : nr(static_cast<int>(lhs.nrow())),
+          nc(static_cast<int>(lhs.ncol())),
           getter(diag ? (&UpperTri::get_diag_true) : (&UpperTri::get_diag_false))
     {}
 

--- a/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
+++ b/inst/include/Rcpp/sugar/operators/Comparator_With_One_Value.h
@@ -31,7 +31,7 @@ class Comparator_With_One_Value : public ::Rcpp::VectorBase< LGLSXP, true, Compa
 public:
 	typedef typename Rcpp::VectorBase<RTYPE,NA,T> VEC_TYPE ;
 	typedef typename traits::storage_type<RTYPE>::type STORAGE ;
-	typedef int (Comparator_With_One_Value::*METHOD)(int) const ;
+	typedef int (Comparator_With_One_Value::*METHOD)(R_xlen_t) const ;
 
 	Comparator_With_One_Value( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 		lhs(lhs_), rhs(rhs_), m(), op() {
@@ -54,8 +54,8 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int /*i*/) const { return rhs ; }
-	inline int rhs_is_not_na(int i) const {
+	inline int rhs_is_na(R_xlen_t /*i*/) const { return NA_INTEGER ; }
+	inline int rhs_is_not_na(R_xlen_t i) const {
 		STORAGE x = lhs[i] ;
 		return Rcpp::traits::is_na<RTYPE>(x) ? NA_INTEGER : op( x, rhs ) ;
 	}
@@ -70,7 +70,7 @@ class Comparator_With_One_Value<RTYPE,Operator,false,T> :
 public:
 	typedef typename Rcpp::VectorBase<RTYPE,false,T> VEC_TYPE ;
 	typedef typename traits::storage_type<RTYPE>::type STORAGE ;
-	typedef int (Comparator_With_One_Value::*METHOD)(int) const ;
+	typedef int (Comparator_With_One_Value::*METHOD)(R_xlen_t) const ;
 
 	Comparator_With_One_Value( const VEC_TYPE& lhs_, STORAGE rhs_ ) :
 		lhs(lhs_), rhs(rhs_), m(), op() {
@@ -93,8 +93,8 @@ private:
 	METHOD m ;
 	Operator op ;
 
-	inline int rhs_is_na(int /*i*/) const { return rhs ; }
-	inline int rhs_is_not_na(int i) const {
+	inline int rhs_is_na(R_xlen_t /*i*/) const { return NA_INTEGER ; }
+	inline int rhs_is_not_na(R_xlen_t i) const {
 		return op( lhs[i], rhs ) ;
 	}
 

--- a/inst/include/Rcpp/vector/ListOf.h
+++ b/inst/include/Rcpp/vector/ListOf.h
@@ -40,10 +40,9 @@ public:
         std::transform(list.begin(), list.end(), list.begin(), as<T>);
     }
 
-    template <typename U>
-    ListOf(const U& data_): list(data_) {
-        std::transform(list.begin(), list.end(), list.begin(), as<T>);
-    }
+    template <typename U,
+              typename std::enable_if<std::is_convertible<U, SEXP>::value, int>::type = 0>
+    ListOf(const U& data_): ListOf(static_cast<SEXP>(data_)) {}
 
     ListOf(const ListOf& other): list(other.list) {}
 

--- a/inst/include/Rcpp/vector/Matrix.h
+++ b/inst/include/Rcpp/vector/Matrix.h
@@ -2,7 +2,8 @@
 //
 // Matrix.h: Rcpp R/C++ interface class library -- matrices
 //
-// Copyright (C) 2010 - 2016  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -74,7 +75,7 @@ public:
     Matrix( const Matrix& other) : VECTOR( other.get__() ), nrows(other.nrows) {}
 
     template <bool NA, typename MAT>
-    Matrix( const MatrixBase<RTYPE,NA,MAT>& other ) : VECTOR( Rf_allocMatrix( RTYPE, other.nrow(), other.ncol() ) ), nrows(other.nrow()) {
+    Matrix( const MatrixBase<RTYPE,NA,MAT>& other ) : VECTOR( Rf_allocMatrix( RTYPE, static_cast<int>(other.nrow()), static_cast<int>(other.ncol()) ) ), nrows(static_cast<int>(other.nrow())) {
         import_matrix_expression<NA,MAT>( other, nrows, ncol() ) ;
     }
 
@@ -135,10 +136,10 @@ public:
     }
 
     inline Proxy operator()( const size_t& i, const size_t& j) {
-      return static_cast< Vector<RTYPE>* >( this )->operator[]( offset( i, j ) ) ;
+      return static_cast< Vector<RTYPE>* >( this )->operator[]( offset( static_cast<int>(i), static_cast<int>(j) ) ) ;
     }
     inline const_Proxy operator()( const size_t& i, const size_t& j) const {
-       return static_cast< const Vector<RTYPE>* >( this )->operator[]( offset( i, j ) ) ;
+       return static_cast< const Vector<RTYPE>* >( this )->operator[]( offset( static_cast<int>(i), static_cast<int>(j) ) ) ;
     }
 
     inline Proxy at( const size_t& i, const size_t& j) {

--- a/inst/include/Rcpp/vector/MatrixBase.h
+++ b/inst/include/Rcpp/vector/MatrixBase.h
@@ -183,7 +183,7 @@ namespace Rcpp{
             }
 
             inline R_xlen_t index() const {
-                return i + nr * j ;
+                return i + static_cast<R_xlen_t>(nr) * j ;
             }
 
         } ;

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -2,7 +2,8 @@
 //
 // MatrixColumn.h: Rcpp R/C++ interface class library -- matrices column
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -76,11 +77,11 @@ public:
         return *this ;
     }
 
-    inline Proxy operator[]( int i ){
+    inline Proxy operator[]( R_xlen_t i ){
         return start[i] ;
     }
 
-    inline const_Proxy operator[]( int i ) const {
+    inline const_Proxy operator[]( R_xlen_t i ) const {
         return const_start[i] ;
     }
 
@@ -142,7 +143,7 @@ public:
         n(other.n),
         const_start(other.const_start) {}
 
-    inline const_Proxy operator[]( int i ) const {
+    inline const_Proxy operator[]( R_xlen_t i ) const {
         return const_start[i] ;
     }
 

--- a/inst/include/Rcpp/vector/MatrixColumn.h
+++ b/inst/include/Rcpp/vector/MatrixColumn.h
@@ -2,8 +2,8 @@
 //
 // MatrixColumn.h: Rcpp R/C++ interface class library -- matrices column
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -2,7 +2,8 @@
 //
 // MatrixRow.h: Rcpp R/C++ interface class library -- matrices row
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -164,12 +165,12 @@ public:
             return *this ;
     }
 
-    inline reference operator[]( int i ){
+    inline reference operator[]( R_xlen_t i ){
         return start[ get_parent_index(i) ] ;
     }
 
-    inline reference operator[]( int i ) const {
-        return parent[ row + static_cast<R_xlen_t>(i) * parent_nrow ] ;
+    inline reference operator[]( R_xlen_t i ) const {
+        return parent[ row + i * parent_nrow ] ;
     }
 
     inline iterator begin(){
@@ -206,9 +207,9 @@ private:
     int parent_nrow ;
     int row ;
 
-    inline R_xlen_t get_parent_index(int i) const {
-        RCPP_DEBUG_4( "MatrixRow<%d>::get_parent_index(int = %d), parent_nrow = %d >> %d\n", RTYPE, i, parent_nrow, static_cast<R_xlen_t>(i) * parent_nrow )
-        return static_cast<R_xlen_t>(i) * parent_nrow ;
+    inline R_xlen_t get_parent_index(R_xlen_t i) const {
+        RCPP_DEBUG_4( "MatrixRow<%d>::get_parent_index(R_xlen_t = %ld), parent_nrow = %d >> %ld\n", RTYPE, i, parent_nrow, i * parent_nrow )
+        return i * parent_nrow ;
     }
 } ;
 
@@ -309,8 +310,8 @@ public:
         row(other.row)
     {} ;
 
-    inline const_reference operator[]( int i ) const {
-        return parent[ row + static_cast<R_xlen_t>(i) * parent_nrow ] ;
+    inline const_reference operator[]( R_xlen_t i ) const {
+        return parent[ row + i * parent_nrow ] ;
     }
 
     inline const_iterator begin() const {
@@ -331,9 +332,9 @@ private:
     int parent_nrow ;
     int row ;
 
-    inline R_xlen_t get_parent_index(int i) const {
-        RCPP_DEBUG_4( "ConstMatrixRow<%d>::get_parent_index(int = %d), parent_nrow = %d >> %d\n", RTYPE, i, parent_nrow, static_cast<R_xlen_t>(i) * parent_nrow )
-        return static_cast<R_xlen_t>(i) * parent_nrow ;
+    inline R_xlen_t get_parent_index(R_xlen_t i) const {
+        RCPP_DEBUG_4( "ConstMatrixRow<%d>::get_parent_index(R_xlen_t = %ld), parent_nrow = %d >> %ld\n", RTYPE, i, parent_nrow, i * parent_nrow )
+        return i * parent_nrow ;
     }
 } ;
 }

--- a/inst/include/Rcpp/vector/MatrixRow.h
+++ b/inst/include/Rcpp/vector/MatrixRow.h
@@ -2,8 +2,8 @@
 //
 // MatrixRow.h: Rcpp R/C++ interface class library -- matrices row
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/vector/RangeIndexer.h
+++ b/inst/include/Rcpp/vector/RangeIndexer.h
@@ -26,8 +26,8 @@
 #define UNROLL_LOOP(OP)                              \
     typedef typename ::Rcpp::traits::Extractor<RTYPE,NA,T>::type EXT ; \
     const EXT& input( x.get_ref() ) ;                   \
-    int __trip_count = (size_) >> 2;                 \
-    int i=0 ;                                        \
+    R_xlen_t __trip_count = (size_) >> 2;            \
+    R_xlen_t i=0 ;                                   \
     for ( ; __trip_count > 0 ; --__trip_count) {     \
         start[i] OP input[i] ; i++ ;                 \
         start[i] OP input[i] ; i++ ;                 \

--- a/inst/include/Rcpp/vector/SubMatrix.h
+++ b/inst/include/Rcpp/vector/SubMatrix.h
@@ -1,8 +1,8 @@
 
 // SubMatrix.h: Rcpp R/C++ interface class library -- sub matrices
 //
-// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
-// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //

--- a/inst/include/Rcpp/vector/SubMatrix.h
+++ b/inst/include/Rcpp/vector/SubMatrix.h
@@ -1,7 +1,8 @@
 
 // SubMatrix.h: Rcpp R/C++ interface class library -- sub matrices
 //
-// Copyright (C) 2010 - 2013 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -34,33 +35,33 @@ public:
         m(m_),
         iter( static_cast< Vector<RTYPE>& >(m_).begin() + row_range_.get_start() + col_range_.get_start() * m_.nrow() ),
         m_nr( m.nrow() ),
-        nc( col_range_.size() ),
-        nr( row_range_.size() )
+        nc( static_cast<int>(col_range_.size()) ),
+        nr( static_cast<int>(row_range_.size()) )
     {}
 
-    inline R_xlen_t size() const { return ((R_xlen_t)ncol()) * nrow() ; }
-    inline R_xlen_t ncol() const { return nc ; }
-    inline R_xlen_t nrow() const { return nr ; }
+    inline R_xlen_t size() const { return static_cast<R_xlen_t>(ncol()) * nrow() ; }
+    inline int ncol() const { return nc ; }
+    inline int nrow() const { return nr ; }
 
     inline Proxy operator()(int i, int j) const {
-        return iter[ i + j*m_nr ] ;
+        return iter[ i + static_cast<R_xlen_t>(m_nr)*j ] ;
     }
 
-    inline vec_iterator column_iterator( int j ) const { return iter + j*m_nr ; }
+    inline vec_iterator column_iterator( int j ) const { return iter + static_cast<R_xlen_t>(m_nr)*j ; }
 
 private:
     MATRIX& m ;
     vec_iterator iter ;
-    R_xlen_t m_nr, nc, nr ;
+    int m_nr, nc, nr ;
 } ;
 
 template <int RTYPE, template <class> class StoragePolicy >
-Matrix<RTYPE,StoragePolicy>::Matrix( const SubMatrix<RTYPE>& sub ) : VECTOR( Rf_allocMatrix( RTYPE, (int)sub.nrow(), (int)sub.ncol() )), nrows((int)sub.nrow()) {
-    R_xlen_t nc = sub.ncol() ;
+Matrix<RTYPE,StoragePolicy>::Matrix( const SubMatrix<RTYPE>& sub ) : VECTOR( Rf_allocMatrix( RTYPE, sub.nrow(), sub.ncol() )), nrows(sub.nrow()) {
+    int nc = sub.ncol() ;
     iterator start = VECTOR::begin() ;
 	iterator rhs_it ;
-	for( R_xlen_t j=0; j<nc; j++){
-	    rhs_it = sub.column_iterator((int)j) ;
+	for( int j=0; j<nc; j++){
+	    rhs_it = sub.column_iterator(j) ;
 	    for( int i=0; i<nrows; i++, ++start){
 	        *start = rhs_it[i] ;
 	    }

--- a/inst/include/Rcpp/vector/Subsetter.h
+++ b/inst/include/Rcpp/vector/Subsetter.h
@@ -58,11 +58,11 @@ public:
 
         if (n == 1) {
             for (R_xlen_t i=0; i < indices_n; ++i) {
-                lhs[ indices[i] ] = other[0];
+                lhs[ indices[i] ] = static_cast<typename LHS_t::stored_type>(other[0]);
             }
         } else if (n == indices_n) {
             for (R_xlen_t i=0; i < n; ++i) {
-                lhs[ indices[i] ] = other[i];
+                lhs[ indices[i] ] = static_cast<typename LHS_t::stored_type>(other[i]);
             }
         } else {
             stop("index error");
@@ -162,7 +162,7 @@ private:
         indices.reserve(rhs_n);
         std::vector<R_xlen_t> tmp(rhs.size()); // create temp R_xlen_t type indices from reals
         for(size_t i = 0 ; i < tmp.size() ; ++i) {
-            tmp[i] = rhs[i];
+            tmp[i] = static_cast<R_xlen_t>(rhs[i]);
         }
         check_indices(&tmp[0], rhs_n, lhs_n);
         for (R_xlen_t i=0; i < rhs_n; ++i) {

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -279,7 +279,7 @@ public:
     /**
      * offset based on the dimensions of this vector
      */
-    R_xlen_t offset(const int& i, const int& j) const {
+    R_xlen_t offset(const R_xlen_t& i, const R_xlen_t& j) const {
         if( !::Rf_isMatrix(Storage::get__()) ) throw not_a_matrix() ;
 
         /* we need to extract the dimensions */
@@ -292,7 +292,7 @@ public:
                               "column index=%i; column extent=%i].";
             throw index_out_of_bounds(fmt, i, nrow, j, ncol);
         }
-        return i + static_cast<R_xlen_t>(nrow)*j ;
+        return i + nrow*j ;
     }
 
     /**
@@ -369,10 +369,10 @@ public:
     }																				// #nocov end
 
     inline Proxy operator()( const size_t& i, const size_t& j) {
-        return cache.ref( offset(i,j) ) ;
+        return cache.ref( offset(i, j) ) ;
     }
     inline const_Proxy operator()( const size_t& i, const size_t& j) const {
-        return cache.ref( offset(i,j) ) ;
+        return cache.ref( offset(i, j) ) ;
     }
 
     inline NameProxy operator[]( const std::string& name ){

--- a/inst/include/Rcpp/vector/Vector.h
+++ b/inst/include/Rcpp/vector/Vector.h
@@ -1,6 +1,7 @@
 // Vector.h: Rcpp R/C++ interface class library -- vectors
 //
-// Copyright (C) 2010 - 2026  Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
+// Copyright (C) 2010 - 2025  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026         Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -75,7 +76,7 @@ public:
     }
 
     template <typename Proxy>
-    Vector( const GenericProxy<Proxy>& proxy ){
+    explicit Vector( const GenericProxy<Proxy>& proxy ){
         Rcpp::Shield<SEXP> safe(proxy.get());
         Storage::set__( r_cast<RTYPE>(safe) ) ;
     }

--- a/inst/tinytest/cpp/Matrix.cpp
+++ b/inst/tinytest/cpp/Matrix.cpp
@@ -2,7 +2,8 @@
 //
 // Matrix.cpp: Rcpp R/C++ interface class library -- Matrix unit tests
 //
-// Copyright (C) 2013 - 2016  Dirk Eddelbuettel, Romain Francois and Kevin Ushey
+// Copyright (C) 2013 - 2025 Dirk Eddelbuettel, Romain Francois and Kevin Ushey
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois, Kevin Ushey and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -87,7 +88,7 @@ int integer_matrix_indexing( IntegerMatrix m){
 
 // [[Rcpp::export]]
 IntegerVector integer_matrix_indexing_lhs( IntegerVector m ){
-    for( size_t i=0 ; i<4; i++){
+    for( int i=0 ; i<4; i++){
         m(i,i) = 2 * i ;
     }
     return m ;

--- a/inst/tinytest/cpp/Module.cpp
+++ b/inst/tinytest/cpp/Module.cpp
@@ -3,7 +3,8 @@
 //
 // Module.cpp: Rcpp R/C++ interface class library -- module unit tests
 //
-// Copyright (C) 2013 - 2015  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2013 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -49,13 +50,13 @@ void bla2(int x, double y) {
 }
 
 int test_reference(std::vector<double>& ref) {
-    return ref.size();
+    return static_cast<int>(ref.size());
 }
 int test_const_reference(const std::vector<double>& ref) {
-    return ref.size();
+    return static_cast<int>(ref.size());
 }
 int test_const(const std::vector<double> ref) {
-    return ref.size();
+    return static_cast<int>(ref.size());
 }
 
 class ModuleWorld {

--- a/inst/tinytest/cpp/String.cpp
+++ b/inst/tinytest/cpp/String.cpp
@@ -28,14 +28,14 @@ public:
         nr(old_.size()), old(old_), new_(new__){}
 
     String operator()(String text) const {
-        for( int i=0; i<nr; i++){
+        for( R_xlen_t i=0; i<nr; i++){
             text.replace_all( old[i], new_[i] ) ;
         }
         return text ;
     }
 
 private:
-    int nr ;
+    R_xlen_t nr ;
     CharacterVector old ;
     CharacterVector new_ ;
 } ;

--- a/inst/tinytest/cpp/Vector.cpp
+++ b/inst/tinytest/cpp/Vector.cpp
@@ -96,8 +96,8 @@ ComplexVector complex_(){
 
 // [[Rcpp::export]]
 ComplexVector complex_CPLXSXP( ComplexVector x ){
-    int nn = x.size();
-    for( int i=0; i<nn; i++) {
+    R_xlen_t nn = x.size();
+    for( R_xlen_t i=0; i<nn; i++) {
         x[i].r = x[i].r*2 ;
         x[i].i = x[i].i*2 ;
     }
@@ -107,7 +107,7 @@ ComplexVector complex_CPLXSXP( ComplexVector x ){
 // [[Rcpp::export]]
 ComplexVector complex_INTSXP( SEXP vec ){
     ComplexVector x(vec);
-    int nn = x.size();
+    R_xlen_t nn = x.size();
     IntegerVector tmp(nn, 2.0);
     ComplexVector tmp1(tmp);
     x = x * tmp1;
@@ -117,7 +117,7 @@ ComplexVector complex_INTSXP( SEXP vec ){
 // [[Rcpp::export]]
 ComplexVector complex_REALSXP(SEXP vec){
     ComplexVector x(vec);
-    int nn = x.size();
+    R_xlen_t nn = x.size();
     NumericVector tmp(nn, 3.0);
     ComplexVector tmp1(tmp);
     x = x * tmp1;
@@ -165,7 +165,7 @@ IntegerVector integer_range_ctor_1(){
 // [[Rcpp::export]]
 IntegerVector integer_range_ctor_2(){
     std::vector<int> vec(4) ;
-    for( size_t i = 0; i<4; i++) vec[i] = i;
+    for( size_t i = 0; i<4; i++) vec[i] = static_cast<int>(i);
     IntegerVector y( vec.begin(), vec.end() ) ;
     return y;
 }
@@ -281,7 +281,7 @@ List integer_create_(){
 IntegerVector integer_clone_( IntegerVector vec ){
     IntegerVector dolly = clone( vec ) ;
     for( size_t i=0; i<10; i++){
-        dolly[i] = 10 - i ;
+        dolly[i] = static_cast<int>(10 - i) ;
     }
     return dolly ;
 }
@@ -622,7 +622,7 @@ List character_listOf( List ll ){
 // [[Rcpp::export]]
 int character_find_(CharacterVector y){
     CharacterVector::iterator it = std::find( y.begin(), y.end(), "foo" ) ;
-    return std::distance( y.begin(), it );
+    return static_cast<int>(std::distance( y.begin(), it ));
 }
 
 // [[Rcpp::export]]
@@ -671,9 +671,9 @@ bool containsElementNamed( List l, CharacterVector n){
 
 // [[Rcpp::export]]
 List CharacterVectorEqualityOperator( CharacterVector x, CharacterVector y){
-    int n = x.size() ;
+    R_xlen_t n = x.size() ;
     LogicalVector eq(n), neq(n);
-    for( int i=0; i<n; i++){
+    for( R_xlen_t i=0; i<n; i++){
         eq[i]  = x[i] == y[i] ;
         neq[i] = x[i] != y[i] ;
     }
@@ -687,42 +687,42 @@ List List_rep_ctor(IntegerVector x){
 
 // [[Rcpp::export]]
 int stdVectorDouble(std::vector<double> x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorDoubleConst(const std::vector<double> x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorDoubleRef(std::vector<double> & x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorDoubleConstRef(const std::vector<double> & x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorInt(std::vector<int> x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorIntConst(const std::vector<int> x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorIntRef(std::vector<int> & x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
 int stdVectorIntConstRef(const std::vector<int> & x) {
-    return x.size();
+    return static_cast<int>(x.size());
 }
 
 // [[Rcpp::export]]
@@ -808,7 +808,7 @@ void no_op(int major) {
 
 // [[Rcpp::export]]
 int noprotect_vector( Vector<REALSXP, NoProtectStorage> x){
-  return x.size() ;
+  return static_cast<int>(x.size()) ;
 }
 
 // [[Rcpp::export]]
@@ -850,7 +850,7 @@ IntegerVector vec_subset(IntegerVector x, IntegerVector y) {
 // [[Rcpp::export]]
 int CharacterVectorNoProtect(Vector<STRSXP, NoProtectStorage> s){
     s[0] = "";
-    return s.size();
+    return static_cast<int>(s.size());
 }
 
 // [[Rcpp::export]]

--- a/inst/tinytest/cpp/dates.cpp
+++ b/inst/tinytest/cpp/dates.cpp
@@ -2,6 +2,7 @@
 // dates.cpp: Rcpp R/C++ interface class library -- Date + Datetime tests
 //
 // Copyright (C) 2010 - 2025   Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026          Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -205,7 +206,7 @@ Date gmtime_mktime(Date d) {
     tm.tm_mday  = d.getDay();
     tm.tm_mon   = d.getMonth() - 1;    // range 0 to 11
     tm.tm_year  = d.getYear() - baseYear;
-    time_t tmp = mktime00(tm);    // use mktime() replacement borrowed from R
+    time_t tmp = static_cast<time_t>(mktime00(tm));    // use mktime() replacement borrowed from R
 
     struct tm chk = *gmtime_(&tmp);
     Date newd(chk.tm_year, chk.tm_mon + 1, chk.tm_mday);
@@ -221,7 +222,7 @@ double test_mktime(Date d) {
     tm.tm_mday  = d.getDay();
     tm.tm_mon   = d.getMonth() - 1;    // range 0 to 11
     tm.tm_year  = d.getYear() - baseYear;
-    time_t t = mktime00(tm);    // use mktime() replacement borrowed from R
+    time_t t = static_cast<time_t>(mktime00(tm));    // use mktime() replacement borrowed from R
     return static_cast<double>(t);
 }
 

--- a/inst/tinytest/cpp/language.cpp
+++ b/inst/tinytest/cpp/language.cpp
@@ -2,7 +2,8 @@
 //
 // language.cpp: Rcpp R/C++ interface class library -- Language unit tests
 //
-// Copyright (C) 2012 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2012 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 // This file is part of Rcpp.
 //
@@ -205,7 +206,7 @@ int runit_pl_size(){
 	p.push_back( 1 ) ;
 	p.push_back( 10.0 ) ;
 	p.push_back( 20.0 ) ;
-	return p.size() ;
+	return static_cast<int>(p.size()) ;
 }
 
 // [[Rcpp::export]]

--- a/src/date.cpp
+++ b/src/date.cpp
@@ -1,6 +1,7 @@
 // Date.cpp: Rcpp R/C++ interface class library -- Date type
 //
-// Copyright (C) 2010 - 2023  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2025 Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2026        Dirk Eddelbuettel, Romain Francois and Iñaki Ucar
 //
 //    The mktime00() as well as the gmtime_() replacement function are
 //    Copyright (C) 2000 - 2010  The R Development Core Team.
@@ -821,7 +822,7 @@ struct tzhead {
 	    */
 	    if (u.tzhead.tzh_version[0] == '\0')
 		break;
-	    nread -= p - u.buf;
+	    nread -= (int)(p - u.buf);
 	    for (i = 0; i < nread; ++i)
 		u.buf[i] = p[i];
 	    /*
@@ -1184,7 +1185,7 @@ struct tzhead {
         }
         sp->charcnt = (int)(stdlen + 1);
         if (dstlen != 0)
-            sp->charcnt += dstlen + 1;
+            sp->charcnt += (int)(dstlen + 1);
         if ((size_t) sp->charcnt > sizeof sp->chars)
             return -1;
         cp = sp->chars;


### PR DESCRIPTION
Closes #1488. There are 3 categories of changes here (divided in blocks in the ChangeLog):

1. **Ambiguous overload resolution** in Rcpp types. This happened to work, but depends on the compiler to do the right thing. The main problem was the `GenericProxy` constructor in `macros/interface.h`, which is inherited by pretty much everything, but each type has its own constructor that actually checks the SEXP, etc. So by [marking the `GenericProxy` constructor as `explicit`](https://github.com/RcppCore/Rcpp/pull/1508/changes/e8f723ed6a5b3ed6b78daf55038f9b67a1276924), we tell the compiler that implicit conversions should go through the specific constructors. Same in `DataFrame` and `ListOf` with their own generic constructors. Actually the `ListOf` case [was also special](https://github.com/RcppCore/Rcpp/pull/1508/changes/05ebafaaf057b9871250e85cc0e98268f55a511b) in its own way, just like everything there. ;-)
2. **Homogenization of `R_xlen_t` vs `int`**. This is a bit of a mess. There were methods that weren't converted to `R_xlen_t` like similar others and now are, and others were the use of `R_xlen_t` was unjustified, unnecessary or plainly wrong. Hopefully this brings some more order.
3. A bunch of explicit casts (not related to the previous point) that don't have any impact apart from being explicit about what we are doing, which is nice.

This requires full revdeps.

#### Checklist

- [x] Code compiles correctly
- [x] `R CMD check` still passes all tests
- [ ] Preferably, new tests were added which fail without the change
- [x] Document the changes by file in [ChangeLog](https://github.com/RcppCore/Rcpp/blob/master/ChangeLog)
